### PR TITLE
fix missing if

### DIFF
--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -9,8 +9,8 @@ function(hljs) {
   var FUNCTION_NAME_RE = '(' + BASIC_ATOM_RE + ':' + BASIC_ATOM_RE + '|' + BASIC_ATOM_RE + ')';
   var ERLANG_RESERVED = {
     keyword:
-      'after and andalso|10 band begin bnot bor bsl bzr bxor case catch cond div end fun let ' +
-      'not of orelse|10 query receive rem try when xor',
+      'after and andalso|10 band begin bnot bor bsl bzr bxor case catch cond div end fun if ' +
+      'let not of orelse|10 query receive rem try when xor',
     literal:
       'false true'
   };


### PR DESCRIPTION
erlang.js is missing `if` as keyword, resulting in not highlighting it like it does with other structure related functions (like `case`).

it was already defined in `BLOCK_STATEMENTS` so no changes needed there.

this changes fixes the issue and there was already a test case in `test.html` showcasing it.
