### PR TITLE
add theme based on Foundation 4 docs

### DIFF
--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -1,0 +1,117 @@
+/*
+Description: Foundation 4 docs style for highlight.js
+Author: Dan Allen <dan.j.allen@gmail.com>
+Website: http://foundation.zurb.com/docs/
+Version: 1.0
+Date: 2013-04-02
+*/
+
+pre code {
+  font-size: .9em;
+  display: block;
+  line-height: 1.4;
+  background-color: #eee;
+  font-family: monospace;
+  padding: .8em;
+}
+
+pre .decorator,
+pre .annotation {
+  color: #000077;
+}
+
+pre .attribute {
+  color: #070;
+}
+
+pre .value,
+pre .string,
+pre .scss .value .string {
+  color: #d14;
+}
+
+pre .comment {
+  color: #998;
+  font-style: italic;
+}
+
+pre .function .title {
+  color: #900;
+}
+
+pre .class {
+  color: #458;
+}
+
+pre .id,
+pre .pseudo,
+pre .constant,
+pre .hexcolor {
+  color: teal;
+}
+
+pre .variable {
+  color: #336699;
+}
+
+pre .javadoc {
+  color: #997700;
+}
+
+pre .pi,
+pre .doctype {
+  color: #3344bb;
+}
+
+pre .number {
+  color: #099;
+}
+
+pre .important {
+  color: #f00;
+}
+
+pre .label {
+  color: #970;
+}
+
+pre .preprocessor {
+  color: #579;
+}
+
+pre .reserved,
+pre .keyword,
+pre .scss .value {
+  color: #000;
+}
+
+pre .regexp {
+  background-color: #fff0ff;
+  color: #880088;
+}
+
+pre .symbol {
+  color: #990073;
+}
+
+pre .symbol .string {
+  color: #a60;
+}
+
+pre .tag {
+  color: #007700;
+}
+
+pre .at_rule,
+pre .at_rule .keyword {
+  color: #088;
+}
+
+pre .at_rule .preprocessor {
+  color: #808;
+}
+
+pre .scss .tag,
+pre .scss .attribute {
+  color: #339;
+}

--- a/src/test.html
+++ b/src/test.html
@@ -34,6 +34,7 @@
   <link rel="alternate stylesheet" title="Obsidian" href="styles/obsidian.css">
   <link rel="alternate stylesheet" title="Docco" href="styles/docco.css">
   <link rel="alternate stylesheet" title="Mono Blue" href="styles/mono-blue.css">
+  <link rel="alternate stylesheet" title="Foundation" href="styles/foundation.css">
 
   <style>
     body {


### PR DESCRIPTION
Matches CodeRay theme used in the Foundation 4 documentation at http://foundation.zurb.com/docs.

Works best with the Ruby and web stack, but does a decent job for other languages as well.
