### PR TITLE
Add support for commented json

### DIFF
--- a/src/languages/json-comments.js
+++ b/src/languages/json-comments.js
@@ -1,0 +1,44 @@
+module.exports = function(hljs) {
+  var LITERALS = {literal: 'true false null'};
+  var TYPES = [
+    hljs.QUOTE_STRING_MODE,
+    hljs.C_NUMBER_MODE,
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE
+  ];
+  var VALUE_CONTAINER = {
+    className: 'value',
+    end: ',', endsWithParent: true, excludeEnd: true,
+    contains: TYPES,
+    keywords: LITERALS
+  };
+  var OBJECT = {
+    begin: '{', end: '}',
+    contains: [
+      {
+        className: 'attribute',
+        begin: '\\s*"', end: '"\\s*:\\s*', excludeBegin: true, excludeEnd: true,
+        contains: [
+            hljs.BACKSLASH_ESCAPE,
+            hljs.C_BLOCK_COMMENT_MODE
+        ],
+        illegal: '\\n',
+        starts: VALUE_CONTAINER
+      },
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
+    ],
+    illegal: '\\S'
+  };
+  var ARRAY = {
+    begin: '\\[', end: '\\]',
+    contains: [hljs.inherit(VALUE_CONTAINER, {className: null})], // inherit is also a workaround for a bug that makes shared modes with endsWithParent compile only the ending of one of the parents
+    illegal: '\\S'
+  };
+  TYPES.splice(TYPES.length, 0, OBJECT, ARRAY);
+  return {
+    contains: TYPES,
+    keywords: LITERALS,
+    illegal: '\\S'
+  };
+};


### PR DESCRIPTION
I'm not sure how useful this is for others, but some JSON parsing frameworks support non-standard C-style comments. It was pretty easy to mix in the comment types so I created a `json-comments` language (updating the `json` language was inappropriate since these are non-standard).

Please feel free to merge or close. Thanks for the great tool!
