### PR TITLE
fixed language contributor checklist to reflect up-to-date language def format

### DIFF
--- a/docs/contribution.rst
+++ b/docs/contribution.rst
@@ -12,9 +12,8 @@ this is done during the build process and details differ for different build tar
 
   function(hljs) {
     return {
-      defaultMode: {
-        contains: [ ..., hljs.NUMBER_MODE, ... ]
-      }
+      keywords: 'foo bar',
+      contains: [ ..., hljs.NUMBER_MODE, ... ]
     }
   }
   


### PR DESCRIPTION
I noticed while working on #374 that the language contributor checklist includes a misleading example, with a `defaultMode` property. As far as I can tell that must be an outdated language definition format. All the current language definitions seem to return the default mode directly rather than wrapping it.
