### PR TITLE
Actualize Rust language keywords

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -68,3 +68,4 @@ Contributors:
 - Nathan Grigg <nathan@nathanamy.org>
 - Dr. Drang <drdrang@gmail.com>
 - Robin Ward <robin.ward@gmail.com>
+- Dmitry Medvinsky <me@dmedvinsky.name>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -68,3 +68,4 @@ URL:   http://softwaremaniacs.org/soft/highlight/
 - Натан Григг <nathan@nathanamy.org>
 - Dr. Drang <drdrang@gmail.com>
 - Робин Ворд <robin.ward@gmail.com>
+- Дмитрий Медвинский <me@dmedvinsky.name>

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -14,10 +14,11 @@ function(hljs) {
     relevance: 0
   };
   var KEYWORDS =
-    'alt any as assert be bind block bool break char check claim const cont dir do else enum ' +
-    'export f32 f64 fail false float fn for i16 i32 i64 i8 if iface impl import in int let ' +
-    'log mod mutable native note of prove pure resource ret self str syntax true type u16 u32 ' +
-    'u64 u8 uint unchecked unsafe use vec while';
+    'assert bool break char check claim comm const cont copy dir do drop ' +
+    'else enum extern export f32 f64 fail false float fn for i16 i32 i64 i8 ' +
+    'if impl int let log loop match mod move mut priv pub pure ref return ' +
+    'self static str struct task true trait type u16 u32 u64 u8 uint unsafe ' +
+    'use vec while';
   return {
     keywords: KEYWORDS,
     illegal: '</',
@@ -45,7 +46,7 @@ function(hljs) {
       },
       {
         beginWithKeyword: true, end: '({|<)',
-        keywords: 'iface enum',
+        keywords: 'trait enum',
         contains: [TITLE],
         illegal: '\\S'
       }


### PR DESCRIPTION
There is 0.4 with some new keywords, e.g.:
- `match` instead of `alt`
- `trait` instead of `iface`
- `use` instead of `import`
- `copy`
- `move`
- ...
