### PR TITLE
added an trivial Erlang snippet in src/test.html that breaks Erlang syntax highlighting

### DIFF
--- a/src/test.html
+++ b/src/test.html
@@ -2258,6 +2258,9 @@ union_dot_union({union, _}=U1, {union, _}=U2) -&gt;
             end,
             union_to_list(U1)
         ))).
+
+read(State) -&gt;
+    {ok, State#state.channel}.
 </code></pre>
 
   <tr>


### PR DESCRIPTION
- See http://www.erlang.org/doc/reference_manual/records.html#id81706 for syntax
- I will try to fix the Erlang parser later on if I find the time
