### PR TITLE
Update php.js

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -9,7 +9,7 @@ function(hljs) {
     className: 'variable', begin: '(\\$)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
   };
   var METHOD = {
-    className: 'method', begin: '(->)[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
+    className: 'method', begin: '\b[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
   };
   var PREPROCESSOR = {
     className: 'preprocessor', begin: /<\?(php)?|\?>/


### PR DESCRIPTION
In PHP OOP it is very frequent the use of variables and methods only, instead of variables and functions.
The current way to parse tokens in HLJS formats methods as variables.
Apart from the syntactical mistake, it makes practically no highlighting difference in a OOP code, failing, in my opinion, its purpose to make code more readable and understandable.
So I propose to split in two the VARIABLE definition, adding a METHOD definition.
