### PR TITLE
Fix for Swift "class" keyword matching

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -97,7 +97,7 @@ function(hljs) {
       {
         className: 'class',
         keywords: 'struct protocol class extension enum',
-        begin: '(struct|protocol|class(?! (func|var))|extension|enum)',
+        begin: /(^|\W)(struct|protocol|class(?! (func|var))|extension|enum)(\W|$)/,
         end: '\\{',
         excludeEnd: true,
         contains: [


### PR DESCRIPTION
Currently the Swift highlighting will match class keywords that appear within another word. For example:

``` swift
var instruction = Instruction()
```

Will match the _struct_ in _instruction_ and break the highlighting.

This patch updates the regular expression to only match "class" keywords that are at the start of a line, or preceded by any non-word character (e.g. space or tab).
