### PR TITLE
Add java5 generics syntax support

### DIFF
--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -33,7 +33,7 @@ function(hljs) {
           {
             className: 'class',
             beginKeywords: 'class interface', endsWithParent: true, excludeEnd: true,
-            illegal: /[:"<>]/,
+            illegal: /[:"\[\]]/,
             contains: [
               {
                 beginKeywords: 'extends implements',


### PR DESCRIPTION
Example:

``` java
public interface TestGenerics<T>{
    public void appendTo(List<T> result,T sample);
}
```
