### PR TITLE
Jshint

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -138,10 +138,10 @@ var hljs = new function() {
         result += open(current.node);
         nodeStack.push(current.node);
       } else if (current.event == 'stop') {
-        var i = nodeStack.length;
+        var node, i = nodeStack.length;
         do {
           i--;
-          var node = nodeStack[i];
+          node = nodeStack[i];
           result += ('</' + node.nodeName.toLowerCase() + '>');
         } while (node != current.node);
         nodeStack.splice(i, 1);
@@ -161,6 +161,7 @@ var hljs = new function() {
     function compileMode(mode, language, is_default) {
       if (mode.compiled)
         return;
+      var group;
 
       if (!is_default) {
         mode.beginRe = langRe(language, mode.begin ? mode.begin : '\\B|\\b');
@@ -179,9 +180,9 @@ var hljs = new function() {
           if (!mode.keywords.hasOwnProperty(className))
             continue;
           if (mode.keywords[className] instanceof Object) {
-            var group = mode.keywords[className];
+            group = mode.keywords[className];
           } else {
-            var group = mode.keywords;
+            group = mode.keywords;
             className = 'keyword';
           }
           for (var keyword in group) {
@@ -393,10 +394,10 @@ var hljs = new function() {
     var keyword_count = 0;
     var result = '';
     try {
-      var index = 0;
+      var mode_info, index = 0;
       language.defaultMode.buffer = '';
       do {
-        var mode_info = eatModeChunk(value, index);
+        mode_info = eatModeChunk(value, index);
         var return_lexem = processModeInfo(mode_info[0], mode_info[1], mode_info[2]);
         index += mode_info[0].length;
         if (!return_lexem) {
@@ -487,17 +488,18 @@ var hljs = new function() {
   function highlightBlock(block, tabReplace, useBR) {
     var text = blockText(block, useBR);
     var language = blockLanguage(block);
+    var result, pre;
     if (language == 'no-highlight')
         return;
     if (language) {
-      var result = highlight(language, text);
+      result = highlight(language, text);
     } else {
-      var result = highlightAuto(text);
+      result = highlightAuto(text);
       language = result.language;
     }
     var original = nodeStream(block);
     if (original.length) {
-      var pre = document.createElement('pre');
+      pre = document.createElement('pre');
       pre.innerHTML = result.value;
       result.value = mergeStreams(original, nodeStream(pre), text);
     }
@@ -510,7 +512,7 @@ var hljs = new function() {
     if (/MSIE [678]/.test(navigator.userAgent) && block.tagName == 'CODE' && block.parentNode.tagName == 'PRE') {
       // This is for backwards compatibility only. IE needs this strange
       // hack becasue it cannot just cleanly replace <code> block contents.
-      var pre = block.parentNode;
+      pre = block.parentNode;
       var container = document.createElement('div');
       container.innerHTML = '<pre><code>' + result.value + '</code></pre>';
       block = container.firstChild.firstChild;


### PR DESCRIPTION
Those changes fix complaints of jshint, which means less chance of leaking some variable to global namespace or just having inconsistent code. UglifyJS results are also a bit smaller when run on this version (results of closure compiler remain the same).
