### PR TITLE
Added fix for incorrect detection of throw as function definition

### DIFF
--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -38,13 +38,8 @@ function(hljs) {
         ]
       },
       {
-        // this prevents 'new Name(...)' from being recognized as a function definition
-        beginKeywords: 'new', end: /\s/,
-        relevance: 0
-      },
-      {
-        // this prevents 'throw ...' from being recognized as a function definition
-        beginKeywords: 'throw', end: /\s/,
+        // this prevents 'new Name(...), or throw ...' from being recognized as a function definition
+        beginKeywords: 'new throw', end: /\s/,
         relevance: 0
       },
       {


### PR DESCRIPTION
I came across problems using highlight.js on java code, which are corrected with this small patch.
