### PR TITLE
Обновления для Ruby

### DIFF
--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -150,7 +150,12 @@ function(hljs) {
     {
       className: 'symbol',
       begin: ':',
-      contains: STRINGS.concat([{begin: RUBY_IDENT_RE}]),
+      contains: STRINGS.concat([{begin: RUBY_METHOD_RE}]),
+      relevance: 0
+    },
+    {
+      className: 'symbol',
+      begin: RUBY_IDENT_RE + ':',
       relevance: 0
     },
     {
@@ -173,7 +178,7 @@ function(hljs) {
           className: 'regexp',
           begin: '/', end: '/[a-z]*',
           illegal: '\\n',
-          contains: [hljs.BACKSLASH_ESCAPE]
+          contains: [hljs.BACKSLASH_ESCAPE, SUBST]
         }
       ]),
       relevance: 0

--- a/src/test.html
+++ b/src/test.html
@@ -216,7 +216,7 @@ module ABC::DEF
   # @return [String] nothing
   def foo(test)
     Thread.new do |blockvar|
-      ABC::DEF.reverse(:a_symbol, :'a symbol' + 'test' + test)
+      ABC::DEF.reverse(:a_symbol, :'a symbol', :<=>, 'test' + test)
     end.join
   end
 
@@ -226,6 +226,7 @@ end
 
 anIdentifier = an_identifier
 Constant = 1
+render action: :new
 </code></pre>
 
   <tr>


### PR DESCRIPTION
- новый синтаксис для хэшей, появившийся в 1.9: `{key: value}`
- "старые" символы должны использовать `RUBY_METHOD_RE`, потому что штуки вроде `:<=>`, `:[]=` вполне реальны и корректны
- регулярные выражения могут включать в себя подстановки: `line.sub(/^#{leading_space.to_s}/)`
