### PR TITLE
Fixed detection of numbers in ruby

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -82,3 +82,4 @@ Contributors:
 - Poren Chiang <ren.chiang@gmail.com>
 - Kelley van Evert <kelleyvanevert@gmail.com>
 - Kurt Emch <kurt@kurtemch.com>
+- Alexander Kaupanin <kaupanin@gmail.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -82,3 +82,4 @@ URL:   http://softwaremaniacs.org/soft/highlight/
 - Порен Чянь <ren.chiang@gmail.com>
 - Келли ван Эверт <kelleyvanevert@gmail.com>
 - Курт Эмч <kurt@kurtemch.com>
+- Александр Каупанин <kaupanin@gmail.com>

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -1,7 +1,7 @@
 /*
 Language: Ruby
 Author: Anton Kovalyov <anton@kovalyov.net>
-Contributors: Peter Leonov <gojpeg@yandex.ru>, Vasily Polovnyov <vast@whiteants.net>, Loren Segal <lsegal@soen.ca>
+Contributors: Peter Leonov <gojpeg@yandex.ru>, Vasily Polovnyov <vast@whiteants.net>, Loren Segal <lsegal@soen.ca>, Alexander Kaupanin <kaupanin@gmail.com>
 */
 
 function(hljs) {
@@ -165,7 +165,7 @@ function(hljs) {
     },
     {
       className: 'number',
-      begin: '\\?\\w'
+      begin: '^\\?\\d'
     },
     {
       className: 'variable',

--- a/src/test.html
+++ b/src/test.html
@@ -232,6 +232,8 @@ module ABC::DEF
   def ==(other) other == self end
 end
 
+answer = valid?42 && valid?CONST && ?A && ?A.ord
+float = 9.03
 anIdentifier = an_identifier
 Constant = 1
 render action: :new


### PR DESCRIPTION
Made tests like this passing:

``` ruby
answer = valid?42 && valid?CONST && ?A && ?A.ord
```
