### PR TITLE
Added language support for Twig templating

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -225,6 +225,23 @@ Django ("django", "jinja")
 * ``filter``:           filter from "|" till the next filter or the end of tag
 * ``argument``:         filter argument
 
+
+Twig ("twig", "craftcms")
+--------------------------
+
+* ``keyword``:          HTML tag in HTML, default tags and default filters in templates
+* ``tag``:              any tag from "<" till ">"
+* ``comment``:          comment
+* ``doctype``:          <!DOCTYPE ... > declaration
+* ``attribute``:        tag's attribute with or withou value
+* ``value``:            attribute's value
+* ``template_tag``:     template tag {% .. %}
+* ``variable``:         template variable {{ .. }}
+* ``template_comment``: template comment {# .. #}
+* ``filter``:           filter from "|" till the next filter or the end of tag
+* ``argument``:         filter argument
+
+
 Handlebars ("handlebars", "hbs", "html.hbs", "html.handlebars")
 ---------------------------------------------------------------
 

--- a/src/languages/twig.js
+++ b/src/languages/twig.js
@@ -1,0 +1,68 @@
+/*
+Language: Twig
+Requires: xml.js
+Author: Luke Holder <lukemh@gmail.com>
+Description: Twig is a templating language for PHP
+*/
+
+function(hljs) {
+
+  var PARAMS = {
+    className: 'params',
+    begin: '\\(', end: '\\)'
+  };
+
+
+  var FUNCTION_NAMES = 'attribute block constant cycle date dump include ' +
+                  'max min parent random range source template_from_string';
+
+  var FUNCTIONS = {
+    className: 'function',
+    beginKeywords: FUNCTION_NAMES,
+    relevance: 0,
+    contains: [
+      PARAMS
+    ]
+  };
+
+  var FILTER = {
+    className: 'filter',
+    begin: /\|[A-Za-z]+\:?/,
+    keywords:
+      'abs batch capitalize convert_encoding date date_modify default ' +
+      'escape first format join json_encode keys last length lower ' +
+      'merge nl2br number_format raw replace reverse round slice sort split ' +
+      'striptags title trim upper url_encode',
+    contains: [
+      FUNCTIONS
+    ]
+  };
+
+
+  return {
+    aliases: ['craftcms'],
+    case_insensitive: true,
+    subLanguage: 'xml', subLanguageMode: 'continuous',
+    contains: [
+      {
+        className: 'template_comment',
+        begin: /\{#/, end: /#}/
+      },
+
+      {
+        className: 'template_tag',
+        begin: /\{%/, end: /%}/,
+        keywords:
+          'autoescape block do embed extends filter flush for ' +
+          'if import include maro sandbox set spaceless use ' +
+          'verbatim',
+        contains: [FILTER,FUNCTIONS]
+      },
+      {
+        className: 'variable',
+        begin: /\{\{/, end: /}}/,
+        contains: [FILTER,FUNCTIONS]
+      }
+    ]
+  };
+}

--- a/src/test.html
+++ b/src/test.html
@@ -737,6 +737,33 @@ Markup is &lt;em&gt;not&lt;/em&gt; highlighted within comments.
 </code></pre>
 
   <tr>
+    <th>Twig templates
+    <td class="twig">
+<pre><code>
+{% if posts|length %}
+  {% for article in articles %}
+  &lt;div&gt;
+  {{ article.title|upper() }}
+
+  {# outputs 'WELCOME' #}
+  &lt;/div&gt;
+  {% endfor %}
+{% endif %}
+
+{% set user = json_encode(user) %}
+
+{{ random(['apple', 'orange', 'citrus']) }}
+
+{{ include(template_from_string("Hello {{ name }}")) }}
+
+
+{#
+Comments may be long and multiline.
+Markup is &lt;em&gt;not&lt;/em&gt; highlighted within comments.
+#}
+</code></pre>
+
+  <tr>
     <th>Handlebars
     <td class="handlebars">
 <pre>


### PR DESCRIPTION
First time creating a language support. At first glance twig looks like django/jinja but it has a number of differences in syntax mainly to do with passing params to filters.
