### PR TITLE
Fix background color bug in scrolling divs

### DIFF
--- a/src/styles/arta.css
+++ b/src/styles/arta.css
@@ -4,7 +4,7 @@ Author: pumbur <pumbur@pumbur.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #222;
 }

--- a/src/styles/ascetic.css
+++ b/src/styles/ascetic.css
@@ -5,7 +5,7 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: white;
   color: black;

--- a/src/styles/atelier-dune.dark.css
+++ b/src/styles/atelier-dune.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #292824;
   color: #a6a28c;
   padding: 0.5em;

--- a/src/styles/atelier-dune.light.css
+++ b/src/styles/atelier-dune.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #fefbec;
   color: #6e6b5e;
   padding: 0.5em;

--- a/src/styles/atelier-forest.dark.css
+++ b/src/styles/atelier-forest.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #2c2421;
   color: #a8a19f;
   padding: 0.5em;

--- a/src/styles/atelier-forest.light.css
+++ b/src/styles/atelier-forest.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #f1efee;
   color: #68615e;
   padding: 0.5em;

--- a/src/styles/atelier-heath.dark.css
+++ b/src/styles/atelier-heath.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #292329;
   color: #ab9bab;
   padding: 0.5em;

--- a/src/styles/atelier-heath.light.css
+++ b/src/styles/atelier-heath.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #f7f3f7;
   color: #695d69;
   padding: 0.5em;

--- a/src/styles/atelier-lakeside.dark.css
+++ b/src/styles/atelier-lakeside.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #1f292e;
   color: #7ea2b4;
   padding: 0.5em;

--- a/src/styles/atelier-lakeside.light.css
+++ b/src/styles/atelier-lakeside.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #ebf8ff;
   color: #516d7b;
   padding: 0.5em;

--- a/src/styles/atelier-seaside.dark.css
+++ b/src/styles/atelier-seaside.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #242924;
   color: #8ca68c;
   padding: 0.5em;

--- a/src/styles/atelier-seaside.light.css
+++ b/src/styles/atelier-seaside.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #f0fff0;
   color: #5e6e5e;
   padding: 0.5em;

--- a/src/styles/brown_paper.css
+++ b/src/styles/brown_paper.css
@@ -5,7 +5,7 @@ Brown Paper style from goldblog.com.ua (c) Zaripov Yura <yur4ik7@ukr.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background:#b7a68e url(./brown_papersq.png);
 }

--- a/src/styles/codepen-embed.css
+++ b/src/styles/codepen-embed.css
@@ -5,7 +5,7 @@
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #222;
   color: #fff;

--- a/src/styles/color-brewer.css
+++ b/src/styles/color-brewer.css
@@ -7,7 +7,7 @@ Ported by Fabrício Tavares de Oliveira
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #fff;
 }

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -5,7 +5,7 @@ Dark style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Or
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #444;
 }

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -5,7 +5,7 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #f0f0f0;
 }

--- a/src/styles/docco.css
+++ b/src/styles/docco.css
@@ -3,7 +3,7 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   color: #000;
   background: #f8f8ff;

--- a/src/styles/far.css
+++ b/src/styles/far.css
@@ -5,7 +5,7 @@ FAR Style (c) MajestiC <majestic2k@gmail.com>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #000080;
 }

--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -7,7 +7,7 @@ Date: 2013-04-02
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #eee;
 }

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -5,7 +5,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   color: #333;
   background: #f8f8f8;

--- a/src/styles/googlecode.css
+++ b/src/styles/googlecode.css
@@ -5,7 +5,7 @@ Google Code style (c) Aahan Krish <geekpanth3r@gmail.com>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: white;
   color: black;

--- a/src/styles/idea.css
+++ b/src/styles/idea.css
@@ -5,7 +5,7 @@ Intellij Idea-like styling (c) Vasily Polovnyov <vast@whiteants.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   color: #000;
   background: #fff;

--- a/src/styles/ir_black.css
+++ b/src/styles/ir_black.css
@@ -3,7 +3,7 @@
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #000;
   color: #f8f8f8;

--- a/src/styles/kimbie.dark.css
+++ b/src/styles/kimbie.dark.css
@@ -77,7 +77,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #221a0f;
   color: #d3af86;
   padding: 0.5em;

--- a/src/styles/kimbie.light.css
+++ b/src/styles/kimbie.light.css
@@ -77,7 +77,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #fbebd4;
   color: #84613d;
   padding: 0.5em;

--- a/src/styles/magula.css
+++ b/src/styles/magula.css
@@ -8,7 +8,7 @@ Music: Aphex Twin / Xtal
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background-color: #f4f4f4;
 }

--- a/src/styles/mono-blue.css
+++ b/src/styles/mono-blue.css
@@ -2,7 +2,7 @@
   Five-color theme from a single blue hue.
 */
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #eaeef3;
   color: #00193a;

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -3,7 +3,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #272822;
 }

--- a/src/styles/monokai_sublime.css
+++ b/src/styles/monokai_sublime.css
@@ -5,7 +5,7 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #23241f;
 }

--- a/src/styles/obsidian.css
+++ b/src/styles/obsidian.css
@@ -4,7 +4,7 @@
  */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #282b2e;
 }

--- a/src/styles/paraiso.dark.css
+++ b/src/styles/paraiso.dark.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #2f1e2e;
   color: #a39e9b;
   padding: 0.5em;

--- a/src/styles/paraiso.light.css
+++ b/src/styles/paraiso.light.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #e7e9db;
   color: #4f424c;
   padding: 0.5em;

--- a/src/styles/pojoaque.css
+++ b/src/styles/pojoaque.css
@@ -7,7 +7,7 @@ Based on Solarized Style from http://ethanschoonover.com/solarized
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   color: #dccf8f;
   background: url(./pojoaque.jpg) repeat scroll left top #181914;

--- a/src/styles/railscasts.css
+++ b/src/styles/railscasts.css
@@ -5,7 +5,7 @@ Railscasts-like style (c) Visoft, Inc. (Damien White)
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #232323;
   color: #e6e1dc;

--- a/src/styles/rainbow.css
+++ b/src/styles/rainbow.css
@@ -5,7 +5,7 @@ Style with support for rainbow parens
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #474949;
   color: #d1d9e1;

--- a/src/styles/school_book.css
+++ b/src/styles/school_book.css
@@ -5,7 +5,7 @@ School Book style from goldblog.com.ua (c) Zaripov Yura <yur4ik7@ukr.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 15px 0.5em 0.5em 30px;
   font-size: 11px !important;
   line-height:16px !important;

--- a/src/styles/solarized_dark.css
+++ b/src/styles/solarized_dark.css
@@ -5,7 +5,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #002b36;
   color: #839496;

--- a/src/styles/solarized_light.css
+++ b/src/styles/solarized_light.css
@@ -5,7 +5,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #fdf6e3;
   color: #657b83;

--- a/src/styles/sunburst.css
+++ b/src/styles/sunburst.css
@@ -5,7 +5,7 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #000;
   color: #f8f8f8;

--- a/src/styles/tomorrow-night-blue.css
+++ b/src/styles/tomorrow-night-blue.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #002451;
   color: white;
   padding: 0.5em;

--- a/src/styles/tomorrow-night-bright.css
+++ b/src/styles/tomorrow-night-bright.css
@@ -75,7 +75,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: black;
   color: #eaeaea;
   padding: 0.5em;

--- a/src/styles/tomorrow-night-eighties.css
+++ b/src/styles/tomorrow-night-eighties.css
@@ -75,7 +75,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #2d2d2d;
   color: #cccccc;
   padding: 0.5em;

--- a/src/styles/tomorrow-night.css
+++ b/src/styles/tomorrow-night.css
@@ -76,7 +76,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: #1d1f21;
   color: #c5c8c6;
   padding: 0.5em;

--- a/src/styles/tomorrow.css
+++ b/src/styles/tomorrow.css
@@ -73,7 +73,7 @@
 }
 
 .hljs {
-  display: block;
+  display: inline-block;
   background: white;
   color: #4d4d4c;
   padding: 0.5em;

--- a/src/styles/vs.css
+++ b/src/styles/vs.css
@@ -4,7 +4,7 @@ Visual Studio-like style based on original C# coloring by Jason Diamond <jason@d
 
 */
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: white;
   color: black;

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -5,7 +5,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #fff;
   color: black;

--- a/src/styles/zenburn.css
+++ b/src/styles/zenburn.css
@@ -6,7 +6,7 @@ based on dark.css by Ivan Sagalaev
 */
 
 .hljs {
-  display: block;
+  display: inline-block;
   padding: 0.5em;
   background: #3f3f3f;
   color: #dcdcdc;


### PR DESCRIPTION
When using a highlighted &lt;pre&gt;&lt;code&gt; section in a div that will scroll,
the background color would not continue into the scrolled area.  Update
the "display" css for all themes to "inline-block" fixes this problem
