### PR TITLE
Dart language support

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -121,3 +121,4 @@ Contributors:
 - Erik Osheim <d_m@plastic-idolatry.com>
 - Guillaume Laforge <glaforge@gmail.com>
 - Lucas Mazza <lucastmazza@gmail.com>
+- Maxim Dikun <dikmax@gmail.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -121,3 +121,4 @@ URL:   http://highlightjs.org/
 - Эрик Осхейм <d_m@plastic-idolatry.com>
 - Гийом Ляфорж <glaforge@gmail.com>
 - Лукас Мазза <lucastmazza@gmail.com>
+- Максим Дикун <dikmax@gmail.com>

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1059,3 +1059,19 @@ Swift ("swift")
 * ``params``:           parameters of a function
 * ``type``:             a type
 * ``preprocessor``:     @attributes
+
+Dart ("dart")
+--------------------
+
+* ``keyword``:          keyword
+* ``literal``:          keyword that can be uses as identifier but have special meaning in some cases
+* ``built_id``:         some of basic built in classes and function
+* ``number``:           number
+* ``string``:           string
+* ``subst``:            in-string substitution (${...})
+* ``comment``:          commment
+* ``annotaion``:        annotation
+* ``dartdoc``:          dartdoc comment
+* ``class``:            class header from "class" till "{"
+* ``title``:            class name
+

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -1,0 +1,115 @@
+/*
+Language: Dart
+Requires: markdown.js
+Author: Maxim Dikun <dikmax@gmail.com>
+Description: Dart is a JavaScript replacement language developed by Google. For more information see http://dartlang.org/
+*/
+
+function (hljs) {
+  var SUBST = {
+    className: 'subst',
+    begin: '\\$\\{', end: '}',
+    keywords: 'true false null this is new super'
+  };
+
+  var STRING = {
+    className: 'string',
+    variants: [
+      {
+        begin: 'r\'\'\'', end: '\'\'\'',
+        relevance: 10
+      },
+      {
+        begin: 'r"""', end: '"""',
+        relevance: 10
+      },
+      {
+        begin: 'r\'', end: '\'',
+        illegal: '\\n',
+        relevance: 10
+      },
+      {
+        begin: 'r"', end: '"',
+        illegal: '\\n',
+        relevance: 10
+      },
+      {
+        begin: '\'\'\'', end: '\'\'\'',
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST],
+        relevance: 10
+      },
+      {
+        begin: '"""', end: '"""',
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST],
+        relevance: 10
+      },
+      {
+        begin: '\'', end: '\'',
+        illegal: '\\n',
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+      },
+      {
+        begin: '"', end: '"',
+        illegal: '\\n',
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+      }
+    ]
+  };
+  SUBST.contains = [
+    hljs.C_NUMBER_MODE, STRING
+  ];
+
+  var KEYWORDS = {
+    keyword: 'assert break case catch class const continue default do else enum extends false final finally for if ' +
+      'in is new null rethrow return super switch this throw true try var void while with',
+    literal: 'abstract as dynamic export external factory get implements import library operator part set static typedef',
+    built_in:
+      // dart:core
+      'print Comparable DateTime Duration Function Iterable Iterator List Map Match Null Object Pattern RegExp Set ' +
+      'Stopwatch String StringBuffer StringSink Symbol Type Uri bool double int num ' +
+      // dart:html
+      'document window querySelector querySelectorAll Element ElementList'
+  };
+
+  return {
+    keywords: KEYWORDS,
+    contains: [
+      STRING,
+      {
+        className: 'dartdoc',
+        begin: '/\\*\\*', end: '\\*/',
+        subLanguage: 'markdown',
+        subLanguageMode: 'continuous',
+        relevance: 5
+      },
+      {
+        className: 'dartdoc',
+        begin: '///', end: '$',
+        subLanguage: 'markdown',
+        subLanguageMode: 'continuous',
+        relevance: 5
+      },
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      {
+        className: 'class',
+        beginKeywords: 'class interface', end: '{', excludeEnd: true,
+        contains: [
+          {
+            beginKeywords: 'extends implements',
+            relevance: 10
+          },
+          hljs.UNDERSCORE_TITLE_MODE
+        ]
+      },
+      hljs.C_NUMBER_MODE,
+      {
+        className: 'annotation', begin: '@[A-Za-z]+'
+      },
+      {
+        begin: '=>' // No markup, just a relevance booster
+      }
+    ]
+  }
+}
+

--- a/src/styles/arta.css
+++ b/src/styles/arta.css
@@ -116,6 +116,7 @@ Author: pumbur <pumbur@pumbur.net>
 
 .hljs-yardoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .profile .hljs-header,
 .ini .hljs-title,
 .apache .hljs-tag,

--- a/src/styles/brown_paper.css
+++ b/src/styles/brown_paper.css
@@ -81,6 +81,7 @@ Brown Paper style from goldblog.com.ua (c) Zaripov Yura <yur4ik7@ukr.net>
 .hljs-literal,
 .css .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-title,
 .hljs-type,
 .vbscript .hljs-built_in,

--- a/src/styles/color-brewer.css
+++ b/src/styles/color-brewer.css
@@ -122,6 +122,7 @@ Ported by Fabrício Tavares de Oliveira
 .css .hljs-tag,
 .hljs-javadoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-yardoctag,
 .smalltalk .hljs-class,
 .hljs-winutils,

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -80,6 +80,7 @@ Dark style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Or
 .hljs-title,
 .css .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-type,
 .vbscript .hljs-built_in,
 .rsl .hljs-built_in,

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -118,6 +118,7 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 .css .hljs-tag,
 .hljs-javadoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-yardoctag,
 .smalltalk .hljs-class,
 .hljs-winutils,

--- a/src/styles/docco.css
+++ b/src/styles/docco.css
@@ -38,6 +38,7 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
 .hljs-string,
 .hljs-tag .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula {
   color: #219161;
 }

--- a/src/styles/far.css
+++ b/src/styles/far.css
@@ -60,6 +60,7 @@ FAR Style (c) MajestiC <majestic2k@gmail.com>
 
 .hljs-comment,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-javadoc,
 .hljs-annotation,
 .hljs-template_comment,

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -42,6 +42,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-string,
 .hljs-tag .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula {
   color: #d14;
 }

--- a/src/styles/googlecode.css
+++ b/src/styles/googlecode.css
@@ -75,6 +75,7 @@ Google Code style (c) Aahan Krish <geekpanth3r@gmail.com>
 .hljs-javadoctag,
 .hljs-yardoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-type,
 .hljs-typename,
 .hljs-tag .hljs-attribute,

--- a/src/styles/idea.css
+++ b/src/styles/idea.css
@@ -101,6 +101,7 @@ Intellij Idea-like styling (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-yardoctag,
 .hljs-javadoctag {
   text-decoration: underline;

--- a/src/styles/ir_black.css
+++ b/src/styles/ir_black.css
@@ -64,6 +64,7 @@
 .hljs-javadoctag,
 .hljs-yardoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .nginx .hljs-built_in {
   color: #ffffb6;
 }

--- a/src/styles/magula.css
+++ b/src/styles/magula.css
@@ -87,6 +87,7 @@ Music: Aphex Twin / Xtal
 .hljs-keyword,
 .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-title,
 .hljs-built_in,
 .smalltalk .hljs-class,

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -100,6 +100,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-literal,
 .css .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-title,
 .hljs-header,
 .hljs-type,

--- a/src/styles/obsidian.css
+++ b/src/styles/obsidian.css
@@ -126,6 +126,7 @@
 .hljs-literal,
 .css .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-title,
 .hljs-header,
 .hljs-type,

--- a/src/styles/pojoaque.css
+++ b/src/styles/pojoaque.css
@@ -42,6 +42,7 @@ Based on Solarized Style from http://ethanschoonover.com/solarized
 .hljs-string,
 .hljs-tag .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula,
 .hljs-regexp,
 .hljs-hexcolor {

--- a/src/styles/railscasts.css
+++ b/src/styles/railscasts.css
@@ -68,7 +68,8 @@ Railscasts-like style (c) Visoft, Inc. (Damien White)
 .smalltalk .hljs-class,
 .hljs-javadoctag,
 .hljs-yardoctag,
-.hljs-phpdoc {
+.hljs-phpdoc,
+.hljs-dartdoc {
   text-decoration: none;
 }
 

--- a/src/styles/rainbow.css
+++ b/src/styles/rainbow.css
@@ -44,6 +44,7 @@ Style with support for rainbow parens
 .hljs-string,
 .hljs-tag .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula,
 .hljs-regexp,
 .hljs-hexcolor {

--- a/src/styles/school_book.css
+++ b/src/styles/school_book.css
@@ -86,6 +86,7 @@ pre{
 .hljs-literal,
 .css .hljs-id,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-title,
 .hljs-type,
 .vbscript .hljs-built_in,

--- a/src/styles/solarized_dark.css
+++ b/src/styles/solarized_dark.css
@@ -42,6 +42,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-tag .hljs-value,
 .hljs-rules .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula,
 .hljs-regexp,
 .hljs-hexcolor,

--- a/src/styles/solarized_light.css
+++ b/src/styles/solarized_light.css
@@ -42,6 +42,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-tag .hljs-value,
 .hljs-rules .hljs-value,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .tex .hljs-formula,
 .hljs-regexp,
 .hljs-hexcolor,

--- a/src/styles/sunburst.css
+++ b/src/styles/sunburst.css
@@ -71,7 +71,8 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
 .smalltalk .hljs-class,
 .hljs-javadoctag,
 .hljs-yardoctag,
-.hljs-phpdoc {
+.hljs-phpdoc,
+.hljs-dartdoc {
   text-decoration: underline;
 }
 

--- a/src/styles/vs.css
+++ b/src/styles/vs.css
@@ -78,6 +78,7 @@ Visual Studio-like style based on original C# coloring by Jason Diamond <jason@d
 }
 
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-javadoc,
 .hljs-xmlDocTag {
   color: #808080;

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -80,6 +80,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 .hljs-javadoctag,
 .hljs-yardoctag,
 .hljs-phpdoc,
+.hljs-dartdoc,
 .hljs-type,
 .hljs-typename,
 .hljs-tag .hljs-attribute,

--- a/src/test.html
+++ b/src/test.html
@@ -3494,6 +3494,44 @@ if( propFile.canRead() ) {
 }
 </code></pre>
 
+  <tr>
+  <th>Dart</th>
+  <td class="dart">
+<pre>
+<code>library app;
+import 'dart:html';
+
+part 'app2.dart';
+
+/**
+ * Class description and [link](http://dartlang.org/).
+ */
+@Awesome('it works!')
+class SomeClass&lt;S extends Iterable&gt; extends BaseClass&lt;S&gt; implements Comparable {
+  factory SomeClass(num param);
+  SomeClass._internal(int q) : super() {
+    assert(q != 1);
+    double z = 0.0;
+  }
+
+  /// **Sum** function
+  int sum(int a, int b) =&gt; a + b;
+
+  ElementList els() => querySelectorAll('.dart');
+}
+
+String str = ' (${'parameter' + 'zxc'})';
+String str = " (${true ? 2 + 2 / 2 : null})";
+String str = r'\nraw\';
+String str = r"\nraw\";
+var str = '''
+Something ${2+3}
+''';
+var str = r"""
+Something ${2+3}
+""";
+</code></pre>
+
 </table>
 
 


### PR DESCRIPTION
Added Dart support (https://www.dartlang.org/).
New CSS class `.hljs-dartdoc` added to every style in same place as `.hljs-phpdoc`.
