### PR TITLE
Simplify exporting of window / amd / cjs.

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -3,26 +3,26 @@ Syntax highlighting with language autodetection.
 https://highlightjs.org/
 */
 
-(function(global, factory) {
+(function(factory) {
 
   // Setup highlight.js for different environments. First is Node.js or
   // CommonJS.
   if(typeof exports !== 'undefined') {
-    factory(global, exports);
+    factory(exports);
   } else {
     // Export hljs globally even when using AMD for cases when this script
     // is loaded with others that may still expect a global hljs.
-    global.hljs = factory(global, {});
+    window.hljs = factory({});
 
     // Finally register the global hljs with AMD.
     if(typeof define === 'function' && define.amd) {
       define([], function() {
-        return global.hljs;
+        return window.hljs;
       });
     }
   }
 
-}(window, function(global, hljs) {
+}(function(hljs) {
 
   /* Utility functions */
 


### PR DESCRIPTION
If your build process wraps the source in an IIFE that gets executed with a modified context then Highlight won't work at all. You could invoke the IIFE with `window`, but that becomes difficult when using something like Traceur where you don't have control over that without having to hack something pretty ugly into your build process.

I've also simplified how the exporting is done. The `global` variable isn't used at all within the `factory()` and it's not used for the CommonJS exporting; it's only used for exporting to the `window` which is `this` when running in a browser context unless the aforementioned happens.

You have both a `src/test.html` file and `tests/index.html` and I'm not really sure how you intend them to be used for testing. I've implemented something with it in a browser context and ran the code through node and everything seems fine.
