### PR TITLE
Add support for Metasploit Framework console output

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -252,3 +252,4 @@ Contributors:
 - Nicolas LLOBERA <nllobera@gmail.com>
 - Morten Piibeleht <morten.piibeleht@gmail.com>
 - Martin Clausen <martin.clausene@gmail.com>
+- Tod Beardsley <tod_beardsley@rapid7.com>

--- a/src/languages/metasploit.js
+++ b/src/languages/metasploit.js
@@ -10,15 +10,25 @@ function(hljs) {
     aliases: ['msf'],
     case_insensitive: false,
     keywords: {
-      keyword: 'msf|10 auxiliary|10 encoder exploit|10 nop payload post|5'
-    }
+      keyword: 'msf|10',
+      nomarkup: 'exploit auxiliary post nop encoder' // Helps classification
+    },
     contains: [
       {
-        className: 'print_status',
-        begin: '^\\[\\*\\]',
-	end:   ' ',
+        className: 'strong',
+        begin: '^\\[\\*\\]', end: ' ',
         relevance: 10
-      }
+      },
+      {
+        className: 'literal',
+        begin: '^\\[\\+\\]', end: ' ',
+        relevance: 10
+      },
+      {
+        className: 'number',
+        begin: '^\\[[-!]\\]', end: ' ',
+        relevance: 10
+      },
     ]
   }
 }

--- a/src/languages/metasploit.js
+++ b/src/languages/metasploit.js
@@ -1,0 +1,24 @@
+/*
+Language: Metasploit Framework Session
+Author: Tod Beardsley <tod_beardsley@rapid.com>
+Category: common
+Description: Metasploit Framework is an open source penetration testing framework, available at https://metasploit.com
+*/
+
+function(hljs) {
+  return {
+    aliases: ['msf'],
+    case_insensitive: false,
+    keywords: {
+      keyword: 'msf|10 auxiliary|10 encoder exploit|10 nop payload post|5'
+    }
+    contains: [
+      {
+        className: 'print_status',
+        begin: '^\\[\\*\\]',
+	end:   ' ',
+        relevance: 10
+      }
+    ]
+  }
+}

--- a/test/detect/metasploit/default.txt
+++ b/test/detect/metasploit/default.txt
@@ -1,0 +1,13 @@
+msf auxiliary(http_version) > rerun
+[*] Reloading module...
+
+[*] This is status!
+[+] This is good!
+[-] This is bad!
+[-] This is error!
+[!] This is warning!
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(http_version) > use exploit/windows/smb/ms08_067_netapi 
+msf exploit(ms08_067_netapi) > 
+


### PR DESCRIPTION
First time trying to create a definition for highlight.js, I think I'm doing it right, but I also think I'm abusing the built-in classnames.

What I think is more correct is to  invent a `className` of `print_good` and say that it should inherit from `literal` but I haven't figured out how to do that (ditto for the other classnames).

Anyway, my whole goal here is to provide minimal highlighting for Metasploit Framework output without it getting mistaken as shell/bash output (which is usually the case, so weird literals get highlighted).
