### PR TITLE
Escape greater than sign (">" to "&gt;")

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -8,7 +8,7 @@ function() {
   /* Utility functions */
 
   function escape(value) {
-    return value.replace(/&/gm, '&amp;').replace(/</gm, '&lt;');
+    return value.replace(/&/gm, '&amp;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;');
   }
 
   function findCode(pre) {


### PR DESCRIPTION
The HTML parser I'm using (Cheerio) doesn't seem to handle greater than signs that aren't part of a tag correctly. Even though the current output is valid HTML (I think!), escaping greater than signs allows the output to be parsed more easily.
