### PR TITLE
Add matrices, cells and transposed variables

### DIFF
--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -1,9 +1,18 @@
 /*
 Language: Matlab
 Author: Denis Bardadym <bardadymchik@gmail.com>
+Contributors: Eugene Nizhibitsky <nizhibitsky@ya.ru>
 */
 
 function(hljs) {
+
+  this.MATLAB_STRING_MODE = {
+    className: 'string',
+    begin: '\'', end: '\'',
+    contains: [hljs.BACKSLASH_ESCAPE, {begin: '\'\''}],
+    relevance: 0
+  };
+
   return {
     keywords: {
       keyword:
@@ -47,15 +56,24 @@ function(hljs) {
         ]
       },
       {
-        className: 'string',
-        begin: '\'', end: '\'',
-        contains: [hljs.BACKSLASH_ESCAPE, {begin: '\'\''}],
-        relevance: 0
+        className: 'transposed_variable',
+        begin: '[a-zA-Z_][a-zA-Z_0-9]*(\'+[\\.\']*|[\\.\']+)', end: ''
+      },
+      {
+        className: 'matrix',
+        begin: '\\[', end: '\\]\'*[\\.\']*',
+        contains: [hljs.C_NUMBER_MODE, this.MATLAB_STRING_MODE]
+      },
+      {
+        className: 'cell',
+        begin: '\\{', end: '\\}\'*[\\.\']*',
+        contains: [hljs.C_NUMBER_MODE, this.MATLAB_STRING_MODE]
       },
       {
         className: 'comment',
         begin: '\\%', end: '$'
       },
+      this.MATLAB_STRING_MODE,
       hljs.C_NUMBER_MODE
     ]
   };


### PR DESCRIPTION
As we had discussed earlier in the mailing list, I have added matrices, cells and transposed variables detection in order to prevent confusing transpose operators with string beginnings.
##### Testing code fragment (github markdown doesn't work properly here)

```
function transposeTest

foo_matrix = [1, 2, 3; 4, 5, 6]''';
foo_cell = {1, 2, 3; 4, 5, 6}''.'.';

string = 'hello world';

bar_matrix = [1, 2, 3; 4, 5, 6];
bar_cell = {1, 2, 3; 4, 5, 6};

strings_in_matrix = ['hello', 'world'; 'from', 'matlab'];

foo_var = foo_var''';
bar_var = bar_var'''.'.';

fprintf('%.0f %.0f ', eps, pi);

end
```
