### PR TITLE
Created codepen.io embed theme

### DIFF
--- a/src/styles/codepen-embed.css
+++ b/src/styles/codepen-embed.css
@@ -1,0 +1,74 @@
+/* codepen.io Embed Theme */
+/* Author: Justin Perry <http://github.com/ourmaninamsterdam> */
+/* Original theme - https://github.com/chriskempson/tomorrow-theme */
+
+.codepen, pre .comment, pre .title{
+  color: #777;
+}
+
+.codepen, pre .variable, pre .attribute, pre .tag, pre .regexp, pre .ruby .constant, pre .xml .tag .title, pre .xml .pi, pre .xml .doctype, pre .html .doctype{
+  color: #ab875d;
+}
+
+.codepen, pre .css .value{
+  color: #cd6a51;
+}
+
+.codepen, pre .css .value .function, pre .css .value .string{
+  color: #a67f59;
+}
+
+.codepen, pre .css .value .number{
+  color: #9b869c;
+}
+
+.codepen, pre .css .id, pre .css .class, pre .css-pseudo, pre .css .selector, pre .css .tag{
+  color: #dfc48c;
+}
+
+.codepen, pre .number, pre .preprocessor, pre .built_in, pre .literal, pre .params, pre .constant {
+  color: #ab875d;
+}
+
+.codepen, pre .ruby .class .title, pre .css .rules .attribute {
+  color: #9B869B;
+}
+
+.codepen, pre .string, pre .value, pre .inheritance, pre .header, pre .ruby .symbol, pre .xml .cdata {
+  color: #8f9c6c;
+}
+
+.codepen, pre .css .hexcolor {
+  color: #cd6a51;
+}
+
+.codepen, .function, pre .python .decorator, pre .python .title, pre .ruby .function .title, pre .ruby .title .keyword, pre .perl .sub, pre .javascript .title, pre .coffeescript .title {
+  color: #fff;
+}
+
+.codepen, pre .keyword, pre .javascript .function {
+  color: #8f9c6c;
+}
+
+pre code{
+  background: #222;
+  color: #fff; 
+  font-family: Menlo, Monaco, 'Andale Mono', 'Lucida Console', 'Courier New', monospace;
+  font-size: 14px;
+  overflow: auto;
+  margin-bottom: 32px;
+  padding: 8px 16px;
+  white-space: pre;
+}
+
+pre .coffeescript .javascript,
+pre .javascript,
+pre .javascript .xml,
+pre .tex .formula,
+pre .xml .javascript,
+pre .xml .vbscript,
+pre .xml .css,
+pre .xml .cdata {
+  background: transparent;
+  opacity: 1;
+}


### PR DESCRIPTION
I've produced a [Codepen](http://codepen.io) embed theme for use on my blog and thought it may prove useful to the community.
# CSS

highlight.js version is first followed by actual Codepen embed
![screen shot 2013-11-05 at 11 08 17](https://f.cloud.github.com/assets/1579511/1472828/9ffc64c4-460a-11e3-8617-cafdf7b4ad94.png)
# JS

Actual Codepen embed is first followed by highlight.js version
![screen shot 2013-11-05 at 11 08 50](https://f.cloud.github.com/assets/1579511/1472831/b203f10a-460a-11e3-9e37-2424a473ca63.png)
# HTML

highlight.js version is first followed by actual Codepen embed
![screen shot 2013-11-05 at 11 11 36](https://f.cloud.github.com/assets/1579511/1472855/16f3f56a-460b-11e3-98c9-f41d283dc8bc.png)
