### PR TITLE
Add browserify usage instructions to docs

### DIFF
--- a/docs/building-testing.rst
+++ b/docs/building-testing.rst
@@ -58,3 +58,13 @@ place the snippet you used inside the browser in
 see if any tests fail. If your language breaks auto-detection, it should be
 fixed by :ref:`improving relevance <relevance>`, which is a black art in and
 of itself. When in doubt, please refer to the discussion group!
+
+Usage with Browserify
+---------------------
+
+highlight.js also works with `Browserify <http://browserify.org/>`, a Node.js tool for bundling browser-ready JavaScript files using npm packages. This technique gives you granular control over the bundled filesize, because you can pick only the languages you want to support. This is the programmatic equivalent of building a custom package at https://highlightjs.org/download/
+
+    var Highlight = require("highlight.js/lib/highlight");
+    var hl = new Highlight();
+    hl.registerLanguage('javascript',
+      require('highlight.js/lib/languages/javascript'));


### PR DESCRIPTION
highlight.js works like a charm with Browserify, but it took me a while to figure out how. Eventually I found https://github.com/isagalaev/highlight.js/pull/195 which got me on the right track.

I've added a bit of documentation so others don't have so much trouble as I did. I'm not sure this file is the right place for it. let me know if I should move it, or if it would make more sense to add it to the highlightjs.org website source somewhere.
