### PR TITLE
vim: backslashes in single quote are literal

### DIFF
--- a/src/languages/vim.js
+++ b/src/languages/vim.js
@@ -69,7 +69,11 @@ function(hljs) {
     illegal: /;/,
     contains: [
       hljs.NUMBER_MODE,
-      hljs.APOS_STRING_MODE,
+      {
+        className: 'string',
+        begin: '\'', end: '\'',
+        illegal: '\\n'
+      },
 
       /*
       A double quote can start either a string or a line comment. Strings are


### PR DESCRIPTION
This pull request solves #1637 