### PR TITLE
Fix .gitignore typo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ docs/_build
 .idea/
 __pycache__
 *.swp
-node_module
+node_modules


### PR DESCRIPTION
Fixed .gitignore typo: node_module -> node_modules.
