### PR TITLE
Move multiline-string regex before normals so it takes precendence

### DIFF
--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -28,7 +28,7 @@ function(hljs) {
         relevance: 10
       },
       hljs.C_LINE_COMMENT_MODE, hljs.C_BLOCK_COMMENT_MODE,
-      hljs.APOS_STRING_MODE, hljs.QUOTE_STRING_MODE, STRING,
+      STRING, hljs.APOS_STRING_MODE, hljs.QUOTE_STRING_MODE,
       {
         className: 'class',
         begin: '((case )?class |object |trait )', end: '({|$)', // beginWithKeyword won't work because a single "case" shouldn't start this mode


### PR DESCRIPTION
""" was being matched as an opening and closing string, then another opening string. Moving the STRING variable before it in the regex order means that the multiline """ takes precendence over the single-line ".

Fixes #243
