### PR TITLE
Support for Franca IDL and Franca deployment models.

### DIFF
--- a/src/languages/fdepl.js
+++ b/src/languages/fdepl.js
@@ -1,0 +1,105 @@
+/*
+Language: Franca Deployment Models (fdepl)
+Author: Klaus Birken <klaus.birken@gmail.com>
+Category: common, idl
+*/
+
+function(hljs) {
+  var GENERIC_IDENT_RE = hljs.UNDERSCORE_IDENT_RE + '(<' + hljs.UNDERSCORE_IDENT_RE + '(\\s*,\\s*' + hljs.UNDERSCORE_IDENT_RE + ')*>)?';
+  var KEYWORDS =
+    'import specification extends for optional default ' +
+    'providers instances interfaces type_collections ' +
+    'attributes methods broadcasts arguments ' +
+    'structs struct_fields unions union_fields ' +
+    'arrays enumerations enumerators typedefs ' +
+    'strings numbers integers floats ' + 
+    'booleans byte_buffers ' +
+    'Boolean Integer String Interface ' + 
+    'define provider instance interface ' +
+    'attribute method broadcast in out ' +
+    'array struct enumeration ' +
+    'false true';
+
+  var FDEPL_NUMBER_RE = '\\b' +
+    '(' +
+      '0[bB]([01]+[01_]+[01]+|[01]+)' + // 0b...
+      '|' +
+      '0[xX]([a-fA-F0-9]+[a-fA-F0-9_]+[a-fA-F0-9]+|[a-fA-F0-9]+)' + // 0x...
+      '|' +
+      '(' +
+        '([\\d]+[\\d_]+[\\d]+|[\\d]+)(\\.([\\d]+[\\d_]+[\\d]+|[\\d]+))?' +
+        '|' +
+        '\\.([\\d]+[\\d_]+[\\d]+|[\\d]+)' +
+      ')' +
+      '([eE][-+]?\\d+)?' + // octal, decimal, float
+    ')' +
+    '[lLfF]?';
+  var FDEPL_NUMBER_MODE = {
+    className: 'number',
+    begin: FDEPL_NUMBER_RE,
+    relevance: 0
+  };
+
+  return {
+    keywords: KEYWORDS,
+    illegal: /<\/|#/,
+    contains: [
+      hljs.COMMENT(
+        '/\\*\\*',
+        '\\*/',
+        {
+          relevance : 0
+        }
+      ),
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.APOS_STRING_MODE,
+      hljs.QUOTE_STRING_MODE,
+      /*
+      {
+        className: 'specification',
+        beginKeywords: 'specification define', end: /[{;=]/, excludeEnd: true,
+        keywords: 'specification define',
+        illegal: /[:"\[\]]/,
+        contains: [
+          {beginKeywords: ''},
+          hljs.UNDERSCORE_TITLE_MODE
+        ]
+      },
+      */
+      /*
+      {
+        className: 'function',
+        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
+        excludeEnd: true,
+        keywords: KEYWORDS,
+        contains: [
+          {
+            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true,
+            relevance: 0,
+            contains: [hljs.UNDERSCORE_TITLE_MODE]
+          },
+          {
+            className: 'params',
+            begin: /\(/, end: /\)/,
+            keywords: KEYWORDS,
+            relevance: 0,
+            contains: [
+              hljs.APOS_STRING_MODE,
+              hljs.QUOTE_STRING_MODE,
+              hljs.C_NUMBER_MODE,
+              hljs.C_BLOCK_COMMENT_MODE
+            ]
+          },
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      */
+      FDEPL_NUMBER_MODE,
+      {
+        className: 'meta', begin: '@[A-Za-z]+'
+      }
+    ]
+  };
+}

--- a/src/languages/franca.js
+++ b/src/languages/franca.js
@@ -1,0 +1,109 @@
+/*
+Language: Franca IDL
+Author: Klaus Birken <klaus.birken@gmail.com>
+Category: common, idl
+*/
+
+function(hljs) {
+  var GENERIC_IDENT_RE = hljs.UNDERSCORE_IDENT_RE + '(<' + hljs.UNDERSCORE_IDENT_RE + '(\\s*,\\s*' + hljs.UNDERSCORE_IDENT_RE + ')*>)?';
+  var KEYWORDS =
+    'package import model from typeCollection interface ' +
+    'version major minor ' +
+    'attribute method broadcast in out error ' +
+    'readonly noSubscriptions fireAndForget selective manages ' +
+    'array of struct union typedef is map to enumeration extends polymorphic ' +
+    'Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Integer minInt maxInt ' +
+    'Boolean String Float Double ByteBuffer const true false ' +
+    'contract PSM vars state transition initial call respond signal set update';
+
+  var FRANCA_NUMBER_RE = '\\b' +
+    '(' +
+      '0[bB]([01]+[01_]+[01]+|[01]+)' + // 0b...
+      '|' +
+      '0[xX]([a-fA-F0-9]+[a-fA-F0-9_]+[a-fA-F0-9]+|[a-fA-F0-9]+)' + // 0x...
+      '|' +
+      '(' +
+        '([\\d]+[\\d_]+[\\d]+|[\\d]+)(\\.([\\d]+[\\d_]+[\\d]+|[\\d]+))?' +
+        '|' +
+        '\\.([\\d]+[\\d_]+[\\d]+|[\\d]+)' +
+      ')' +
+      '([eE][-+]?\\d+)?' + // octal, decimal, float
+    ')' +
+    '[lLfF]?';
+  var FRANCA_NUMBER_MODE = {
+    className: 'number',
+    begin: FRANCA_NUMBER_RE,
+    relevance: 0
+  };
+
+  var COMMENTS = [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.COMMENT(
+        '<\\*\\*',
+        '\\*\\*>',
+        {
+          relevance : 0
+        }
+      ),
+      hljs.COMMENT(
+        '/\\*\\*',
+        '\\*/',
+        {
+          relevance : 0
+        }
+      )
+  ];
+  
+  return {
+    keywords: KEYWORDS,
+    illegal: /<\/|#/,
+    contains: [
+      hljs.APOS_STRING_MODE,
+      hljs.QUOTE_STRING_MODE,
+      {
+        className: 'interface',
+        beginKeywords: 'interface typeCollection', end: /[{;=]/, excludeEnd: true,
+        keywords: 'interface typeCollection',
+        illegal: /[:"\[\]]/,
+        contains: [
+          {beginKeywords: 'extends implements'},
+          hljs.UNDERSCORE_TITLE_MODE
+        ]
+      },
+      /*
+      {
+        className: 'function',
+        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
+        excludeEnd: true,
+        keywords: KEYWORDS,
+        contains: [
+          {
+            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true,
+            relevance: 0,
+            contains: [hljs.UNDERSCORE_TITLE_MODE]
+          },
+          {
+            className: 'params',
+            begin: /\(/, end: /\)/,
+            keywords: KEYWORDS,
+            relevance: 0,
+            contains: [
+              hljs.APOS_STRING_MODE,
+              hljs.QUOTE_STRING_MODE,
+              hljs.C_NUMBER_MODE,
+              hljs.C_BLOCK_COMMENT_MODE
+            ]
+          },
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      */
+      FRANCA_NUMBER_MODE,
+      {
+        className: 'meta', begin: '@[A-Za-z]+'
+      }
+    ].concat(COMMENTS)
+  };
+}

--- a/test/detect/fdepl/default.txt
+++ b/test/detect/fdepl/default.txt
@@ -1,0 +1,19 @@
+// import the actual Franca interfaces we want to deploy 
+import "classpath:/org/example/idl/SimpleInterface.fidl"
+
+/**
+ * One example deployment of SimpleInterface according to specification SimpleSpec.
+ */
+define org.example.spec.SimpleSpec for interface org.example.idl.SimpleInterface
+{
+	method m1 {
+		in {
+			arg1 { Encoding = utf8 }
+		}
+	}
+
+	struct SomeStruct {
+		f1 { Encoding = utf8 }
+		f2 { Encoding = utf8 }
+	}
+}

--- a/test/detect/franca/default.txt
+++ b/test/detect/franca/default.txt
@@ -1,0 +1,41 @@
+/**
+ * @author John Smith <john.smith@example.com>
+*/
+interface MediaPlayer {
+	version { major 4 minor 2 }
+
+	<** @description: Playlist which is currently active. **>
+	attribute Playlist currentPlaylist
+
+	<** @description: Append another track to the playlist. **>
+	method appendTrack {
+		in {
+			TrackId trackId
+		}
+	}
+	
+	<** @description: Indicate end of playlist. **>
+	broadcast endOfPlaylist { }	
+
+	<** @description : Repeat modes for playback. **>
+	enumeration RepeatMode {
+		MODE_REPEAT_NONE   = 0
+		MODE_REPEAT_SINGLE = 1
+		MODE_REPEAT_ALL    = 2
+	}
+
+	<** @description: Track metadata. **>
+	struct TrackInfo {
+		String title
+		String album
+		String interpret
+		String composer
+		String genre
+		Year year
+		Duration trackLength
+	}
+
+	<** @description: Simple playlist (as an array of track ids). **>
+	array Playlist of TrackId
+
+}


### PR DESCRIPTION
I created language support for the two languages of the Franca project:
- "franca": Franca IDL
- "fdepl": Franca Deployment models

Franca is an open-source project which provides an Interface Definition Language (IDL) and tools around this IDL. It is used heavily in the Automotive domain (e.g., for building car navigation systems), but also in other domains. Here is [Franca's github page](https://github.com/franca/franca/tree/master) for more information.

I introduced a new category "idl". I didn't find a category with the same semantics, so I suppose it should be added. There are more IDLs, e.g. Thrift, Protobuf, OMG IDL. Probably someone will add them in future and finds the category useful.

Disclaimer: I am quite new to the highlight.js business :-). I used the "java" language support as a starting point. The highlighting for Franca seems to work here, but there might be some room to improve implementation-wise. Please feel free to suggest improvements.
