### PR TITLE
Add brief note on how to use in node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ If you use different markup or need to apply highlighting dynamically, read
 [cr]: http://github.com/isagalaev/highlight.js/blob/master/classref.txt
 
 
+## Usage in node.js
+
+To install:
+
+    npm install highlight.js
+
+To use:
+
+```javascript
+var hljs = require('highlight.js');
+//If you know the language
+hljs.highlight(lang, code).value;
+//If you don't know the language
+hljs.highlightAuto(code).value;
+```
+
 ## Tab replacement
 
 You can replace TAB ('\x09') characters used for indentation in your code


### PR DESCRIPTION
It took me ages before I realised it was possible.  Googling for syntax highlighting in node doesn't put this very high up, and this doesn't clearly state support for node anywhere, for a while I was using stupid hacky methods of getting the minified hljs to work in node, before I realised there's a highlight.js module in npm.
