### PR TITLE
Added support for Java Generics

### DIFF
--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -12,7 +12,7 @@ function(hljs) {
   return {
     aliases: ['jsp'],
     keywords: KEYWORDS,
-    illegal: /<\//,
+    illegal: /\//,
     contains: [
       {
         className: 'javadoc',

--- a/src/test.html
+++ b/src/test.html
@@ -1513,7 +1513,7 @@ package l2f.gameserver.model;
 
 import java.util.ArrayList;
 
-public abstract class L2Character extends L2Object {
+public abstract class L2Character extends L2Object&lt;Interface&gt; Hello {
   public static final Short ABNORMAL_EFFECT_BLEEDING = 0x0001; // not sure
 
   public void moveTo(int x, int y, int z) {


### PR DESCRIPTION
Hey,

I had a strange bug: Java Generics weren't highlighted when using the API programatically (it was working when highlighting from the DOM):

```
hljs.highlight("java", "public class MyProvider implements Provider<Protocol> { }")
```

This removes '<' from the illegal characters. However, I'm not sure if it's a correct fix, it fixes my issue, but maybe someone with more experience can have a look at it?
