### PR TITLE
A Few Improvements to SCSS Mode

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -665,7 +665,8 @@ function() {
       '|s|ms' +
       '|Hz|kHz' +
       '|dpi|dpcm|dppx' +
-      ')?'
+      ')?',
+    relevance: 0
   };
   this.REGEXP_MODE = {
     className: 'regexp',

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -6,8 +6,10 @@ function(hljs) {
   var IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
   var FUNCTION = {
     className: 'function',
-    begin: IDENT_RE + '\\(', end: '\\)',
-    contains: ['self', hljs.CSS_NUMBER_MODE, hljs.APOS_STRING_MODE, hljs.QUOTE_STRING_MODE]
+    begin: IDENT_RE + '\\(', 
+    returnBegin: true,
+    excludeEnd: true,
+    end: '\\('
   };
   return {
     case_insensitive: true,

--- a/src/languages/scss.js
+++ b/src/languages/scss.js
@@ -12,6 +12,7 @@ function(hljs) {
     className: 'function',
     begin: IDENT_RE + '\\(', 
     returnBegin: true,
+    excludeEnd: true,
     end: '\\('
   };
   var HEXCOLOR = {


### PR DESCRIPTION
This adds detection for variables in SCSS mode (I think this previously existed, but was removed without comment in @7e3b127), along with improved detection of functions.  

I also have a few questions, if anyone's available to answer them -
1. Should function arguments be classified as functions? This leads to the parentheses and any unclassified arguments to be colored the same as the function, which strikes me as a bit odd. 
2. Would it be appropriate to create a CSS-specific form of NUMBER_MODE that includes units? Right now, a value like `10px` would classify the `10` as a number and leave `px` alone (this is true for both CSS and SCSS). To me, it seems reasonable that units like `px`, `em` and `deg` should be classified with the number. 
