### PR TITLE
XML: tagname should be script/style to enter submode.  Not styleClass

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -62,7 +62,7 @@ hljs.LANGUAGES.xml = function(){
         },
         {
           className: 'tag',
-          begin: '<style', end: '>',
+          begin: '<style(?=\\s|>)', end: '>',
           keywords: {'title': {'style': 1}},
           contains: [TAG_INTERNALS],
           starts: {
@@ -73,7 +73,7 @@ hljs.LANGUAGES.xml = function(){
         },
         {
           className: 'tag',
-          begin: '<script', end: '>',
+          begin: '<script(?=\\s|>)', end: '>',
           keywords: {'title': {'script': 1}},
           contains: [TAG_INTERNALS],
           starts: {


### PR DESCRIPTION
Added a lookahead to the beginRes for script and style tags to ensure the tagname doesn't just start with script or style.
