### PR TITLE
Added .adoc as alias for .asciidoc.

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -265,8 +265,8 @@ Markdown ("markdown", "md", "mkdown", "mkd")
 * ``link_url``:          link url
 * ``link_reference``:    link reference
 
-AsciiDoc ("asciidoc", "adoc", "asc")
-------------------------------------
+AsciiDoc ("asciidoc", "adoc")
+-----------------------------
 
 * ``header``:            heading
 * ``bullet``:            list or labeled bullet

--- a/src/languages/asciidoc.js
+++ b/src/languages/asciidoc.js
@@ -7,7 +7,7 @@ Description: A semantic, text-based document format that can be exported to HTML
 */
 function(hljs) {
   return {
-    aliases: ['adoc', 'asc'],
+    aliases: ['adoc'],
     contains: [
       // block comment
       {


### PR DESCRIPTION
Added `.adoc` and `.asc` as aliases for `.asciidoc`, per http://asciidoctor.org/docs/asciidoc-recommended-practices/ and https://github.com/github/markup.

@mojavelinux 
