### PR TITLE
Alias for Objective-C

### DIFF
--- a/src/languages/objectivec.js
+++ b/src/languages/objectivec.js
@@ -35,7 +35,7 @@ function(hljs) {
   var LEXEMES = /[a-zA-Z@][a-zA-Z0-9_]*/;
   var CLASS_KEYWORDS = '@interface @class @protocol @implementation';
   return {
-    aliases: ['m', 'mm'],
+    aliases: ['m', 'mm', 'objc'],
     keywords: OBJC_KEYWORDS, lexemes: LEXEMES,
     illegal: '</',
     contains: [


### PR DESCRIPTION
On GitHub, the `objc` alias is often used. Can we add it?
Also, is it possible to add `obj-c` (with a dash)?
