### PR TITLE
Add plain C language mode

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -93,3 +93,4 @@ Contributors:
 - Carlo Kok <ck@remobjects.com>
 - Bram de Haan <info@atelierbramdehaan.nl>
 - Seongwon Lee <dlimpid@gmail.com>
+- Zaven Muradyan <megalivoithos@gmail.com>

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -11,10 +11,16 @@ function(hljs) {
       'do return goto auto void enum else break new extern using true class asm case typeid ' +
       'short reinterpret_cast|10 default double register explicit signed typename try this ' +
       'switch continue wchar_t inline delete alignof char16_t char32_t constexpr decltype ' +
-      'noexcept nullptr static_assert thread_local restrict _Bool complex',
+      'noexcept nullptr static_assert thread_local restrict _Bool complex _Complex _Imaginary',
     built_in: 'std string cin cout cerr clog stringstream istringstream ostringstream ' +
       'auto_ptr deque list queue stack vector map set bitset multiset multimap unordered_set ' +
-      'unordered_map unordered_multiset unordered_multimap array shared_ptr'
+      'unordered_map unordered_multiset unordered_multimap array shared_ptr abort abs acos ' +
+      'asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp ' +
+      'fscanf isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper ' +
+      'isxdigit tolower toupper labs ldexp log10 log malloc memchr memcmp memcpy memset modf pow ' +
+      'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
+      'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
+      'vfprintf vprintf vsprintf'
   };
   return {
     aliases: ['c'],


### PR DESCRIPTION
I mostly used the existing CPP language definition as a base, although C has its own set of keywords and built-ins. It _is_ a different programming language, and as such would benefit from having a definition in highlight.js.

This would be particularly important in cases where the highlighting language is known beforehand (and is not being auto-detected). In my case, I had a code snippet with class="language-c", and not knowing otherwise highlight.js was unfortunately guessing that the snippet was Haskell.
