### PR TITLE
subMode should identify mode based on exact match

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -238,7 +238,7 @@ var hljs = new function() {
 
     function subMode(lexem, mode) {
       for (var i = 0; i < mode.contains.length; i++) {
-        if (mode.contains[i].beginRe.test(lexem)) {
+        if ((mode.contains[i].beginRe.exec(lexem) || [null])[0] == lexem) {
           return mode.contains[i];
         }
       }


### PR DESCRIPTION
For example, in Lisp `#c(0 -5.6)` is matched by the pattern for number, but since a substring of it looks like a list, subMode uses that mode instead which is clearly not the desired behavior.
