### PR TITLE
C++ highlighting improvements

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -6,6 +6,9 @@ Category: common, system
 */
 
 function(hljs) {
+
+  var IDENT_RE = '[a-zA-Z][<>\\w]*';
+
   var CPP_PRIMITIVE_TYPES = {
     className: 'keyword',
     begin: '\\b[a-z\\d_]*_t\\b'
@@ -100,6 +103,7 @@ function(hljs) {
   return {
     aliases: ['c', 'cc', 'h', 'c++', 'h++', 'hpp'],
     keywords: CPP_KEYWORDS,
+    lexemes: IDENT_RE,
     illegal: '</',
     contains: EXPRESSION_CONTAINS.concat([
       PREPROCESSOR,
@@ -109,7 +113,7 @@ function(hljs) {
         contains: ['self', CPP_PRIMITIVE_TYPES]
       },
       {
-        begin: hljs.IDENT_RE + '::',
+        begin: IDENT_RE + '::',
         keywords: CPP_KEYWORDS
       },
       {
@@ -134,7 +138,7 @@ function(hljs) {
       },
       {
         className: 'function',
-        begin: '(' + hljs.IDENT_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
+        begin: '(' + IDENT_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
         returnBegin: true, end: /[{;=]/,
         excludeEnd: true,
         keywords: CPP_KEYWORDS,

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -108,41 +108,12 @@ function(hljs) {
     contains: EXPRESSION_CONTAINS.concat([
       PREPROCESSOR,
       {
-        begin: '\\b(deque|list|queue|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<', end: '>',
-        keywords: CPP_KEYWORDS,
-        contains: ['self', CPP_PRIMITIVE_TYPES]
-      },
-      {
-        begin: IDENT_RE + '::',
-        keywords: CPP_KEYWORDS
-      },
-      {
-        // This mode covers expression context where we can't expect a function
-        // definition and shouldn't highlight anything that looks like one:
-        // `return some()`, `else if()`, `(x*sum(1, 2))`
-        variants: [
-          {begin: /=/, end: /;/},
-          {begin: /\(/, end: /\)/},
-          {beginKeywords: 'new throw return else', end: /;/}
-        ],
-        keywords: CPP_KEYWORDS,
-        contains: EXPRESSION_CONTAINS.concat([
-          {
-            begin: /\(/, end: /\)/,
-            keywords: CPP_KEYWORDS,
-            contains: EXPRESSION_CONTAINS.concat(['self']),
-            relevance: 0
-          }
-        ]),
-        relevance: 0
-      },
-      {
         className: 'function',
         begin: '(' + IDENT_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
         returnBegin: true, end: /[{;=]/,
         excludeEnd: true,
         keywords: CPP_KEYWORDS,
-        illegal: /[^\w\s\*&]/,
+        illegal: /[^<>\w\s\*&]/,
         contains: [
           {
             begin: FUNCTION_TITLE, returnBegin: true,
@@ -174,7 +145,37 @@ function(hljs) {
           {begin: /</, end: />/, contains: ['self']}, // skip generic stuff
           hljs.TITLE_MODE
         ]
-      }
+      },
+      {
+        begin: '\\b(deque|list|queue|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<', end: '>',
+        keywords: CPP_KEYWORDS,
+        contains: ['self', CPP_PRIMITIVE_TYPES]
+      },
+      {
+        begin: IDENT_RE + '::',
+        keywords: CPP_KEYWORDS
+      },
+      {
+        // This mode covers expression context where we can't expect a function
+        // definition and shouldn't highlight anything that looks like one:
+        // `return some()`, `else if()`, `(x*sum(1, 2))`
+        variants: [
+          {begin: /=/, end: /;/},
+          {begin: /\(/, end: /\)/},
+          {beginKeywords: 'new throw return else', end: /;/}
+        ],
+        keywords: CPP_KEYWORDS,
+        contains: EXPRESSION_CONTAINS.concat([
+          {
+            begin: /\(/, end: /\)/,
+            keywords: CPP_KEYWORDS,
+            contains: EXPRESSION_CONTAINS.concat(['self']),
+            relevance: 0
+          }
+        ]),
+        relevance: 0
+      },
+
     ]),
     exports: {
       preprocessor: PREPROCESSOR,

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -88,7 +88,7 @@ function(hljs) {
       'isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow ' +
       'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
       'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
-      'vfprintf vprintf vsprintf endl initializer_list unique_ptr',
+      'vfprintf vprintf vsprintf endl initializer_list unique_ptr optional variant',
     literal: 'true false nullptr NULL'
   };
 

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -68,6 +68,16 @@ function(hljs) {
 
   var FUNCTION_TITLE = hljs.IDENT_RE + '\\s*\\(';
 
+  var CPP_BUILTINS = 'string cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
+      'auto_ptr deque list queue stack vector map set bitset multiset multimap unordered_set ' +
+      'unordered_map unordered_multiset unordered_multimap array shared_ptr abort abs acos ' +
+      'asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp ' +
+      'fscanf isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper ' +
+      'isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow ' +
+      'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
+      'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
+      'vfprintf vprintf vsprintf endl initializer_list unique_ptr optional variant';
+
   var CPP_KEYWORDS = {
     keyword: 'int float while private char catch import module export virtual operator sizeof ' +
       'dynamic_cast|10 typedef const_cast|10 const for static_cast|10 union namespace ' +
@@ -80,15 +90,7 @@ function(hljs) {
       'atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong ' +
       'atomic_ullong new throw return ' +
       'and or not',
-    built_in: 'string cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
-      'auto_ptr deque list queue stack vector map set bitset multiset multimap unordered_set ' +
-      'unordered_map unordered_multiset unordered_multimap array shared_ptr abort abs acos ' +
-      'asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp ' +
-      'fscanf isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper ' +
-      'isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow ' +
-      'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
-      'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
-      'vfprintf vprintf vsprintf endl initializer_list unique_ptr optional variant',
+    built_in: CPP_BUILTINS,
     literal: 'true false nullptr NULL'
   };
 
@@ -147,7 +149,7 @@ function(hljs) {
         ]
       },
       {
-        begin: '\\b(deque|list|queue|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<', end: '>',
+        begin: '\\b(' + CPP_BUILTINS.split(' ').join('|') + ')\\s*<', end: '>',
         keywords: CPP_KEYWORDS,
         contains: ['self', CPP_PRIMITIVE_TYPES]
       },

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -169,7 +169,7 @@ function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'class struct', end: /[{;:]/,
+        beginKeywords: 'class struct using', end: /[{;:=]/,
         contains: [
           {begin: /</, end: />/, contains: ['self']}, // skip generic stuff
           hljs.TITLE_MODE

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -80,7 +80,7 @@ function(hljs) {
       'atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong ' +
       'atomic_ullong new throw return ' +
       'and or not',
-    built_in: 'std string cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
+    built_in: 'string cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
       'auto_ptr deque list queue stack vector map set bitset multiset multimap unordered_set ' +
       'unordered_map unordered_multiset unordered_multimap array shared_ptr abort abs acos ' +
       'asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp ' +


### PR DESCRIPTION
I hope you like this!

## Improvements

### Fix templates in function signatures

  #1502

This makes identifiers consume subsequent `<` or `>` symbols that are
there without spaces.  Because of how Highlight.js treats other
syntactic elements, I believe this is no problem, but may require
further testing.

### Mark using expressions as classes

This shows in "class/type" color the type alias in expressions of the
form:

```
    using my_type_alias = ...;
```