### PR TITLE
Adds support for multi-line comments in Matlab

### DIFF
--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -92,6 +92,11 @@ function(hljs) {
         starts: TRANSPOSE
       },
       {
+        // Block comment
+        className: 'comment',
+        begin: '^\\s*\\%\\{\\s*$', end: '^\\s*\\%\\}\\s*$'
+      },
+      {
         className: 'comment',
         begin: '\\%', end: '$'
       }

--- a/test/detect/matlab/default.txt
+++ b/test/detect/matlab/default.txt
@@ -24,6 +24,10 @@ while(max(len) > 2 * min(len))
     points = [ points(1:i, :); [xm, ym]; points(i + 1:end, :)];
 end
 
+%{
+    This is a block comment. Please ignore me.
+%}
+
 function [net] = get_fit_network(inputs, targets)
     % Create Network
     numHiddenNeurons = 20;  % Adjust as desired

--- a/test/markup/matlab/block_comment.expect.txt
+++ b/test/markup/matlab/block_comment.expect.txt
@@ -1,0 +1,27 @@
+<span class="hljs-comment">%{ evaluate_this = false; % Evaluated as regular single-line comment</span>
+evaluate_this = true;
+<span class="hljs-comment">%}</span>
+
+evaluate_this = true;
+<span class="hljs-comment">
+%{
+This is a multi-line comment
+evaluate_this = false;
+%{
+%}
+</span>
+evaluate_this = true;
+<span class="hljs-comment">
+%{
+Opening (%{) and closing (%}) block comment markers can be within a comment block
+%}
+</span>
+evaluate_this = true;
+<span class="hljs-comment">
+    %{
+    Indented block comments can be indented
+or not
+and whitespace can be added before or after the %{ and %}
+  %}   
+</span>
+evaluate_this = true;

--- a/test/markup/matlab/block_comment.txt
+++ b/test/markup/matlab/block_comment.txt
@@ -1,0 +1,27 @@
+%{ evaluate_this = false; % Evaluated as regular single-line comment
+evaluate_this = true;
+%}
+
+evaluate_this = true;
+
+%{
+This is a multi-line comment
+evaluate_this = false;
+%{
+%}
+
+evaluate_this = true;
+
+%{
+Opening (%{) and closing (%}) block comment markers can be within a comment block
+%}
+
+evaluate_this = true;
+
+    %{
+    Indented block comments can be indented
+or not
+and whitespace can be added before or after the %{ and %}
+  %}   
+
+evaluate_this = true;


### PR DESCRIPTION
Matlab block comments were not considered previously and the operators %{ and %} were treated as inline comments and all text between those symbols was parsed as if it were code rather than being treated as a block comment.

I have added new checks to the language definition and added the appropriate test files.

The basic rule is that block comments should begin with %{ and end with %} with the specification that %{ and %} must appear on their own lines with only whitespace before or after them on that line.

More information available at the [Mathworks website](http://www.mathworks.com/help/matlab/matlab_prog/comments.html).
