### PR TITLE
Fix language aliases not being registered.

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -557,9 +557,9 @@ function() {
   var aliases = {};
 
   function registerLanguage(name, language) {
-    languages[name] = language(self);
-    if (language.aliases) {
-      language.aliases.forEach(function(alias) {aliases[alias] = name;});
+    var lang = languages[name] = language(self);
+    if (lang.aliases) {
+      lang.aliases.forEach(function(alias) {aliases[alias] = name;});
     }
   }
 


### PR DESCRIPTION
The registerLanguage function should retrieve the aliases information
from the language instance, NOT the language constructor.

Did this ever work before?
