### PR TITLE
parse individual javascript function parameters

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -61,7 +61,11 @@ function(hljs) {
             begin: /\(/, end: /\)/,
             contains: [
               hljs.C_LINE_COMMENT_MODE,
-              hljs.C_BLOCK_COMMENT_MODE
+              hljs.C_BLOCK_COMMENT_MODE,
+              {
+                  className: 'param',
+                  begin: /[A-Za-z$_][0-9A-Za-z$_]*/, excludeEnd: true
+              }
             ],
             illegal: /["'\(]/
           }


### PR DESCRIPTION
My personal opinion is that coloring the entire function parameters from parentheses to parenthesis is somewhat ugly. This is a tiny change that adds a "param" style to individual function parameters.
