### PR TITLE
Get rid of template_comment css class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## master
 
+Some notable changes:
+
+- The `template_comment` class is gone in favor of the more general `comment`.
+
 New languages:
 
 - *AspectJ* by [Hakan Özler][]

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -286,13 +286,12 @@ Django ("django", "jinja")
 
 * ``keyword``:          HTML tag in HTML, default tags and default filters in templates
 * ``tag``:              any tag from "<" till ">"
-* ``comment``:          comment
+* ``comment``:          template comment, both {# .. #} and {% comment %}
 * ``doctype``:          <!DOCTYPE ... > declaration
 * ``attribute``:        tag's attribute with or without value
 * ``value``:            attribute's value
 * ``template_tag``:     template tag {% .. %}
 * ``variable``:         template variable {{ .. }}
-* ``template_comment``: template comment, both {# .. #} and {% comment %}
 * ``filter``:           filter from "|" till the next filter or the end of tag
 * ``argument``:         filter argument
 
@@ -302,13 +301,12 @@ Twig ("twig", "craftcms")
 
 * ``keyword``:          HTML tag in HTML, default tags and default filters in templates
 * ``tag``:              any tag from "<" till ">"
-* ``comment``:          comment
+* ``comment``:          template comment {# .. #}
 * ``doctype``:          <!DOCTYPE ... > declaration
 * ``attribute``:        tag's attribute with or withou value
 * ``value``:            attribute's value
 * ``template_tag``:     template tag {% .. %}
 * ``variable``:         template variable {{ .. }}
-* ``template_comment``: template comment {# .. #}
 * ``filter``:           filter from "|" till the next filter or the end of tag
 * ``argument``:         filter argument
 

--- a/src/languages/django.js
+++ b/src/languages/django.js
@@ -30,11 +30,11 @@ function(hljs) {
     subLanguage: 'xml', subLanguageMode: 'continuous',
     contains: [
       {
-        className: 'template_comment',
+        className: 'comment',
         begin: /\{%\s*comment\s*%}/, end: /\{%\s*endcomment\s*%}/
       },
       {
-        className: 'template_comment',
+        className: 'comment',
         begin: /\{#/, end: /#}/
       },
       {

--- a/src/languages/twig.js
+++ b/src/languages/twig.js
@@ -47,7 +47,7 @@ function(hljs) {
     subLanguage: 'xml', subLanguageMode: 'continuous',
     contains: [
       {
-        className: 'template_comment',
+        className: 'comment',
         begin: /\{#/, end: /#}/
       },
       {

--- a/src/styles/arta.css
+++ b/src/styles/arta.css
@@ -28,7 +28,6 @@ Author: pumbur <pumbur@pumbur.net>
 .hljs-pi,
 .hljs-doctype,
 .hljs-tag,
-.hljs-template_comment,
 .css .hljs-rules,
 .tex .hljs-special {
   color: #444;

--- a/src/styles/ascetic.css
+++ b/src/styles/ascetic.css
@@ -26,7 +26,6 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-shebang,
 .hljs-doctype,
 .hljs-pi,

--- a/src/styles/brown_paper.css
+++ b/src/styles/brown_paper.css
@@ -64,7 +64,6 @@ Brown Paper style from goldblog.com.ua (c) Zaripov Yura <yur4ik7@ukr.net>
 .hljs-comment,
 .hljs-annotation,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype,
 .hljs-deletion,

--- a/src/styles/color-brewer.css
+++ b/src/styles/color-brewer.css
@@ -53,7 +53,6 @@ Ported by Fabrício Tavares de Oliveira
 .smartquote,
 .hljs-comment,
 .hljs-annotation,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-chunk,
 .asciidoc .hljs-blockquote,

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -63,7 +63,6 @@ Dark style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Or
 .hljs-comment,
 .hljs-annotation,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype,
 .hljs-deletion,

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -51,7 +51,6 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 .smartquote,
 .hljs-comment,
 .hljs-annotation,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-chunk,
 .asciidoc .hljs-blockquote,

--- a/src/styles/docco.css
+++ b/src/styles/docco.css
@@ -12,7 +12,6 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-javadoc {
   color: #408080;

--- a/src/styles/far.css
+++ b/src/styles/far.css
@@ -61,7 +61,6 @@ FAR Style (c) MajestiC <majestic2k@gmail.com>
 .hljs-dartdoc,
 .hljs-javadoc,
 .hljs-annotation,
-.hljs-template_comment,
 .hljs-deletion,
 .apache .hljs-sqbracket,
 .tex .hljs-formula {

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -14,7 +14,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-javadoc {
   color: #998;

--- a/src/styles/googlecode.css
+++ b/src/styles/googlecode.css
@@ -14,7 +14,6 @@ Google Code style (c) Aahan Krish <geekpanth3r@gmail.com>
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc {
   color: #800;
 }

--- a/src/styles/hybrid.css
+++ b/src/styles/hybrid.css
@@ -54,7 +54,6 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 .hljs-output .hljs-value,
 .hljs-pi,
 .hljs-shebang,
-.hljs-template_comment,
 .hljs-doctype {
   color: #707880;
 }

--- a/src/styles/idea.css
+++ b/src/styles/idea.css
@@ -21,7 +21,6 @@ Intellij Idea-like styling (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc,
 .diff .hljs-header {
   color: #808080;

--- a/src/styles/ir_black.css
+++ b/src/styles/ir_black.css
@@ -13,7 +13,6 @@
 
 .hljs-shebang,
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc {
   color: #7c7c7c;
 }

--- a/src/styles/magula.css
+++ b/src/styles/magula.css
@@ -43,7 +43,6 @@ Music: Aphex Twin / Xtal
 
 .hljs-comment,
 .hljs-annotation,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-chunk {
   color: #777;

--- a/src/styles/mono-blue.css
+++ b/src/styles/mono-blue.css
@@ -24,8 +24,7 @@
 }
 
 .hljs-comment,
-.hljs-chunk,
-.hljs-template_comment {
+.hljs-chunk {
   color: #738191;
 }
 

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -85,7 +85,6 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-blockquote,
 .hljs-horizontal_rule,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype,
 .hljs-deletion,

--- a/src/styles/monokai_sublime.css
+++ b/src/styles/monokai_sublime.css
@@ -130,7 +130,6 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 .hljs-javadoc,
 .hljs-annotation,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype,
 .hljs-deletion,

--- a/src/styles/obsidian.css
+++ b/src/styles/obsidian.css
@@ -111,7 +111,6 @@
 .hljs-blockquote,
 .hljs-horizontal_rule,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-deletion,
 .hljs-shebang,

--- a/src/styles/pojoaque.css
+++ b/src/styles/pojoaque.css
@@ -16,7 +16,6 @@ Based on Solarized Style from http://ethanschoonover.com/solarized
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-doctype,
 .lisp .hljs-string,

--- a/src/styles/railscasts.css
+++ b/src/styles/railscasts.css
@@ -14,7 +14,6 @@ Railscasts-like style (c) Visoft, Inc. (Damien White)
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc,
 .hljs-shebang {
   color: #bc9458;

--- a/src/styles/rainbow.css
+++ b/src/styles/rainbow.css
@@ -20,7 +20,6 @@ Style with support for rainbow parens
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-doctype,
 .lisp .hljs-string,

--- a/src/styles/school_book.css
+++ b/src/styles/school_book.css
@@ -71,7 +71,6 @@ pre{
 .hljs-comment,
 .hljs-annotation,
 .hljs-decorator,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype,
 .hljs-deletion,

--- a/src/styles/solarized_dark.css
+++ b/src/styles/solarized_dark.css
@@ -14,7 +14,6 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-doctype,
 .hljs-pi,

--- a/src/styles/solarized_light.css
+++ b/src/styles/solarized_light.css
@@ -14,7 +14,6 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-doctype,
 .hljs-pi,

--- a/src/styles/sunburst.css
+++ b/src/styles/sunburst.css
@@ -14,7 +14,6 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc {
   color: #aeaeae;
   font-style: italic;

--- a/src/styles/vs.css
+++ b/src/styles/vs.css
@@ -14,7 +14,6 @@ Visual Studio-like style based on original C# coloring by Jason Diamond <jason@d
 
 .hljs-comment,
 .hljs-annotation,
-.hljs-template_comment,
 .diff .hljs-header,
 .hljs-chunk,
 .apache .hljs-cbracket {

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -14,7 +14,6 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 }
 
 .hljs-comment,
-.hljs-template_comment,
 .hljs-javadoc {
   color: #006a00;
 }

--- a/src/styles/zenburn.css
+++ b/src/styles/zenburn.css
@@ -101,7 +101,6 @@ based on dark.css by Ivan Sagalaev
 .diff .hljs-addition,
 .hljs-comment,
 .hljs-annotation,
-.hljs-template_comment,
 .hljs-pi,
 .hljs-doctype {
   color: #7f9f7f;

--- a/test/markup/twig/template_tags.expect.txt
+++ b/test/markup/twig/template_tags.expect.txt
@@ -3,7 +3,7 @@
   &amp;lt;div&amp;gt;
   </span><span class="hljs-variable">{{ article.title<span class="hljs-filter">|<span class="hljs-keyword">upper</span></span>() }}</span><span class="xml">
 
-  </span><span class="hljs-template_comment">{# outputs 'WELCOME' #}</span><span class="xml">
+  </span><span class="hljs-comment">{# outputs 'WELCOME' #}</span><span class="xml">
   &amp;lt;/div&amp;gt;
   </span><span class="hljs-template_tag">{% <span class="hljs-keyword">endfor</span> %}</span><span class="xml">
 </span><span class="hljs-template_tag">{% <span class="hljs-keyword">endif</span> %}</span><span class="xml">
@@ -15,7 +15,7 @@
 </span><span class="hljs-variable">{{ <span class="hljs-function"><span class="hljs-keyword">include</span><span class="hljs-params">(template_from_string("Hello {{ name }}")</span></span>) }}</span><span class="xml">
 
 
-</span><span class="hljs-template_comment">{#
+</span><span class="hljs-comment">{#
 Comments may be long and multiline.
 Markup is &amp;lt;em&amp;gt;not&amp;lt;/em&amp;gt; highlighted within comments.
 #}</span><span class="xml">


### PR DESCRIPTION
Looks like this is backward-compatible change - all styles have same instructions for `comment` and `template_comment` classes.
