### PR TITLE
Highlight NGINX config files which have .conf extension

### DIFF
--- a/src/languages/nginx.js
+++ b/src/languages/nginx.js
@@ -68,7 +68,7 @@ function(hljs) {
   };
 
   return {
-    aliases: ['nginxconf'],
+    aliases: ['nginxconf','conf'],
     contains: [
       hljs.HASH_COMMENT_MODE,
       {


### PR DESCRIPTION
As I see in the [reference](https://github.com/isagalaev/highlight.js/blob/master/docs/css-classes-reference.rst) `.conf` extension isn't reserved yet. I think we can add this one, but I wonder why it hasn't added yet? Will it cause any conflicts? I'm not sure whether Apache (or others) also uses `.conf` extension, but it would be nice to highlight `.conf` files somehow.