### PR TITLE
Added php to alias list

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -28,7 +28,7 @@ function(hljs) {
   };
   var NUMBER = {variants: [hljs.BINARY_NUMBER_MODE, hljs.C_NUMBER_MODE]};
   return {
-    aliases: ['php3', 'php4', 'php5', 'php6'],
+    aliases: ['php', 'php3', 'php4', 'php5', 'php6'],
     case_insensitive: true,
     keywords:
       'and include_once list abstract global private echo interface as static endswitch ' +


### PR DESCRIPTION
I could not get the syntax highlighting to work without doing this.