### PR TITLE
Line numbers and callouts

### DIFF
--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -143,3 +143,21 @@ pre .line::before {
   padding-right: 0.5em; margin-right: 0.5em;
   color: #BBB; border-right: solid 1px;
 }
+
+pre .line-callout::before {
+  content: '\2192'; text-align: right;
+  display: inline-block; width: 2em;
+  padding-right: 0.5em; margin-right: 0.5em;
+  color: #BBB;
+}
+
+.lines-callout {
+  opacity:0.6;
+  filter:alpha(opacity=60);
+  background: white;
+  border-radius: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border: solid thin #BBB;
+}
+

--- a/src/test.html
+++ b/src/test.html
@@ -2009,5 +2009,24 @@ foo %union% bar
   &lt;p&gt;Hello, World!
 &lt;/div&gt;
 </code></pre>
+  <tr>
+    <th>Callouts:
+<pre>
+&lt;code class="ruby" 
+      data-callout-lines='2,3,4,7'&gt;
+  &hellip;
+&lt;&gt;
+</pre>
+    <td>
+<pre><code class="ruby" data-callout-lines='2,3,4,7'>class Person < Struct.new(:name,:age)
+  def minor?
+    @age < 18
+  end
+end
+
+p = Person.new("Bob",24)
+
+puts "too young" if p.minor?
+</code></pre>
 
 </table>


### PR DESCRIPTION
Took your line-numbers branch and added callouts to it, as well as added specific line-number classes, to allow for dynamic manipulation of the resulting structure.

Open up `test.html` using default theme and scroll to the bottom for an example.

I am not super-skilled with JavaScript, so please forgive any dumb-coding things.  Am happy to clean things up or do things differently, but this is a generally useful feature for me.

Thanks!
