### PR TITLE
Fixed syntax error that makes variables be declared in the global scope

### DIFF
--- a/src/languages/d.js
+++ b/src/languages/d.js
@@ -66,7 +66,7 @@ function(hljs) {
 		hexadecimal_float_re = '(0[xX](' +
 									hexadecimal_digits_re + '\\.' + hexadecimal_digits_re + '|'+
 									'\\.?' + hexadecimal_digits_re +
-							   ')[pP][+-]?' + decimal_integer_nosus_re + ')';
+							   ')[pP][+-]?' + decimal_integer_nosus_re + ')',
 
 		integer_re = '(' +
 			decimal_integer_re + '|' +


### PR DESCRIPTION
I found a problem running mocha. It was giving me the following error:
Error: global leaks detected: integer_re, float_re

I found out that it was a syntax problem that left integer_re and float_re without a "var" declaration, so they are defined in the global scope which is a potential problem if you use the same name for other global variable.
