### PR TITLE
Deal with trailing commas errors

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -92,10 +92,10 @@ function(hljs) {
           contains: [hljs.BACKSLASH_ESCAPE, SUBST],
           variants: [
             {
-              begin: '/', end: '/[a-z]*',
+              begin: '/', end: '/[a-z]*'
             },
             {
-              begin: '%r\\[', end: '\\][a-z]*',
+              begin: '%r\\[', end: '\\][a-z]*'
             }
           ]
         }

--- a/src/languages/haml.js
+++ b/src/languages/haml.js
@@ -106,7 +106,7 @@ function(hljs) {
                     relevance: 0
                   }
                 ]
-              },
+              }
             ]
           }
         ]

--- a/src/languages/lisp.js
+++ b/src/languages/lisp.js
@@ -47,11 +47,11 @@ function(hljs) {
     contains: [NUMBER, STRING, VARIABLE, KEYWORD, QUOTED_LIST],
     variants: [
       {
-        begin: '[\'`]\\(', end: '\\)',
+        begin: '[\'`]\\(', end: '\\)'
       },
       {
         begin: '\\(quote ', end: '\\)',
-        keywords: {title: 'quote'},
+        keywords: {title: 'quote'}
       }
     ]
   };

--- a/src/languages/nix.js
+++ b/src/languages/nix.js
@@ -21,7 +21,7 @@ function(hljs) {
   var ATTRS = {
     className: 'variable',
     // TODO: we have to figure out a way how to exclude \s*=
-    begin: /[a-zA-Z0-9-_]+(\s*=)/,
+    begin: /[a-zA-Z0-9-_]+(\s*=)/
   };
   var SINGLE_QUOTE = {
     className: 'string',

--- a/src/languages/ocaml.js
+++ b/src/languages/ocaml.js
@@ -16,7 +16,7 @@ function(hljs) {
         'then to true try type val virtual when while with parser value',
       built_in:
         'bool char float int list unit array exn option int32 int64 nativeint ' +
-        'format4 format6 lazy_t in_channel out_channel string',
+        'format4 format6 lazy_t in_channel out_channel string'
     },
     illegal: /\/\//,
     contains: [

--- a/src/languages/scilab.js
+++ b/src/languages/scilab.js
@@ -41,8 +41,8 @@ function(hljs) {
           {
             className: 'params',
             begin: '\\(', end: '\\)'
-          },
-        ],
+          }
+        ]
       },
       {
         className: 'transposed_variable',

--- a/src/languages/vbnet.js
+++ b/src/languages/vbnet.js
@@ -41,7 +41,7 @@ function(hljs) {
           {
             className: 'xmlDocTag',
             begin: '</?', end: '>'
-          },
+          }
           ]
       },
       hljs.C_NUMBER_MODE,
@@ -49,7 +49,7 @@ function(hljs) {
         className: 'preprocessor',
         begin: '#', end: '$',
         keywords: 'if else elseif end region externalsource'
-      },
+      }
     ]
   };
 }

--- a/src/languages/vim.js
+++ b/src/languages/vim.js
@@ -36,7 +36,7 @@ function(hljs) {
         'match matchadd matcharg matchdelete matchend matchlist matchstr max min mkdir mode mzeval nextnonblank nr2char or pathshorten pow prevnonblank printf pumvisible py3eval pyeval range readfile reltime reltimestr remote_expr remote_foreground remote_peek remote_read remote_send remove rename repeat '+
         'resolve reverse round screenattr screenchar screencol screenrow search searchdecl searchpair searchpairpos searchpos server2client serverlist setbufvar setcmdpos setline setloclist setmatches setpos setqflist setreg settabvar settabwinvar setwinvar sha256 shellescape shiftwidth simplify sin '+
         'sinh sort soundfold spellbadword spellsuggest split sqrt str2float str2nr strchars strdisplaywidth strftime stridx string strlen strpart strridx strtrans strwidth submatch substitute synconcealed synID synIDattr '+
-        'synIDtrans synstack system tabpagebuflist tabpagenr tabpagewinnr tagfiles taglist tan tanh tempname tolower toupper tr trunc type undofile undotree values virtcol visualmode wildmenumode winbufnr wincol winheight winline winnr winrestcmd winrestview winsaveview winwidth writefile xor',
+        'synIDtrans synstack system tabpagebuflist tabpagenr tabpagewinnr tagfiles taglist tan tanh tempname tolower toupper tr trunc type undofile undotree values virtcol visualmode wildmenumode winbufnr wincol winheight winline winnr winrestcmd winrestview winsaveview winwidth writefile xor'
     },
     illegal: /[{:]/,
     contains: [


### PR DESCRIPTION
We found some trailing commas errors when compiling the packed code with Closure Compiler.

The errors can be reproduced by packing the code and compile with the online compiler:

```
python3 -t amd -n
```

http://closure-compiler.appspot.com/home

Full error log is:

```
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 2582 character 0
begin: '/', end: '/[a-z]*',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 2585 character 0
begin: '%r\\[', end: '\\][a-z]*',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 3251 character 0
{
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 3906 character 0
begin: '[\'`]\\(', end: '\\)',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 3909 character 0
begin: '\\(quote ', end: '\\)',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 4789 character 0
className: 'variable',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 5000 character 0
keyword:
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 5898 character 0
className: 'function',
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 5902 character 0
hljs.UNDERSCORE_TITLE_MODE,
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 6329 character 0
hljs.inherit(hljs.QUOTE_STRING_MODE, {contains: [{begin: '""'}]}),
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 6334 character 0
{
^
JSC_TRAILING_COMMA: Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option. at line 6438 character 0
keyword: //ex command
^
```
