### PR TITLE
Colors in compliance with WCAG 2.0 AA

### DIFF
--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -36,7 +36,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-number,
 .hljs-hexcolor,
 .ruby .hljs-constant {
-  color: #099;
+  color: #008080;
 }
 
 .hljs-string,


### PR DESCRIPTION
Darkened one of the colors to be compliant with WCAG  2.0 AA requirement contrast ratio (4.5).
