### PR TITLE
add Tcl language syntax highlighting

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -128,3 +128,4 @@ Contributors:
 - JP Verkamp <me@jverkamp.com>
 - Adam Joseph Cook <adam.joseph.cook@gmail.com>
 - Sergey Vidyuk <svidyuk@gmail.com>
+- Radek Liska <radekliska@gmail.com>

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1122,3 +1122,14 @@ Q ("k", "kdb")
 * ``constant``:         0/1b
 * ``typename``:         built-in plain types (int, symbol etc.)
 * ``built_in``:         built-in function
+
+Tcl ("tcl", "tk")
+-----------------
+
+* ``keyword``:          keyword
+* ``comment``:          comment
+* ``symbol``:           function (proc)
+* ``variable``:         variable
+* ``string``:           string
+* ``number``:           number
+

--- a/src/languages/tcl.js
+++ b/src/languages/tcl.js
@@ -1,0 +1,71 @@
+/*
+Language: Tcl
+Author: Radek Liska <radekliska@gmail.com>
+*/
+
+function(hljs) {
+  return {
+    aliases: ['tk'],
+    keywords: 'after append apply array auto_execok auto_import auto_load auto_mkindex ' +
+      'auto_mkindex_old auto_qualify auto_reset bgerror binary break catch cd chan clock ' +
+      'close concat continue dde dict encoding eof error eval exec exit expr fblocked ' +
+      'fconfigure fcopy file fileevent filename flush for foreach format gets glob global ' +
+      'history http if incr info interp join lappend|10 lassign|10 lindex|10 linsert|10 list ' +
+      'llength|10 load lrange|10 lrepeat|10 lreplace|10 lreverse|10 lsearch|10 lset|10 lsort|10 '+
+      'mathfunc mathop memory msgcat namespace open package parray pid pkg::create pkg_mkIndex '+
+      'platform platform::shell proc puts pwd read refchan regexp registry regsub|10 rename '+
+      'return safe scan seek set socket source split string subst switch tcl_endOfWord '+
+      'tcl_findLibrary tcl_startOfNextWord tcl_startOfPreviousWord tcl_wordBreakAfter '+
+      'tcl_wordBreakBefore tcltest tclvars tell time tm trace unknown unload unset update '+
+      'uplevel upvar variable vwait while',
+    contains: [
+      {
+        className: 'comment',
+        variants: [
+          {begin: ';[ \\t]*#', end: '$'},
+          {begin: '^[ \\t]*#', end: '$'}
+        ]
+      },
+      {
+        beginKeywords: 'proc',
+        end: '[\\{]',
+        excludeEnd: true,
+        contains: [
+          {
+            className: 'symbol',
+            begin: '[ \\t\\n\\r]+(::)?[a-zA-Z_]((::)?[a-zA-Z0-9_])*',
+            end: '[ \\t\\n\\r]',
+            endsWithParent: true,
+            excludeEnd: true,
+          }
+        ]
+      },
+      {
+        className: 'variable',
+        excludeEnd: true,
+        variants: [
+          {
+            begin: '\\$(\\{)?(::)?[a-zA-Z_]((::)?[a-zA-Z0-9_])*\\(([a-zA-Z0-9_])*\\)',
+            end: '[^a-zA-Z0-9_\\}\\$]',
+          },
+          {
+            begin: '\\$(\\{)?(::)?[a-zA-Z_]((::)?[a-zA-Z0-9_])*',
+            end: '(\\))?[^a-zA-Z0-9_\\}\\$]',
+          },
+        ]
+      },
+      {
+        className: 'string',
+        contains: [hljs.BACKSLASH_ESCAPE],
+        variants: [
+          hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
+          hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null})
+        ]
+      },
+      {
+        className: 'number',
+        variants: [hljs.BINARY_NUMBER_MODE, hljs.C_NUMBER_MODE]
+      },
+    ]
+  }
+}

--- a/src/test.html
+++ b/src/test.html
@@ -3637,6 +3637,37 @@ N28 VZOFZ=652.9658
 %
 </code></pre>
 
+<tr>
+    <th>Tcl
+    <td class="tcl">
+<pre><code>package json
+
+source helper.tcl
+# randomness verified by a die throw
+set ::rand 4
+
+proc give::recursive::count {base p} { ; # 2 mandatory params
+    while {$p > 0} {
+        set result [expr $result * $base]; incr p -1
+    }
+    return $result
+}
+
+set a 'a'; set b "bcdef"; set lst [list "item"]
+puts [llength $a$b]
+
+set ::my::tid($id) $::my::tid(def)
+lappend lst $arr($idx) $::my::arr($idx) $ar(key)
+lreplace ::my::tid($id) 4 4
+puts $::rand ${::rand} ${::AWESOME::component::variable}
+
+puts "$x + $y is\t [expr $x + $y]"
+
+proc isprime x {
+    expr {$x>1 && ![regexp {^(oo+?)\1+$} [string repeat o $x]]}
+}
+</code></pre>
+
 </table>
 
 

--- a/test/detect/tcl/default.txt
+++ b/test/detect/tcl/default.txt
@@ -1,0 +1,26 @@
+package json
+
+source helper.tcl
+# randomness verified by a die throw
+set ::rand 4
+
+proc give::recursive::count {base p} { ; # 2 mandatory params
+    while {$p > 0} {
+        set result [expr $result * $base]; incr p -1
+    }
+    return $result
+}
+
+set a 'a'; set b "bcdef"; set lst [list "item"]
+puts [llength $a$b]
+
+set ::my::tid($id) $::my::tid(def)
+lappend lst $arr($idx) $::my::arr($idx) $ar(key)
+lreplace ::my::tid($id) 4 4
+puts $::rand ${::rand} ${::AWESOME::component::variable}
+
+puts "$x + $y is\t [expr $x + $y]"
+
+proc isprime x {
+    expr {$x>1 && ![regexp {^(oo+?)\1+$} [string repeat o $x]]}
+}


### PR DESCRIPTION
Hi! 
I have created a syntax highlight rules for Tcl (http://www.tcl.tk/). I went according to the instructions in http://highlightjs.readthedocs.org/en/latest/language-contribution.html and it seems everything is fine.

Screenshot:
![highlightjs_tcl](https://cloud.githubusercontent.com/assets/6383928/4099189/e0149636-3050-11e4-976d-e91d93c63892.png)
