### PR TITLE
Improve C# highlighting for the Tomorrow styles

### DIFF
--- a/src/styles/tomorrow-night-blue.css
+++ b/src/styles/tomorrow-night-blue.css
@@ -4,8 +4,7 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
-.hljs-comment,
-.hljs-title {
+.hljs-comment {
   color: #7285b7;
 }
 
@@ -53,6 +52,7 @@
 }
 
 /* Tomorrow Aqua */
+.hljs-title,
 .css .hljs-hexcolor {
   color: #99ffff;
 }

--- a/src/styles/tomorrow-night-bright.css
+++ b/src/styles/tomorrow-night-bright.css
@@ -3,8 +3,7 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
-.hljs-comment,
-.hljs-title {
+.hljs-comment {
   color: #969896;
 }
 
@@ -52,6 +51,7 @@
 }
 
 /* Tomorrow Aqua */
+.hljs-title,
 .css .hljs-hexcolor {
   color: #70c0b1;
 }

--- a/src/styles/tomorrow-night-eighties.css
+++ b/src/styles/tomorrow-night-eighties.css
@@ -3,8 +3,7 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
-.hljs-comment,
-.hljs-title {
+.hljs-comment {
   color: #999999;
 }
 
@@ -52,6 +51,7 @@
 }
 
 /* Tomorrow Aqua */
+.hljs-title,
 .css .hljs-hexcolor {
   color: #66cccc;
 }

--- a/src/styles/tomorrow-night.css
+++ b/src/styles/tomorrow-night.css
@@ -4,8 +4,7 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
-.hljs-comment,
-.hljs-title {
+.hljs-comment {
   color: #969896;
 }
 
@@ -53,6 +52,7 @@
 }
 
 /* Tomorrow Aqua */
+.hljs-title,
 .css .hljs-hexcolor {
   color: #8abeb7;
 }

--- a/src/styles/tomorrow.css
+++ b/src/styles/tomorrow.css
@@ -1,8 +1,7 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
-.hljs-comment,
-.hljs-title {
+.hljs-comment {
   color: #8e908c;
 }
 
@@ -50,6 +49,7 @@
 }
 
 /* Tomorrow Aqua */
+.hljs-title,
 .css .hljs-hexcolor {
   color: #3e999f;
 }


### PR DESCRIPTION
Class and method names were being colored with the same color as comments, which was a little bit confusing.

I tried some other colors, but ended up choosing _Aqua_ for the job, which I believe was a good fit for all variations.
### Comparison Screenshots

_Before_ first, _after_ second.

`tomorrow`:

![image](https://cloud.githubusercontent.com/assets/126538/4691300/82d8647e-5711-11e4-886f-f74ca3fbb951.png)
![image](https://cloud.githubusercontent.com/assets/126538/4691320/8c912d6a-5712-11e4-9d9f-02ccd6c9fc2f.png)

`tomorrow-night`:

![image](https://cloud.githubusercontent.com/assets/126538/4691337/5c55cc54-5713-11e4-8722-0305e12f9033.png)
![image](https://cloud.githubusercontent.com/assets/126538/4691351/d51a8c88-5713-11e4-9413-9d0eb7ca4bdb.png)
