### PR TITLE
Add support for Beancount markup language

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -236,3 +236,4 @@ Contributors:
 - Sergey Sobko <s.sobko@profitware.ru>
 - Hale Chan <halechan@qq.com>
 - Matt Evans <syrius3@gmail.com>
+- Henrique Bastos <henrique@bastos.net>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -236,3 +236,4 @@ URL:   https://highlightjs.org/
 - Сергей Собко <s.sobko@profitware.ru>
 - Хейл Чан <halechan@qq.com>
 - Мэт Эванс <syrius3@gmail.com>
+- Henrique Бастос <henrique@bastos.net>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ New languages
 
 - *Hy* by [Sergey Sobko][]
 - *Leaf* by [Hale Chan][]
+- *Beancount* by [Henrique Bastos][]
 
 Improvements:
 
@@ -19,6 +20,7 @@ Improvements:
 [Hale Chan]: https://github.com/halechan
 [Matt Evans]: https://github.com/matthewevans
 [Joe Blow]: https://github.com/mossarelli
+[Henrique Bastos]: https://github.com/henriquebastos
 
 
 ## Version 9.9.0

--- a/src/languages/beancount.js
+++ b/src/languages/beancount.js
@@ -1,0 +1,101 @@
+/*
+Language: Beancount
+Author: Henrique Bastos <henrique@bastos.net>
+Description: Double-Entry Accounting from Text Files
+*/
+function(hljs) {
+    var ACCOUNT_RE = '[A-Z][A-Za-z0-9\-]*';
+
+    var COMMODITY_RE = '[A-Z][A-Z0-9\'._\\-]{0,22}[A-Z0-9]';
+
+    var DATE_RE = '[0-9]{4}[\\-|/][0-9]{2}[\\-|/][0-9]{2}'
+
+    var ACCOUNT = {
+        className: 'type',
+        begin: ACCOUNT_RE + ':',
+        contains: [
+            {
+                className: 'subst',
+                begin: ACCOUNT_RE + ':?'
+            }
+        ]
+    }
+
+    var AMOUNT = {
+        className: 'literal',
+        begin: /([\-|\+]?)([\d]+[\.]?[\d]*)/
+    };
+
+    var COMMENT = hljs.COMMENT(';', '$');
+
+    var DATE = {
+        className: 'type',
+        begin: '^' + DATE_RE,
+    }
+
+    var LINK = {
+        className: 'link',
+        begin: /\^[A-Za-z0-9\-_/.]+/
+    }
+
+    var META = {
+        className: 'meta',
+        begin: /^\s{2,}[a-z][A-Za-z0-9\-_]+:/
+    }
+
+    var ORGMODE = {
+        className: 'section',
+        begin: /^\*\s+?.*/
+    }
+
+    var STRING = {
+        className: 'string',
+        begin: '"', end: '"',
+        contains: [hljs.BACKSLASH_ESCAPE]
+    }
+
+    var TAG = {
+        className: ['emphasis'],
+        begin: /#[A-Za-z0-9\-_/.]+/
+    }
+
+    var PRICE = {
+        className: 'name',
+        begin: '@'
+    }
+
+    var COST = {
+        className: 'name',
+        begin: '\\{',
+        end: '\\}',
+        contains: [
+            DATE, AMOUNT, STRING,
+            // Commodity
+            {
+                className: 'subst',
+                begin: COMMODITY_RE
+            }
+        ]
+    }
+
+    return {
+        aliases: ['beancount', 'bean', 'ledger'],
+        keywords:
+            'balance commodity custom document event include' +
+            'note open option pad plugin popmeta poptag price' +
+            'pushmeta pushtag query',
+        contains: [
+            COMMENT,
+            STRING,
+            DATE,
+            META,
+            AMOUNT,
+            COST,
+            PRICE,
+            ACCOUNT,
+            ORGMODE,
+            LINK,
+            TAG
+        ]
+    }
+}

--- a/test/detect/beancount/default.txt
+++ b/test/detect/beancount/default.txt
@@ -10,14 +10,14 @@ option "operating_currency" "BRL"
 1792-01-01 commodity USD
     name: "US Dollar"
 
-2017-01-01 open Assets:Cash
+2017-01-01 open Assets:My:Cash
 2017-01-01 open Expenses:Taxes
 2017-01-01 open Income:Sales
 
 2017-01-02 * "Payee" "Narration" ^txn-link
-    Income:Sales                                   180.00 BRL #xmas
-    Assets:Cash                                    -90.00 USD @ 0.50 BRL
+    Income:Sales                              180.00 BRL #xmas
+    Assets:My:Cash                            -90.00 USD @ 0.50 BRL
 
 2017-01-03 ! "" "Exchanging"
-    Assets:Cash                                    300.00 BRL ; trip to US.
-    Assets:Cash                                   -100.00 USD {300.00 BRL, "ref-001"}
+    Assets:My:Cash                            300.00 BRL ; trip to US.
+    Assets:My:Cash                           -100.00 USD {300.00 BRL, "ref-001"}

--- a/test/detect/beancount/default.txt
+++ b/test/detect/beancount/default.txt
@@ -1,0 +1,23 @@
+;; -*- mode: org; mode: beancount; -*-
+* Options
+
+option "title" "My Book"
+option "operating_currency" "BRL"
+
+1994-07-01 commodity BRL
+    name: "Real"
+
+1792-01-01 commodity USD
+    name: "US Dollar"
+
+2017-01-01 open Assets:Cash
+2017-01-01 open Expenses:Taxes
+2017-01-01 open Income:Sales
+
+2017-01-02 * "Payee" "Narration" ^txn-link
+    Income:Sales                                   180.00 BRL #xmas
+    Assets:Cash                                    -90.00 USD @ 0.50 BRL
+
+2017-01-03 ! "" "Exchanging"
+    Assets:Cash                                    300.00 BRL ; trip to US.
+    Assets:Cash                                   -100.00 USD {300.00 BRL, "ref-001"}

--- a/test/markup/beancount/sample.expect.txt
+++ b/test/markup/beancount/sample.expect.txt
@@ -1,8 +1,8 @@
 <span class="hljs-comment">;; -*- mode: org; mode: beancount; -*-</span>
 <span class="hljs-section">* Options</span>
 
-<span class="hljs-keyword">option</span> <span class="hljs-string">"title"</span> <span class="hljs-string">"My Book"</span>
-<span class="hljs-keyword">option</span> <span class="hljs-string">"operating_currency"</span> <span class="hljs-string">"BRL"</span>
+<span class="hljs-built_in">option</span> <span class="hljs-string">"title"</span> <span class="hljs-string">"My Book"</span>
+<span class="hljs-built_in">option</span> <span class="hljs-string">"operating_currency"</span> <span class="hljs-string">"BRL"</span>
 
 <span class="hljs-type">1994-07-01</span> <span class="hljs-keyword">commodity</span> BRL
 <span class="hljs-meta">    name:</span> <span class="hljs-string">"Real"</span>
@@ -10,14 +10,14 @@
 <span class="hljs-type">1792-01-01</span> <span class="hljs-keyword">commodity</span> USD
 <span class="hljs-meta">    name:</span> <span class="hljs-string">"US Dollar"</span>
 
-<span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>
+<span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Assets:<span class="hljs-subst">My:Cash</span></span>
 <span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Expenses:<span class="hljs-subst">Taxes</span></span>
 <span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Income:<span class="hljs-subst">Sales</span></span>
 
-<span class="hljs-type">2017-01-02</span> * <span class="hljs-string">"Payee"</span> <span class="hljs-string">"Narration"</span> <span class="hljs-link">^txn-link</span>
-    <span class="hljs-type">Income:<span class="hljs-subst">Sales</span></span>                                   <span class="hljs-literal">180.00</span> BRL <span class="hljs-emphasis">#xmas</span>
-    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                    <span class="hljs-literal">-90.00</span> USD <span class="hljs-name">@</span> <span class="hljs-literal">0.50</span> BRL
+<span class="hljs-type">2017-01-02</span> <span class="hljs-variable">*</span> <span class="hljs-string">"Payee"</span> <span class="hljs-string">"Narration"</span> <span class="hljs-link">^txn-link</span>
+    <span class="hljs-type">Income:<span class="hljs-subst">Sales</span></span>                              <span class="hljs-literal">180.00</span> BRL <span class="hljs-emphasis">#xmas</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">My:Cash</span></span>                            <span class="hljs-literal">-90.00</span> USD <span class="hljs-name">@</span> <span class="hljs-literal">0.50</span> BRL
 
-<span class="hljs-type">2017-01-03</span> ! <span class="hljs-string">""</span> <span class="hljs-string">"Exchanging"</span>
-    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                    <span class="hljs-literal">300.00</span> BRL <span class="hljs-comment">; trip to US.</span>
-    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                   <span class="hljs-literal">-100.00</span> USD <span class="hljs-name">{<span class="hljs-literal">300.00</span> <span class="hljs-subst">BRL</span>, <span class="hljs-string">"ref-001"</span>}</span>
+<span class="hljs-type">2017-01-03</span> <span class="hljs-variable">!</span> <span class="hljs-string">""</span> <span class="hljs-string">"Exchanging"</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">My:Cash</span></span>                            <span class="hljs-literal">300.00</span> BRL <span class="hljs-comment">; trip to US.</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">My:Cash</span></span>                           <span class="hljs-literal">-100.00</span> USD <span class="hljs-name">{<span class="hljs-literal">300.00</span> <span class="hljs-subst">BRL</span>, <span class="hljs-string">"ref-001"</span>}</span>

--- a/test/markup/beancount/sample.expect.txt
+++ b/test/markup/beancount/sample.expect.txt
@@ -1,0 +1,23 @@
+<span class="hljs-comment">;; -*- mode: org; mode: beancount; -*-</span>
+<span class="hljs-section">* Options</span>
+
+<span class="hljs-keyword">option</span> <span class="hljs-string">"title"</span> <span class="hljs-string">"My Book"</span>
+<span class="hljs-keyword">option</span> <span class="hljs-string">"operating_currency"</span> <span class="hljs-string">"BRL"</span>
+
+<span class="hljs-type">1994-07-01</span> <span class="hljs-keyword">commodity</span> BRL
+<span class="hljs-meta">    name:</span> <span class="hljs-string">"Real"</span>
+
+<span class="hljs-type">1792-01-01</span> <span class="hljs-keyword">commodity</span> USD
+<span class="hljs-meta">    name:</span> <span class="hljs-string">"US Dollar"</span>
+
+<span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>
+<span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Expenses:<span class="hljs-subst">Taxes</span></span>
+<span class="hljs-type">2017-01-01</span> <span class="hljs-keyword">open</span> <span class="hljs-type">Income:<span class="hljs-subst">Sales</span></span>
+
+<span class="hljs-type">2017-01-02</span> * <span class="hljs-string">"Payee"</span> <span class="hljs-string">"Narration"</span> <span class="hljs-link">^txn-link</span>
+    <span class="hljs-type">Income:<span class="hljs-subst">Sales</span></span>                                   <span class="hljs-literal">180.00</span> BRL <span class="hljs-emphasis">#xmas</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                    <span class="hljs-literal">-90.00</span> USD <span class="hljs-name">@</span> <span class="hljs-literal">0.50</span> BRL
+
+<span class="hljs-type">2017-01-03</span> ! <span class="hljs-string">""</span> <span class="hljs-string">"Exchanging"</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                    <span class="hljs-literal">300.00</span> BRL <span class="hljs-comment">; trip to US.</span>
+    <span class="hljs-type">Assets:<span class="hljs-subst">Cash</span></span>                                   <span class="hljs-literal">-100.00</span> USD <span class="hljs-name">{<span class="hljs-literal">300.00</span> <span class="hljs-subst">BRL</span>, <span class="hljs-string">"ref-001"</span>}</span>

--- a/test/markup/beancount/sample.txt
+++ b/test/markup/beancount/sample.txt
@@ -10,14 +10,14 @@ option "operating_currency" "BRL"
 1792-01-01 commodity USD
     name: "US Dollar"
 
-2017-01-01 open Assets:Cash
+2017-01-01 open Assets:My:Cash
 2017-01-01 open Expenses:Taxes
 2017-01-01 open Income:Sales
 
 2017-01-02 * "Payee" "Narration" ^txn-link
-    Income:Sales                                   180.00 BRL #xmas
-    Assets:Cash                                    -90.00 USD @ 0.50 BRL
+    Income:Sales                              180.00 BRL #xmas
+    Assets:My:Cash                            -90.00 USD @ 0.50 BRL
 
 2017-01-03 ! "" "Exchanging"
-    Assets:Cash                                    300.00 BRL ; trip to US.
-    Assets:Cash                                   -100.00 USD {300.00 BRL, "ref-001"}
+    Assets:My:Cash                            300.00 BRL ; trip to US.
+    Assets:My:Cash                           -100.00 USD {300.00 BRL, "ref-001"}

--- a/test/markup/beancount/sample.txt
+++ b/test/markup/beancount/sample.txt
@@ -1,0 +1,23 @@
+;; -*- mode: org; mode: beancount; -*-
+* Options
+
+option "title" "My Book"
+option "operating_currency" "BRL"
+
+1994-07-01 commodity BRL
+    name: "Real"
+
+1792-01-01 commodity USD
+    name: "US Dollar"
+
+2017-01-01 open Assets:Cash
+2017-01-01 open Expenses:Taxes
+2017-01-01 open Income:Sales
+
+2017-01-02 * "Payee" "Narration" ^txn-link
+    Income:Sales                                   180.00 BRL #xmas
+    Assets:Cash                                    -90.00 USD @ 0.50 BRL
+
+2017-01-03 ! "" "Exchanging"
+    Assets:Cash                                    300.00 BRL ; trip to US.
+    Assets:Cash                                   -100.00 USD {300.00 BRL, "ref-001"}


### PR DESCRIPTION
This PR adds highlight support for [Beancount](http://furius.ca/beancount/), a plaintext accounting tool.

It's a first naive implementation with very good result. Thanks to Beancount simple and unambiguous syntax.