### PR TITLE
Lasso: skip highlighting name of named rest parameter

### DIFF
--- a/src/languages/lasso.js
+++ b/src/languages/lasso.js
@@ -93,8 +93,13 @@ function(hljs) {
     {
       className: 'attribute',
       variants: [
-        {begin: '(\\.\\.\\.)' + hljs.UNDERSCORE_IDENT_RE},
-        {begin: '-' + hljs.UNDERSCORE_IDENT_RE, relevance: 0}
+        {
+          begin: '-' + hljs.UNDERSCORE_IDENT_RE,
+          relevance: 0
+        },
+        {
+          begin: '(\\.\\.\\.)'
+        }
       ]
     },
     {


### PR DESCRIPTION
A fix for the previous commit.
