### PR TITLE
Add ANTLR language

### DIFF
--- a/src/languages/antlr.js
+++ b/src/languages/antlr.js
@@ -6,8 +6,6 @@ Description: Language definition for grammar described using ANTLR
 */
 
 function(hljs) {
-    var ruleDeclarationRegEx = "^[a-z][a-z_]*";
-
   return {
     keywords: ['parser', 'grammar', 'options'],
     aliases: ['antlr'],

--- a/src/languages/antlr.js
+++ b/src/languages/antlr.js
@@ -1,0 +1,31 @@
+/*
+Language: Antlr
+Author: Bill Wagner <wiwagn@microsoft.com>
+Website: http://thebillwagner.com/
+Description: Language definition for grammar described using ANTLR
+*/
+
+function(hljs) {
+    var ruleDeclarationRegEx = "^[a-z][a-z_]*";
+
+  return {
+    keywords: ['parser', 'grammar', 'options'],
+    aliases: ['antlr'],
+    case_insensitive: false,
+    illegal: '<!--|-->|</|::|`|\\s=\\s',
+    contains: [
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
+      hljs.APOS_STRING_MODE,
+      {
+         className: 'title',
+         begin: '^' + hljs.UNDERSCORE_IDENT_RE,
+         relevance: 0
+      },
+      {
+          begin: ';|\\||:' // relevance booster
+      }
+    ]
+  };
+}

--- a/test/detect/antlr/default.txt
+++ b/test/detect/antlr/default.txt
@@ -1,0 +1,3 @@
+input
+    : input_section?
+    ;


### PR DESCRIPTION
Fixes #1290

I did not implement all the styles in that issue, but this does correctly recognize ANTLR, highlight grammar rules, recognize comments, and add ANTLR as a first class citizen for the set of languages that can be processed.