### PR TITLE
Fix regular expression for BACKSLASH_ESCAPE

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -609,7 +609,7 @@ function() {
 
   // Common modes
   this.BACKSLASH_ESCAPE = {
-    begin: '\\\\[.\\n]', relevance: 0
+    begin: '\\\\[\\s\\S]', relevance: 0
   };
   this.APOS_STRING_MODE = {
     className: 'string',


### PR DESCRIPTION
A dot inside a character class matches a literal dot.
The new character class will match any character, including a newline.
