### PR TITLE
Add Less language

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -130,3 +130,4 @@ Contributors:
 - Sergey Vidyuk <svidyuk@gmail.com>
 - Radek Liska <radekliska@gmail.com>
 - Jose Molina Colmenero <gaudy41@gmail.com>
+- Max Mikhailov <seven.phases.max@gmail.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -130,3 +130,4 @@ URL:   https://highlightjs.org/
 - Сергей Видюк <svidyuk@gmail.com>
 - Радэк Лиска <radekliska@gmail.com>
 - Хосе Молина Колменеро <gaudy41@gmail.com>
+- Макс Михайлов <seven.phases.max@gmail.com>

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1140,3 +1140,22 @@ Puppet ("pp")
 * ``number``:           number
 * ``keyword``:          classes and types
 * ``constant``:         dependencies
+
+Less ("less")
+-------------
+
+* ``comment``:          comment
+* ``number``:           number
+* ``string``:           string
+* ``attribute``:        property name
+* ``variable``:         @var, @@var or @{var}
+* ``keyword``:          Less keywords (when, extend etc.)
+* ``function``:         Less and CSS functions (rgba, unit etc.)
+* ``tag``:              tag
+* ``id``:               #id
+* ``class``:            .class
+* ``at_rule``:          at-rule keyword (@media, @keyframes etc.)
+* ``attr_selector``:    attribute selector (e.g. [href^=http://])
+* ``pseudo``:           pseudo classes and elements (:hover, ::before etc.)
+* ``hexcolor``:         hex color (#FFF)
+* ``built_in``:         inline javascript (or whatever host language) string

--- a/src/languages/less.js
+++ b/src/languages/less.js
@@ -1,0 +1,144 @@
+/*
+Language: Less
+Author:   Max Mikhailov <seven.phases.max@gmail.com>
+*/
+
+function(hljs) {
+  var IDENT_RE        = '[\\w-]+'; // yes, Less identifiers may begin with a digit
+  var INTERP_IDENT_RE = '(' + IDENT_RE + '|@{' + IDENT_RE + '})+';
+
+  /* Generic Modes */
+
+  var RULES = [], VALUE = []; // forward def. for recursive modes
+
+  var STRING_MODE = function(c) { return {
+    // Less strings are not multiline (also include '~' for more consistent coloring of "escaped" strings)
+    className: 'string', begin: '~?' + c + '.*?' + c
+  };};
+
+  var IDENT_MODE = function(name, begin, relevance) { return {
+    className: name, begin: begin, relevance: relevance
+  };};
+
+  var FUNCT_MODE = function(name, ident, obj) {
+    return hljs.inherit({
+        className: name, begin: ident + '\\(', end: '\\(',
+        returnBegin: true, excludeEnd: true, relevance: 0
+    }, obj);
+  };
+
+  var PARENS_MODE = {
+    // used only to properly balance nested parens inside mixin call/def. arg list
+    begin: '\\(', end: '\\)', contains: VALUE, relevance: 0
+  };
+
+  // generic Less highlighter (used almost everywhere except selectors):
+  VALUE.push(
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE,
+    STRING_MODE("'"),
+    STRING_MODE('"'),
+    hljs.CSS_NUMBER_MODE, // fixme: it does not include dot for numbers like .5em :(
+    IDENT_MODE('hexcolor', '#[0-9A-Fa-f]+\\b'),
+    FUNCT_MODE('function', '(url|data-uri)', {
+      starts: {className: 'string', end: '[\\)\\n]', excludeEnd: true}
+    }),
+    FUNCT_MODE('function', IDENT_RE),
+    PARENS_MODE,
+    IDENT_MODE('variable', '@@?' + IDENT_RE, 10),
+    IDENT_MODE('variable', '@{'  + IDENT_RE + '}'),
+    IDENT_MODE('built_in', '~?`[^`]*?`'), // inline javascript (or whatever host language) *multiline* string
+    { // @media features (it's here to not duplicate things in AT_RULE_MODE with extra PARENS_MODE overriding):
+      className: 'attribute', begin: IDENT_RE + '\\s*:', end: ':', returnBegin: true, excludeEnd: true
+    }
+  );
+
+  var VALUE_WITH_RULESETS = VALUE.concat({
+    begin: '{', end: '}', contains: RULES,
+  });
+
+  var MIXIN_GUARD_MODE = {
+    beginKeywords: 'when', endsWithParent: true,
+    contains: [{beginKeywords: 'and not'}].concat(VALUE) // using this form to override VALUE's 'function' match
+  };
+
+  /* Rule-Level Modes */
+
+  var RULE_MODE = {
+    className: 'attribute', begin: INTERP_IDENT_RE, relevance: 0,
+    starts: {end: '[;}]', returnEnd: true, contains: VALUE, illegal: '[<=$]'}
+  };
+
+  var AT_RULE_MODE = {
+    className: 'at_rule', // highlight only at-rule keyword
+    begin: '@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b',
+    starts: {end: '[;{}]', returnEnd: true, contains: VALUE, relevance: 0}
+  };
+
+  // variable definitions and calls
+  var VAR_RULE_MODE = {
+    className: 'variable',
+    variants: [
+      // using more strict pattern for higher relevance to increase chances of Less detection.
+      // this is *the only* Less specific statement used in most of the sources, so...
+      // (we'll still often loose to the css-parser unless there's '//' comment,
+      // simply because 1 variable just can't beat 99 properties :)
+      {begin: '@' + IDENT_RE + '\\s*:', relevance: 15},
+      {begin: '@' + IDENT_RE}
+    ],
+    starts: {end: '[;}]', returnEnd: true, contains: VALUE_WITH_RULESETS}
+  };
+
+  var SELECTOR_MODE = {
+    // first parse unambiguous selectors (i.e. those not starting with tag)
+    // then fall into the scary lookahead-discriminator variant.
+    // this mode also handles mixin definitions and calls
+    variants: [{
+      begin: '[\\.#:&\\[]', end: '[;{}]'  // mixin calls end with ';'
+      }, {
+      begin: '(?=' + INTERP_IDENT_RE + ')(' + [
+          '//.*',                         // line comment
+          '/\\*(?:[^*]|\\*+[^*/])*\\*+/', // block comment
+          '\\[[^\\]]*\\]',                // attribute selector (it may contain strings we need to skip too)
+          '@{.*?}',                       // variable interpolation
+          '[^;}\'"`]',                    // non-selector terminals
+        ].join('|') + ')*?[^@\'"`]{',     // at last
+      end: '{'
+    }],
+    returnBegin: true,
+    returnEnd:   true,
+    illegal: '[<=\'$"]',
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      MIXIN_GUARD_MODE,
+      IDENT_MODE('keyword',  'all\\b'),
+      IDENT_MODE('variable', '@{'  + IDENT_RE + '}'),     // otherwise it's identified as tag
+      IDENT_MODE('tag',       INTERP_IDENT_RE + '%?', 0), // '%' for more consistent coloring of @keyframes "tags"
+      IDENT_MODE('id',       '#'   + INTERP_IDENT_RE),
+      IDENT_MODE('class',    '\\.' + INTERP_IDENT_RE, 0),
+      IDENT_MODE('keyword',  '&', 0),
+      FUNCT_MODE('pseudo',   ':not'),
+      FUNCT_MODE('keyword',  ':extend'),
+      IDENT_MODE('pseudo',   '::?' + INTERP_IDENT_RE),
+      {className: 'attr_selector', begin: '\\[', end: '\\]'},
+      {begin: '\\(', end: '\\)', contains: VALUE_WITH_RULESETS}, // argument list of parametric mixins
+      {begin: '!important'} // eat !important after mixin call or it will be colored as tag
+    ]
+  };
+
+  RULES.push(
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE,
+    AT_RULE_MODE,
+    VAR_RULE_MODE,
+    SELECTOR_MODE,
+    RULE_MODE
+  );
+
+  return {
+    case_insensitive: true,
+    illegal: '[=>\'/<($"]',
+    contains: RULES
+  };
+}

--- a/test/detect/less/default.txt
+++ b/test/detect/less/default.txt
@@ -1,0 +1,32 @@
+/*
+Using the most minimal language subset to ensure we
+have enough relevance hints for proper Less detection
+*/
+
+@import "fruits";
+
+@rhythm: 1.5em;
+
+@media screen and (min-resolution: 2dppx) {
+    body {font-size: 125%}
+}
+
+section > .foo + #bar:hover [href*="less"] {
+    margin:     @rhythm 0 0 @rhythm;
+    padding:    calc(5% + 20px);
+    background: #f00ba7 url(http://placehold.alpha-centauri/42.png) no-repeat;
+    background-image: linear-gradient(-135deg, wheat, fuchsia) !important ;
+    background-blend-mode: multiply;
+}
+
+@font-face {
+    font-family: /* ? */ 'Omega';
+    src: url('../fonts/omega-webfont.woff?v=2.0.2');
+}
+
+.icon-baz::before {
+    display:     inline-block;
+    font-family: "Omega", Alpha, sans-serif;
+    content:     "\f085";
+    color:       rgba(98, 76 /* or 54 */, 231, .75);
+}


### PR DESCRIPTION
Support for [Less](http://lesscss.org/) language.

List of known issues and limitations (just for reference):
- Comments with `{` in a rule statement make this statement to be highlighted as a selector 
- CSS [escaping](http://www.w3.org/TR/CSS2/syndata.html#escaped-characters) (i.e. `\`) is not quite supported (so `"\0025"` is colored properly but `"foo\"bar"` is not) - too rarely used feature to bother
- `all` is colored as keyword even when used as tag (too minor issue to encumber things with)
- `%` function name is not highlighted (too minor to bother)
- `@page`'s `ident:pseudo` selectors are not properly highlighted (too subtle issue to burden the parser further)
- Subsequent `@page` "Box"-rules (e.g. `@top-left`, `@bottom-right-corner` etc.) are highlighted as variable definitions (too scarce feature)
- Definition of variable with at-rule name (e.g. `@media: 1px;`) is colored as an at-rule (too rare to care)
