### PR TITLE
Ruby Hash + stabby proc syntax issue

### DIFF
--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -105,13 +105,13 @@ function(hljs) {
     },
     {
       className: 'symbol',
-      begin: ':',
-      contains: [STRING, {begin: RUBY_METHOD_RE}],
+      begin: hljs.UNDERSCORE_IDENT_RE + '(\\!|\\?)?:',
       relevance: 0
     },
     {
       className: 'symbol',
-      begin: hljs.UNDERSCORE_IDENT_RE + '(\\!|\\?)?:',
+      begin: ':',
+      contains: [STRING, {begin: RUBY_METHOD_RE}],
       relevance: 0
     },
     {
@@ -146,7 +146,7 @@ function(hljs) {
   ];
   SUBST.contains = RUBY_DEFAULT_CONTAINS;
   PARAMS.contains = RUBY_DEFAULT_CONTAINS;
-  
+
   var IRB_DEFAULT = [
     {
       relevance: 1,

--- a/src/test.html
+++ b/src/test.html
@@ -354,6 +354,8 @@ end
 
 class Car < ActiveRecord::Base
   has_many :wheels, :class_name => 'Wheel', :foreign_key => 'car_id'
+  has_many :wheels, class_name: 'Wheel', foreign_key: 'car_id'
+  scope :available, -> { where(available: true) }
 end
 omega = -> { 'alpha' }
 alpha = ->(arg) { arg*2 }


### PR DESCRIPTION
The following snippet isn't properly highlighted.

``` ruby
class Car < ActiveRecord::Base
  has_many :wheels, class_name: 'Wheel', foreign_key: 'car_id'
  scope :available, -> { where(available: true) }
end
```

![](http://cl.ly/image/1h2n3D220R2e/Screen%20Shot%202014-07-14%20at%207.19.36%20PM.png)

This problem is only present when using both lines - switching back to the hash rocket Hash syntax (`:class_name => 'Wheel'`) or replacing the `->` with the `lambda` keyword does not replicates this issue
