### PR TITLE
Escape <>& correctly - now valid HTML5

### DIFF
--- a/src/test.html
+++ b/src/test.html
@@ -223,7 +223,7 @@ module ABC::DEF
   # @return [String] nothing
   def foo(test)
     Thread.new do |blockvar|
-      ABC::DEF.reverse(:a_symbol, :'a symbol', :<=>, 'test' + test)
+      ABC::DEF.reverse(:a_symbol, :'a symbol', :&lt;=&gt;, 'test' + test)
     end.join
   end
 
@@ -705,8 +705,8 @@ ul {
 
 a {
   color: $colorGreen;
-  &:hover { color: $colorGreenDark; }
-  &:visited { color: #c458cb; }
+  &amp;:hover { color: $colorGreenDark; }
+  &amp;:visited { color: #c458cb; }
 }
 
 @for $i from 1 through 5 {
@@ -1227,16 +1227,16 @@ async Task&lt;int&gt; AccessTheWebAsync()
 *)
 let checkList alist =
     match alist with
-    | [] -> 0
-    | [a] -> 1
-    | [a; b] -> 2
-    | [a; b; c] -> 3
-    | _ -> failwith "List is too big!"
+    | [] -&gt; 0
+    | [a] -&gt; 1
+    | [a; b] -&gt; 2
+    | [a; b; c] -&gt; 3
+    | _ -&gt; failwith "List is too big!"
 
 
 type IEncoding =
-    abstract Encode : string -> string
-    abstract Decode : string -> string
+    abstract Encode : string -&gt; string
+    abstract Decode : string -&gt; string
 
 let text = "Some text..."
 let text2 = @"A ""verbatim"" string..."
@@ -1244,18 +1244,18 @@ let catalog = """
 Some "long" string...
 """
 
-let rec fib x = if x <= 2 then 1 else fib(x-1) + fib(x-2)
+let rec fib x = if x &lt;= 2 then 1 else fib(x-1) + fib(x-2)
 
 let fibs =
-    Async.Parallel [ for i in 0..40 -> async { return fib(i) } ]
-    |> Async.RunSynchronously
+    Async.Parallel [ for i in 0..40 -&gt; async { return fib(i) } ]
+    |&gt; Async.RunSynchronously
 
 type Sprocket(gears) =
   member this.Gears : int = gears
 
-[&ltAbstractClass&gt]
+[&lt;AbstractClass&gt;]
 type Animal =
-  abstract Speak : unit -> unit
+  abstract Speak : unit -&gt; unit
 
 type Widget =
   | RedWidget
@@ -1263,9 +1263,9 @@ type Widget =
 
 type Point = {X: float; Y: float;}
 
-[&ltMeasure&gt]
+[&lt;Measure&gt;]
 type s
-let minutte = 60&lts&gt
+let minutte = 60&lt;s&gt;
 
 </code></pre>
 
@@ -1420,7 +1420,7 @@ layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
 void main() {
-  for(int i = 0; i < gl_in.length(); i++) {
+  for(int i = 0; i &lt; gl_in.length(); i++) {
     gl_Position = gl_in[i].gl_Position;
     EmitVertex();
   }
@@ -1543,11 +1543,11 @@ heapExample
 (def
   ^{:macro true
     :added "1.0"}
-  let (fn* let [&form &env & decl] (cons 'let* decl)))
+  let (fn* let [&amp;form &amp;env &amp; decl] (cons 'let* decl)))
 
 (def
 
- defn (fn defn [&form &env name & fdecl]
+ defn (fn defn [&amp;form &amp;env name &amp; fdecl]
         (let [m (conj {:arglists (list 'quote (sigs fdecl))} m)
               m (let [inline (:inline m)
                       ifn (first inline)
@@ -2023,21 +2023,22 @@ $$
     <td class="brainfuck">
 <pre><code>++++++++++
 [ 3*10 and 10*10
-  ->+++>++++++++++<<
-]>>
+  -&gt;+++&gt;++++++++++&lt;&lt;
+]&gt;&gt;
 [ filling cells
-  ->++>>++>++>+>++>>++>++>++>++>++>++>++>++>++>++>++[<]<[<]<[<]>>
-]<
-+++++++++<<
+  -&gt;++&gt;&gt;++&gt;++&gt;+&gt;++&gt;&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++&gt;++[&lt;]&lt;[&lt;]&lt;[&lt;]&gt;&gt;
+]&lt;
++++++++++&lt;&lt;
 [ rough codes correction loop
-  ->>>+>+>+>+++>+>+>+>+>+>+>+>+>+>+>+>+>+>+[<]<
+  -&gt;&gt;&gt;+&gt;+&gt;+&gt;+++&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+&gt;+[&lt;]&lt;
 ]
 more accurate сodes correction
->>>++>
--->+++++++>------>++++++>++>+++++++++>++++++++++>++++++++>--->++++++++++>------>++++++>
-++>+++++++++++>++++++++++++>------>+++
+&gt;&gt;&gt;++&gt;
+--&gt;+++++++&gt;------&gt;++++++&gt;++&gt;+++++++++&gt;++++++++++&gt;++++++++&gt;---&gt;++++++++++&gt;------&gt;++++++&gt;
+++&gt;+++++++++++&gt;++++++++++++&gt;------&gt;+++
 rewind and output
-[<]>[.>]</code></pre>
+[&lt;]&gt;[.&gt;]
+</code></pre>
 
   <tr>
     <th>Haskell
@@ -2064,8 +2065,8 @@ import Network.Socket.ByteString (sendTo, recv, recvFrom)
 
 -- Type class for converting StringLike types to and from strict ByteStrings
 class DataPacket a where
-  toStrictBS :: a -> Strict.ByteString
-  fromStrictBS :: Strict.ByteString -> a
+  toStrictBS :: a -&gt; Strict.ByteString
+  fromStrictBS :: Strict.ByteString -&gt; a
 
 instance DataPacket Strict.ByteString where
   toStrictBS = id
@@ -2073,16 +2074,16 @@ instance DataPacket Strict.ByteString where
   fromStrictBS = id
   {-# INLINE fromStrictBS #-}
 
-openBoundUDPPort :: String -> Int -> IO Socket
+openBoundUDPPort :: String -&gt; Int -&gt; IO Socket
 openBoundUDPPort uri port = do
-  s <- getUDPSocket
-  bindAddr <- inet_addr uri
+  s &lt;- getUDPSocket
+  bindAddr &lt;- inet_addr uri
   let a = SockAddrInet (toEnum port) bindAddr
   bindSocket s a
   return s
 
-pingUDPPort :: Socket -> SockAddr -> IO ()
-pingUDPPort s a = sendTo s (Strict.singleton 0) a >> return ()
+pingUDPPort :: Socket -&gt; SockAddr -&gt; IO ()
+pingUDPPort s a = sendTo s (Strict.singleton 0) a &gt;&gt; return ()
 </code></pre>
 
   <tr>
@@ -2102,36 +2103,36 @@ pingUDPPort s a = sendTo s (Strict.singleton 0) a >> return ()
     channel
    }).
 
-test(Foo)->Foo.
+test(Foo)-&gt;Foo.
 
-init([Shell, Exec]) ->
+init([Shell, Exec]) -&gt;
     {ok, #state{shell = Shell, exec = Exec}};
-init([Shell]) ->
+init([Shell]) -&gt;
     false = not true,
     io:format("Hello, \"~p!~n", [atom_to_list('World')]),
     {ok, #state{shell = Shell}}.
 
-concat([Single]) -> Single;
-concat(RList) ->
+concat([Single]) -&gt; Single;
+concat(RList) -&gt;
     EpsilonFree = lists:filter(
-        fun (Element) ->
+        fun (Element) -&gt;
             case Element of
-                epsilon -> false;
-                _ -> true
+                epsilon -&gt; false;
+                _ -&gt; true
             end
         end,
         RList),
     case EpsilonFree of
-        [Single] -> Single;
-        Other -> {concat, Other}
+        [Single] -&gt; Single;
+        Other -&gt; {concat, Other}
     end.
 
-union_dot_union({union, _}=U1, {union, _}=U2) ->
+union_dot_union({union, _}=U1, {union, _}=U2) -&gt;
     union(lists:flatten(
         lists:map(
-            fun (X1) ->
+            fun (X1) -&gt;
                 lists:map(
-                    fun (X2) ->
+                    fun (X2) -&gt;
                         concat([X1, X2])
                     end,
                     union_to_list(U2)
@@ -2144,32 +2145,32 @@ union_dot_union({union, _}=U1, {union, _}=U2) ->
   <tr>
     <th>Erlang REPL
     <td class="erlang-repl">
-<pre><code>1> Str = "abcd".
+<pre><code>1&gt; Str = "abcd".
 "abcd"
-2> L = test:length(Str).
+2&gt; L = test:length(Str).
 4
-3> Descriptor = {L, list_to_atom(Str)}.
+3&gt; Descriptor = {L, list_to_atom(Str)}.
 {4,abcd}
-4> L.
+4&gt; L.
 4
-5> b().
+5&gt; b().
 Descriptor = {4,abcd}
 L = 4
 Str = "abcd"
 ok
-6> f(L).
+6&gt; f(L).
 ok
-7> b().
+7&gt; b().
 Descriptor = {4,abcd}
 Str = "abcd"
 ok
-8> {L, _} = Descriptor.
+8&gt; {L, _} = Descriptor.
 {4,abcd}
-9> L.
+9&gt; L.
 4
-10> 2#101.
+10&gt; 2#101.
 5
-11> 1.85e+3.
+11&gt; 1.85e+3.
 1850
 </code></pre>
 
@@ -2195,7 +2196,7 @@ export fac, test1;
 12E+99_f64;                        // type f64
 
 /* Factorial */
-fn fac(n: int) -> int {
+fn fac(n: int) -&gt; int {
     let s: str = "This is
 a multi-line string.
 
@@ -2203,39 +2204,39 @@ It ends with an unescaped '\"'.";
     let c: char = 'Ф';
 
     let result = 1, i = 1;
-    while i <= n { // No parens around the condition
+    while i &lt;= n { // No parens around the condition
         result *= i;
         i += 1;
     }
     ret result;
 }
 
-pure fn pure_length&lt;T>(ls: list&lt;T>) -> uint { /* ... */ }
+pure fn pure_length&lt;T&gt;(ls: list&lt;T&gt;) -&gt; uint { /* ... */ }
 
-type t = map::hashtbl&lt;int,str>;
-let x = id::&lt;int>(10);
+type t = map::hashtbl&lt;int,str&gt;;
+let x = id::&lt;int&gt;(10);
 
 // Define some modules.
 #[path = "foo.rs"]
 mod foo;
 
-iface seq&lt;T> {
-    fn len() -> uint;
+iface seq&lt;T&gt; {
+    fn len() -&gt; uint;
 }
 
-impl &lt;T> of seq&lt;T> for [T] {
-    fn len() -> uint { vec::len(self) }
+impl &lt;T&gt; of seq&lt;T&gt; for [T] {
+    fn len() -&gt; uint { vec::len(self) }
     fn iter(b: fn(T)) {
         for elt in self { b(elt); }
     }
 }
 
-enum list&lt;T> {
+enum list&lt;T&gt; {
     nil;
-    cons(T, @list&lt;T>);
+    cons(T, @list&lt;T&gt;);
 }
 
-let a: list&lt;int> = cons(7, @cons(13, @nil));
+let a: list&lt;int&gt; = cons(7, @cons(13, @nil));
 </code></pre>
 
   <tr>
@@ -2250,7 +2251,7 @@ plot(points(:,1),points(:,2));
 for i = 1: n-1
     len(i) = points(i + 1, 1) - points(i, 1);
 end
-while(max(len) > 2 * min(len))
+while(max(len) &gt; 2 * min(len))
     [d, i] = max(len);
     k = on_margin(points, i, d, -1);
     m = on_margin(points, i + 1, d, 1);
@@ -2286,7 +2287,7 @@ foo_cell = {1, 2, 3; 4, 5, 6}''.'.';
     <td class="r">
 <pre><code>library(ggplot2)
 
-centre <- function(x, type, ...) {
+centre &lt;- function(x, type, ...) {
   switch(type,
          mean = mean(x),
          median = median(x),
@@ -2315,8 +2316,8 @@ foo "bar" baz
 1L + 30
 plot(cars, xlim=20)
 plot(cars, xlim=0x20)
-foo<-30
-my.data.3 <- read() # not a number
+foo&lt;-30
+my.data.3 &lt;- read() # not a number
 c(1,2,3)
 1%%2
 
@@ -2345,8 +2346,8 @@ na_character_ na_complex_ Function While Repeat
 For If In Else Next Break .. .... "NULL" `NULL` 'NULL'
 
 # operators
-+, -, *, /, %%, ^, >, >=, <, <=, ==, !=, !, &, |, ~,
-->, <-, <<-, $, :, ::
++, -, *, /, %%, ^, &gt;, &gt;=, &lt;, &lt;=, ==, !=, !, &amp;, |, ~,
+-&gt;, &lt;-, &lt;&lt;-, $, :, ::
 
 # infix operator
 foo %union% bar
@@ -2380,17 +2381,17 @@ definition
   let D;
 
   attr D is LambdaTerm-like means
-    (dom D qua Tree) is finite &
-::>                          *143,306
+    (dom D qua Tree) is finite &amp;
+::&gt;                          *143,306
     for r st r in dom D holds
-      r is FinSequence of {0,1} &
-      r^<*0*> in dom D implies D.r = 0;
+      r is FinSequence of {0,1} &amp;
+      r^&lt;*0*&gt; in dom D implies D.r = 0;
 end;
 
 registration
   cluster LambdaTerm-like for DecoratedTree of NAT;
   existence;
-::>       *4
+::&gt;       *4
 end;
 
 definition
@@ -2404,22 +2405,22 @@ definition
 
   pred M beta N means
     ex p st
-      M|p beta_shallow N|p &
+      M|p beta_shallow N|p &amp;
       for q st not p is_a_prefix_of q holds
         [r,x] in M iff [r,x] in N;
 end;
 
 theorem Th4:
-  ProperPrefixes (v^<*x*>) = ProperPrefixes v \/ {v}
+  ProperPrefixes (v^&lt;*x*&gt;) = ProperPrefixes v \/ {v}
 proof
-  thus ProperPrefixes (v^<*x*>) c= ProperPrefixes v \/ {v}
+  thus ProperPrefixes (v^&lt;*x*&gt;) c= ProperPrefixes v \/ {v}
   proof
     let y;
-    assume y in ProperPrefixes (v^<*x*>);
+    assume y in ProperPrefixes (v^&lt;*x*&gt;);
     then consider v1 such that
 A1: y = v1 and
-A2: v1 is_a_proper_prefix_of v^<*x*> by TREES_1:def 2;
- v1 is_a_prefix_of v & v1 <> v or v1 = v by A2,TREES_1:9;
+A2: v1 is_a_proper_prefix_of v^&lt;*x*&gt; by TREES_1:def 2;
+ v1 is_a_prefix_of v &amp; v1 &lt;&gt; v or v1 = v by A2,TREES_1:9;
 then
  v1 is_a_proper_prefix_of v or v1 in {v} by TARSKI:def 1,XBOOLE_0:def 8;
 then  y in ProperPrefixes v or y in {v} by A1,TREES_1:def 2;
@@ -2433,15 +2434,15 @@ A4: now
     then consider v1 such that
 A5: y = v1 and
 A6: v1 is_a_proper_prefix_of v by TREES_1:def 2;
- v is_a_prefix_of v^<*x*> by TREES_1:1;
-then  v1 is_a_proper_prefix_of v^<*x*> by A6,XBOOLE_1:58;
+ v is_a_prefix_of v^&lt;*x*&gt; by TREES_1:1;
+then  v1 is_a_proper_prefix_of v^&lt;*x*&gt; by A6,XBOOLE_1:58;
     hence thesis by A5,TREES_1:def 2;
   end;
  v^{} = v by FINSEQ_1:34;
   then
- v is_a_prefix_of v^<*x*> & v <> v^<*x*> by FINSEQ_1:33,TREES_1:1;
-then  v is_a_proper_prefix_of v^<*x*> by XBOOLE_0:def 8;
-then  y in ProperPrefixes v or y = v & v in ProperPrefixes (v^<*x*>)
+ v is_a_prefix_of v^&lt;*x*&gt; &amp; v &lt;&gt; v^&lt;*x*&gt; by FINSEQ_1:33,TREES_1:1;
+then  v is_a_proper_prefix_of v^&lt;*x*&gt; by XBOOLE_0:def 8;
+then  y in ProperPrefixes v or y = v &amp; v in ProperPrefixes (v^&lt;*x*&gt;)
   by A3,TARSKI:def 1,TREES_1:def 2;
   hence thesis by A4;
 end;</code></pre>


### PR DESCRIPTION
Tested with http://validator.w3.org/check

F# section was already valid HTML, but had double-escaped &amplt; -
fixed as well.
