### PR TITLE
Implement R language highlighter

### DIFF
--- a/classref.txt
+++ b/classref.txt
@@ -497,9 +497,19 @@ Matlab ("matlab"):
   param            params of function
 
 D language ("d"):
+
   comment          comment
   string           string constant
   number           number
   keyword          language keywords (including @attributes)
   constant         true false null
   built_in         built-in plain types (int, string etc.)
+
+R ("r"):
+
+  comment          comment
+  string           string constant
+  number           number
+  keyword          language keywords (function, if) plus "structural"
+                   functions (attach, require, setClass)
+  literal          special literal: TRUE, FALSE, NULL, NA, etc.

--- a/src/languages/r.js
+++ b/src/languages/r.js
@@ -1,0 +1,121 @@
+/*
+Language: R
+Author: Joe Cheng <joe@rstudio.org>
+*/
+
+hljs.LANGUAGES.r = (function() {
+  var HEX_RE = "0[xX][0-9a-fA-F]+[Li]?\\b";
+  var INT_RE = "\\d+(?:[eE][+\\-]?\\d*)?L\\b";
+  var TRAILING_DEC_RE = "\\d+\\.(?!\\d)(?:i\\b)?";
+  var NUM_RE = "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?i?\\b";
+  var LEADING_DEC_RE = "\\.\\d+(?:[eE][+\\-]?\\d*)?i?\\b";
+
+  return {
+    defaultMode: {
+      lexems: '[a-zA-Z.][a-zA-Z0-9._]*',
+      keywords: {
+        'keyword': {
+           'function' : 2, 'if' : 1, 'in' : 1, 'break' : 1, 'next' : 1, 'repeat' : 1, 'else' : 1, 'for' : 1,
+           'return' : 1, 'switch' : 1, 'while' : 1, 'try' : 1, 'tryCatch' : 10, 'stop' : 1, 'warning' : 1,
+           'require' : 1, 'library' : 10, 'attach' : 1, 'detach' : 1, 'source' : 1, 'setMethod' : 1,
+           'setGeneric' : 10, 'setGroupGeneric' : 10, 'setClass' : 1, '...' : 10
+        },
+        'literal': {'NULL': 1, 'NA': 10, 'TRUE': 1, 'FALSE': 1, 'T': 1, 'F': 1, 'Inf': 1, 'NaN': 1,
+                    'NA_integer_': 10, 'NA_real_': 10, 'NA_character_': 10, 'NA_complex_': 10}
+      },
+      contains: [
+        hljs.HASH_COMMENT_MODE,
+        {
+          begin: "\\s|,|=|!|\\||&|\\+|\\-|\\*|/|\\^|>|<|:|%|~|\\[|\\]|\\(|\\)|\\{|\\}",
+          contains: [
+           {
+              // hex value
+              className: 'number',
+              begin: "\\b" + HEX_RE,
+              relevance: 0
+            },
+            {
+              // explicit integer
+              className: 'number',
+              begin: "\\b" + INT_RE,
+              relevance: 0
+            },
+            {
+              // number with trailing decimal
+              className: 'number',
+              begin: "\\b" + TRAILING_DEC_RE,
+              relevance: 1
+            },
+            {
+              // number
+              className: 'number',
+              begin: "\\b" + NUM_RE,
+              relevance: 0
+            },
+            {
+              // number with leading decimal
+              className: 'number',
+              begin: LEADING_DEC_RE,
+              relevance: 1
+            }
+          ],
+          relevance: 0
+        },
+
+        {
+          // hex value
+          className: 'number',
+          begin: "^" + HEX_RE,
+          relevance: 0
+        },
+        {
+          // explicit integer
+          className: 'number',
+          begin: "^" + INT_RE,
+          relevance: 0
+        },
+        {
+          // number with trailing decimal
+          className: 'number',
+          begin: "^" + TRAILING_DEC_RE,
+          relevance: 1
+        },
+        {
+          // number
+          className: 'number',
+          begin: "^" + NUM_RE,
+          relevance: 0
+        },
+        {
+          // number with leading decimal
+          className: 'number',
+          begin: "^" + LEADING_DEC_RE,
+          relevance: 1
+        },
+
+        {
+          // escaped identifier
+          begin: '`',
+          end: '`',
+          relevance: 0
+        },
+
+        {
+          className: 'string',
+          begin: '"',
+          end: '"',
+          contains: [hljs.BACKSLASH_ESCAPE],
+          relevance: 0
+        },
+        {
+          className: 'string',
+          begin: "'",
+          end: "'",
+          contains: [hljs.BACKSLASH_ESCAPE],
+          relevance: 0
+        },
+      ]
+    }
+  };
+})();
+

--- a/src/test.html
+++ b/src/test.html
@@ -1776,6 +1776,80 @@ function [net] = get_fit_network(inputs, targets)
 end
 </code></pre>
 
+  <tr>
+    <th>R
+    <td class="r">
+<pre><code>library(ggplot2)
+
+centre <- function(x, type, ...) {
+  switch(type,
+         mean = mean(x),
+         median = median(x),
+         trimmed = mean(x, trim = .1))
+}
+
+myVar1
+myVar.2
+data$x
+foo "bar" baz
+# test "test"
+"test # test"
+
+(123) (1) (10) (0.1) (.2) (1e-7)
+(1.2e+7) (2e) (3e+10) (0x0) (0xa)
+(0xabcdef1234567890) (123L) (1L)
+(0x10L) (10000000L) (1e6L) (1.1L)
+(1e-3L) (4123.381E-10i)
+(3.) (3.E10) # BUG: .E10 should be part of number
+
+# Numbers in some different contexts
+1L
+0x40
+.234
+3.
+1L + 30
+plot(cars, xlim=20)
+plot(cars, xlim=0x20)
+foo<-30
+my.data.3 <- read() # not a number
+c(1,2,3)
+1%%2
+
+"this is a quote that spans
+multiple lines
+\"
+
+is this still a quote? it should be.
+# even still!
+
+" # now we're done.
+
+'same for
+single quotes #'
+
+# keywords
+NULL, NA, TRUE, FALSE, Inf, NaN, NA_integer_,
+NA_real_, NA_character_, NA_complex_, function,
+while, repeat, for, if, in, else, next, break,
+..., ..1, ..2
+
+# not keywords
+the quick brown fox jumped over the lazy dogs
+null na true false inf nan na_integer_ na_real_
+na_character_ na_complex_ Function While Repeat
+For If In Else Next Break .. .... "NULL" `NULL` 'NULL'
+
+# operators
++, -, *, /, %%, ^, >, >=, <, <=, ==, !=, !, &, |, ~,
+->, <-, <<-, $, :, ::
+
+# infix operator
+foo %union% bar
+%"test"%
+`"test"`
+
+</code></pre>
+
 </table>
 
 <script>


### PR DESCRIPTION
Thanks for all of the feedback, hopefully this covers it all.

It is quite possible in R for lines to begin with numeric literals, so I had to include another copy of the number rules (but preprended with ^) in the default mode. Let me know if there is a better way to do this.
