### PR TITLE
Replace cyrillic 'и' by 'and' to avoid LaTeX error

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -602,7 +602,7 @@ Bash ("bash", "sh", "zsh")
 * ``string``:           string
 * ``number``:           number
 * ``comment``:          comment
-* ``literal``:          special literal: "true" и "false"
+* ``literal``:          special literal: "true" and "false"
 * ``variable``:         variable
 * ``shebang``:          script interpreter header
 


### PR DESCRIPTION
Hi,

Currently there is a LaTeX error caused by a cyrillic letter in spec/text_spec.rb. I am proposing to replace it by its English translation 'and'.

Thanks.

Cédric
