### PR TITLE
Add "golang" as an alias for the go language

### DIFF
--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -19,6 +19,7 @@ function(hljs) {
       'append cap close complex copy imag len make new panic print println real recover delete'
   };
   return {
+    aliases: ["golang"],
     keywords: GO_KEYWORDS,
     illegal: '</',
     contains: [


### PR DESCRIPTION
Ace Editor's reports the go language as "golang".

Maybe it's legit to consider golang as an alias?
