### PR TITLE
PHP 5.5 keywords

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -35,7 +35,8 @@ function(hljs) {
       'return implements parent clone use __CLASS__ __LINE__ else break print eval new ' +
       'catch __METHOD__ case exception php_user_filter default die require __FUNCTION__ ' +
       'enddeclare final try this switch continue endfor endif declare unset true false ' +
-      'namespace trait goto instanceof insteadof __DIR__ __NAMESPACE__ __halt_compiler',
+      'namespace trait goto instanceof insteadof __DIR__ __NAMESPACE__ __halt_compiler ' +
+      'yield finally',
     contains: [
       hljs.C_LINE_COMMENT_MODE,
       hljs.HASH_COMMENT_MODE,


### PR DESCRIPTION
Вань, а что делает в ключевых словах PHP класс php_user_filter? Это не ключевое слово, а обычный класс модуля stream: http://php.net/manual/en/class.php-user-filter.php Таких классов в PHP пруд пруди.
