### PR TITLE
recognized plus quoting in AsciiDoc markup

### DIFF
--- a/src/languages/asciidoc.js
+++ b/src/languages/asciidoc.js
@@ -139,7 +139,7 @@ function(hljs) {
       // inline code snippets (TODO should get same treatment as strong and emphasis)
       {
         className: 'code',
-        begin: '`.+?`',
+        begin: '(`.+?`|\\+.+?\\+)',
         relevance: 0
       },
       // indented literal block

--- a/src/test.html
+++ b/src/test.html
@@ -478,6 +478,7 @@ using an explicit link:http://example.com[link prefix].
 * single quotes around a phrase place 'emphasis'
 ** alternatively, you can put underlines around a phrase to add _emphasis_
 * astericks around a phrase make the text *bold*
+* pluses around a phrase make it +monospaced+
 
 - escape characters are supported
 - you can escape a quote inside emphasized text like 'here\'s johnny!'
@@ -489,7 +490,7 @@ term:: definition
 
 Let's make a break.
 
-''''
+'''
 
 ////
 we'll be right with you


### PR DESCRIPTION
Support the following AsciiDoc syntax:

```
Pluses around text make it +monospaced+
```
