### PR TITLE
Rust: fix highlighting for lifetime parameters.

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -22,6 +22,10 @@ function(hljs) {
       hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null}),
       {
         className: 'string',
+        begin: /r(#*)".*?"\1(?!#)/
+      },
+      {
+        className: 'string',
         begin: /'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/
       },
       {

--- a/src/test.html
+++ b/src/test.html
@@ -2775,6 +2775,10 @@ use std;
 '\u12AS';
 '\U1234ASDF';
 
+r"hello";
+r###"world"###;
+r##" "### "# "##;
+
 /* Factorial */
 fn fac(n: int) -&gt; int {
     let s: str = "This is
@@ -2782,6 +2786,7 @@ a multi-line string.
 
 It ends with an unescaped '\"'.";
     let c: char = 'Ф';
+    let r: str = r##" raw string "##;
 
     let result = 1, i = 1;
     while i &lt;= n { // No parens around the condition


### PR DESCRIPTION
 This will fix #463.
