### PR TITLE
Fix OCaml language support

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -654,12 +654,15 @@ OCaml ("ocaml", "ml")
 ---------------------
 
 * ``keywords``:         keyword
+* ``literal``:          true false etc.
 * ``number``:           number
 * ``string``:           string
+* ``char``:             character
 * ``comment``:          comment
-* ``class``:            any custom OCaml type
-* ``title``:            the name of a custom OCaml type
-* ``annotation``:       any attribute
+* ``built_in``:         built-in type (int, list etc.)
+* ``type``:             variant constructor, module name
+* ``tag``:              polymorphic variant tag
+* ``symbol``:           type variable
 
 D ("d")
 -------

--- a/src/languages/ocaml.js
+++ b/src/languages/ocaml.js
@@ -1,49 +1,71 @@
 /*
 Language: OCaml
 Author: Mehdi Dogguy <mehdi@dogguy.org>
-Contributors: Nicolas Braud-Santoni <nicolas.braud-santoni@ens-cachan.fr>
+Contributors: Nicolas Braud-Santoni <nicolas.braud-santoni@ens-cachan.fr>, Mickael Delahaye <mickael.delahaye@gmail.com>
 Description: OCaml language definition.
 */
 function(hljs) {
+  /* missing support for heredoc-like string (OCaml 4.0.2+) */
   return {
     aliases: ['ml'],
     keywords: {
       keyword:
         'and as assert asr begin class constraint do done downto else end ' +
-        'exception external false for fun function functor if in include ' +
-        'inherit initializer land lazy let lor lsl lsr lxor match method ' +
-        'mod module mutable new object of open or private rec ref sig struct ' +
-        'then to true try type val virtual when while with parser value',
+        'exception external for fun function functor if in include ' +
+        'inherit! inherit initializer land lazy let lor lsl lsr lxor match method!|10 method ' +
+        'mod module|5 mutable|5 new object of open! open or private rec sig|5 struct ' +
+        'then to try type val! val virtual when while with ' +
+        /* camlp4 */
+        'parser value',
       built_in:
-        'bool char float int list unit array exn option int32 int64 nativeint ' +
-        'format4 format6 lazy_t in_channel out_channel string'
+        /* built-in types */
+        'array bool bytes char exn|5 float int int32 int64 list lazy_t|5 nativeint|5 string unit ' +
+        /* (some) types in Pervasives */
+        'in_channel out_channel ref',
+      literal:
+        'true false',
     },
     illegal: /\/\//,
+    lexemes: '[a-z_]\\w*!?',
     contains: [
       {
-        className: 'string',
-        begin: '"""', end: '"""'
+        className: 'literal',
+        begin: '\\[(\\|\\|)?\\]|\\(\\)'
       },
       {
         className: 'comment',
         begin: '\\(\\*', end: '\\*\\)',
-        contains: ['self']
+        contains: ['self'],
       },
-      {
-        className: 'class',
-        beginKeywords: 'type', end: '\\(|=|$', excludeEnd: true,
-        contains: [
-          hljs.UNDERSCORE_TITLE_MODE
-        ]
+      { /* type variable */
+        className: 'symbol',
+        begin: '\'[A-Za-z_](?!\')[\\w\']*',
+        /* the grammar is ambiguous on how 'a'b should be interpreted but not the compiler */
       },
-      {
-        className: 'annotation',
-        begin: '\\[<', end: '>\\]'
+      { /* polymorphic variant */
+        className: 'tag',
+        begin: '`[A-Z][\\w\']*',
       },
-      hljs.C_BLOCK_COMMENT_MODE,
-      hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
+      { /* module or constructor */
+        className: 'type',
+        begin: '\\b[A-Z][\\w\']*',
+        relevance: 0
+      },
+      { /* don't color identifiers, but safely catch all identifiers with '*/
+        begin: '[a-z_]\\w*\'[\\w\']*',
+        relevance: 0
+      },
+      hljs.inherit(hljs.APOS_STRING_MODE, {className: 'char', relevance: 0}),
       hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null}),
-      hljs.C_NUMBER_MODE
+      {
+        className: 'number',
+        begin:
+          '\\b(0[xX][a-fA-F0-9_]+[Lln]?|' +
+          '0[oO][0-7_]+[Lln]?|' +
+          '0[bB][01_]+[Lln]?|' +
+          '[0-9][0-9_]*([Lln]|(\\.[0-9_]*)?([eE][-+]?[0-9_]+)?)?)',
+        relevance: 0
+      }
     ]
   }
 }

--- a/test/markup/ocaml/literals.expect.txt
+++ b/test/markup/ocaml/literals.expect.txt
@@ -1,0 +1,29 @@
+<span class="hljs-keyword">let</span> i = <span class="hljs-number">14</span>
+<span class="hljs-keyword">let</span> i = -<span class="hljs-number">14</span>
+<span class="hljs-keyword">let</span> i = <span class="hljs-number">1_000</span>
+<span class="hljs-keyword">let</span> i = <span class="hljs-number">0b100</span>
+<span class="hljs-keyword">let</span> i = <span class="hljs-number">0x1FF</span>
+<span class="hljs-keyword">let</span> i = <span class="hljs-number">0o777</span>
+<span class="hljs-keyword">let</span> i64 = <span class="hljs-number">128L</span>
+<span class="hljs-keyword">let</span> i64 = <span class="hljs-number">0b10L</span>
+<span class="hljs-keyword">let</span> i32 = <span class="hljs-number">32l</span>
+<span class="hljs-keyword">let</span> i32 = <span class="hljs-number">0x12l</span>
+<span class="hljs-keyword">let</span> nat = <span class="hljs-number">10n</span>
+<span class="hljs-keyword">let</span> nat = <span class="hljs-number">0o644n</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">5.</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">5.1</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">1e+1</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">1e1</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">1e-1</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">1_024e12</span>
+<span class="hljs-keyword">let</span> f = <span class="hljs-number">1L</span>
+
+<span class="hljs-keyword">let</span> b = <span class="hljs-literal">true</span> || <span class="hljs-literal">false</span>
+<span class="hljs-keyword">let</span> l = <span class="hljs-literal">[]</span>
+<span class="hljs-keyword">let</span> a = <span class="hljs-literal">[||]</span>
+<span class="hljs-keyword">let</span> <span class="hljs-literal">()</span> = ignore (b)
+
+<span class="hljs-keyword">let</span> c = <span class="hljs-char">'a'</span>
+<span class="hljs-keyword">let</span> c = <span class="hljs-char">'\xFF'</span>
+<span class="hljs-keyword">let</span> c = <span class="hljs-char">'\128'</span>
+<span class="hljs-keyword">let</span> c = <span class="hljs-char">'\n'</span>

--- a/test/markup/ocaml/literals.txt
+++ b/test/markup/ocaml/literals.txt
@@ -1,0 +1,29 @@
+let i = 14
+let i = -14
+let i = 1_000
+let i = 0b100
+let i = 0x1FF
+let i = 0o777
+let i64 = 128L
+let i64 = 0b10L
+let i32 = 32l
+let i32 = 0x12l
+let nat = 10n
+let nat = 0o644n
+let f = 5.
+let f = 5.1
+let f = 1e+1
+let f = 1e1
+let f = 1e-1
+let f = 1_024e12
+let f = 1L
+
+let b = true || false
+let l = []
+let a = [||]
+let () = ignore (b)
+
+let c = 'a'
+let c = '\xFF'
+let c = '\128'
+let c = '\n'

--- a/test/markup/ocaml/types.expect.txt
+++ b/test/markup/ocaml/types.expect.txt
@@ -1,0 +1,17 @@
+<span class="hljs-comment">(* type variables *)</span>
+<span class="hljs-keyword">type</span> <span class="hljs-symbol">'a</span> t = <span class="hljs-symbol">'a</span> <span class="hljs-built_in">list</span>
+<span class="hljs-keyword">let</span> f (a : <span class="hljs-symbol">'a</span> <span class="hljs-built_in">list</span>) : <span class="hljs-symbol">'a</span> = <span class="hljs-type">List</span>.hd a
+
+<span class="hljs-comment">(* polymorphic variants *)</span>
+<span class="hljs-keyword">type</span> t = [ <span class="hljs-tag">`A</span> | <span class="hljs-tag">`B</span> ]
+
+<span class="hljs-comment">(* variants *)</span>
+<span class="hljs-keyword">type</span> result = <span class="hljs-type">Sat</span> | <span class="hljs-type">Unsat</span> | <span class="hljs-type">Unknown</span>
+
+<span class="hljs-comment">(* module and module types *)</span>
+<span class="hljs-keyword">module</span> <span class="hljs-keyword">type</span> <span class="hljs-type">S</span> = <span class="hljs-keyword">sig</span>
+  <span class="hljs-keyword">val</span> compute : <span class="hljs-built_in">unit</span> -&gt; <span class="hljs-built_in">unit</span>
+<span class="hljs-keyword">end</span>
+<span class="hljs-keyword">module</span> <span class="hljs-type">Impl</span> : <span class="hljs-type">S</span> = <span class="hljs-keyword">struct</span>
+  <span class="hljs-keyword">let</span> compute <span class="hljs-literal">()</span> = <span class="hljs-literal">()</span>
+<span class="hljs-keyword">end</span>

--- a/test/markup/ocaml/types.txt
+++ b/test/markup/ocaml/types.txt
@@ -1,0 +1,17 @@
+(* type variables *)
+type 'a t = 'a list
+let f (a : 'a list) : 'a = List.hd a
+
+(* polymorphic variants *)
+type t = [ `A | `B ]
+
+(* variants *)
+type result = Sat | Unsat | Unknown
+
+(* module and module types *)
+module type S = sig
+  val compute : unit -> unit
+end
+module Impl : S = struct
+  let compute () = ()
+end


### PR DESCRIPTION
The major concern with the state of OCaml in Highlight.js is about the apostrophe `'`. They are very used in OCaml : they are allowed in identifiers (`my_var'`), and are used to  prefix "generic" types (type variable, e.g. in `'a list` type of a generic list). Yet the existing language description, totally ignore it (except for character literals) and as a result the first use of `'` messes up the highlighting of the rest of the code (in particular interfaces).

The proposed modification provides various improvements:
- character support (as char rather than string)
- type variable (`'a`)
- polymorphic variant tag (`[ `A | `B ]`)
- module name/variant constructor (module `List` or constructor `Some a`)
- support `'` in identifier
- add support for literals `()` `[]` `[||]`
- better support for numbers (OCaml ≠ C)
- remove unrelated rules (from F# maybe?)
- add new keywords (`method!`, `open!` etc.)
- cleanup built-in types
- add some tests

A step backward: remove very incomplete type definition. It would not have been easy to really support that and in terms of highlighting I don't think it's worth it.

The complete test suite sucessfully run including the language detection.

Cheers, M
