### PR TITLE
Enable CSS Modules

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -48,7 +48,8 @@ https://highlightjs.org/
     classPrefix: 'hljs-',
     tabReplace: null,
     useBR: false,
-    languages: undefined
+    languages: undefined,
+    classNames: {}
   };
 
   // Object map that is used to escape some common HTML characters.
@@ -356,10 +357,11 @@ https://highlightjs.org/
 
     function buildSpan(classname, insideSpan, leaveOpen, noPrefix) {
       var classPrefix = noPrefix ? '' : options.classPrefix,
-          openSpan    = '<span class="' + classPrefix,
+          cName = (options.classNames || {})[classPrefix + classname] || classPrefix + classname || '',
+          openSpan    = '<span class="',
           closeSpan   = leaveOpen ? '' : spanEndTag
 
-      openSpan += classname + '">';
+      openSpan += cName + '">';
 
       return openSpan + insideSpan + closeSpan;
     }


### PR DESCRIPTION
This commit adds an option `classNames` which is a hash from class
name to string. This enables projects to pass in a set of matching
(scoped) classnames generated from CSS Modules.

If there is no hash passed in, or there is no specified class name, we
fall back to the default to keep backwards compatibility.

The following CSS file:

``` css
.hljs {
  display: block;
  overflow-x: auto;
  color: #00193a;
  composes: p1 from 'basscss-padding/index.css';
}

.hljs-keyword,
.hljs-selector-tag,
.hljs-title,
.hljs-section,
.hljs-doctag,
.hljs-name,
.hljs-strong {
  font-weight: bold;
}
...
```

Could produce the following example hash:

``` javascript
{
  hljs: '_css_mono_blue__hljs _node_modules_basscss_padding_index__p1',
  'hljs-keyword': '_css_mono_blue__hljs-keyword',
  'hljs-selector-tag': '_css_mono_blue__hljs-selector-tag',
  'hljs-title': '_css_mono_blue__hljs-title',
  'hljs-section': '_css_mono_blue__hljs-section',
  ...
}
```

which can then be passed in `configure`

``` javascript
hljs.configure({ classNames: hash })
```

---

This should also keep compatibility with any of the already-created color schemes
since we used the same class names to access the hash object. So a user
currently using `solarized` could process the style file with CSS Modules and 
get scoped class names for pretty much free.
