### PR TITLE
Make flatten function a variable to avoid strict mode errors.

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -162,7 +162,7 @@ function() {
       if (mode.keywords) {
         var compiled_keywords = {};
 
-        function flatten(className, str) {
+        var flatten = function(className, str) {
           if (language.case_insensitive) {
             str = str.toLowerCase();
           }
@@ -170,7 +170,7 @@ function() {
             var pair = kw.split('|');
             compiled_keywords[pair[0]] = [className, pair[1] ? Number(pair[1]) : 1];
           });
-        }
+        };
 
         if (typeof mode.keywords == 'string') { // string
           flatten('keyword', mode.keywords);


### PR DESCRIPTION
I was trying to use highlight.js in an environment that has strict mode on and kept getting this error: In strict mode code, functions can only be declared at top level or immediately within another function. It took a bit of digging, but I found the `flatten` function being defined part way through another function. Moving the function to the top of the parent function resolves the issue, but I didn't want to move it outside of its current condition. Making it a variable worked just as well and allows it to remain where it is.
