### PR TITLE
remove requirement for parentNode in .hightlightBlock()

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -33,7 +33,7 @@ function() {
   }
 
   function blockLanguage(block) {
-    var classes = (block.className + ' ' + block.parentNode.className).split(/\s+/);
+    var classes = (block.className + ' ' + (block.parentNode ? block.parentNode.className : '')).split(/\s+/);
     classes = classes.map(function(c) {return c.replace(/^language-/, '')});
     for (var i = 0; i < classes.length; i++) {
       if (languages[classes[i]] || classes[i] == 'no-highlight') {


### PR DESCRIPTION
This patch allows .highlightBlock() to be applied to DOM elements that don't have a parentNode. Especially useful if you want to apply markup before inserting your element into the DOM tree.
