### PR TITLE
Change top example to use CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ library along with one of the styles and calling
 [`initHighlightingOnLoad`][1]:
 
 ```html
-<link rel="stylesheet" href="/path/to/styles/default.css">
-<script src="/path/to/highlight.pack.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/default.min.css">
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 ```
 


### PR DESCRIPTION
As a hello-world example, using the CDN versions is easier than finding and downloading the js&css