### PR TITLE
feat(solidity): Add lang highlighting for solidity

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -252,3 +252,4 @@ Contributors:
 - Nicolas LLOBERA <nllobera@gmail.com>
 - Morten Piibeleht <morten.piibeleht@gmail.com>
 - Martin Clausen <martin.clausene@gmail.com>
+- Kaustav Haldar <khaldar@uwaterloo.ca>

--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -1,0 +1,104 @@
+/*
+Language: Solidity
+Author: Kaustav Haldar <khaldar@uwaterloo.ca>
+*/
+
+function (hljs) {
+  var IDENT_RE = '[A-Za-z$_][0-9A-Za-z$_]*';
+
+	var NUMBER = {
+		className: 'number',
+	    variants: [
+		   // jacked from julia.js, should match ethereum addresses too
+	      { begin: /(\b0x[\d_]*(\.[\d_]*)?|0x\.\d[\d_]*)p[-+]?\d+|\b0[box][a-fA-F0-9][a-fA-F0-9_]*|(\b\d[\d_]*(\.[\d_]*)?|\.\d[\d_]*)([eEfF][-+]?\d+)?/ },
+	    ],
+	    relevance: 0
+	}
+	var COMMONS = {
+		contains: [
+		  hljs.C_LINE_COMMENT_MODE,
+	      hljs.C_BLOCK_COMMENT_MODE,
+	      hljs.APOS_STRING_MODE,
+	      hljs.QUOTE_STRING_MODE,
+	      NUMBER,
+	      hljs.REGEXP_MODE
+		]
+	}
+
+	var FUNC = {
+		className: 'function',
+		beginKeywords: 'function',
+		end: /\{/,
+		excludeEnd: true,
+        contains: [
+          hljs.inherit(hljs.TITLE_MODE, {begin: IDENT_RE}),
+          {
+            className: 'params',
+            begin: /\(/, end: /\)/,
+            excludeBegin: true,
+            excludeEnd: true,
+            contains: COMMONS.contains
+          }
+        ],
+        illegal: /\[|%/
+	}
+
+	var CONTRACT = {
+		className: 'class',
+		variants: [
+			{
+				begin: '/(contract|library|interface|struct)/'
+			}
+		],
+		relevance: 10,
+		end: /[{;=]/, 
+		excludeEnd: true,        
+		illegal: /[:"\[\]]/,
+		contains: COMMONS.contains
+	}
+
+	function getStr() {
+		return 
+		  'uint' + Array(256/8).fill().map(function(_, i) { (i+1)*8}).join(' uint') + ' ' +
+		  'uint' + Array(256/8).fill().map(function(_, i) { (i+1)*8}).join('[] uint') + ' ' +
+		  'int' + Array(256/8).fill().map(function(_, i) { (i+1)*8}).join(' int') + ' ' +
+		  'int' + Array(256/8).fill().map(function(_, i) { (i+1)*8}).join('[] int') + ' ' +
+		  'bytes' + Array(32).fill().map(function(_, i) { i+1}).join(' bytes') + ' ' +
+		  'bytes' + Array(32).fill().map(function(_, i) { i+1}).join('[] bytes') + ' ' +
+		  'fixed' + [].concat.apply(
+		  	[], Array(32).fill().map(function(_, i) {
+		  		Array(81).fill().map(function(_, j) {
+		  			((i+1)*8)+'x'+j
+		  		})
+		  	})
+		  	).join(' fixed') + ' ' +
+		  'ufixed' + [].concat.apply([], Array(32).fill().map(function(_, i) { Array(81).fill().map(function(_, j) { ((i+1)*8)+'x'+j})})).join(' ufixed');
+	}
+
+	var KEYWORDS = {
+		keyword: 
+		  'anonymous as assembly break constant continue do delete else external for hex if ' +
+		  'indexed internal import is mapping memory new payable public pragma ' +
+		  'private pure return returns storage super this throw using view while' +
+		  'var function event modifier struct enum contract library interface ' +
+		  'abstract after case catch default final in inline let match ' +
+		  'of relocatable static switch try type typeof'
+		  ,
+		literal: 'true false null',
+		built_in: 
+		  'block msg tx now suicide selfdestruct addmod mulmod sha3 keccak256 log ' +
+		  'sha256 ecrecover ripemd160 assert revert require ' +
+		  'bytes string address uint int bool byte ' + 
+		  'bytes[] string[] address[] uint[] int[] bool[] byte[] ' +
+		  'wei szabo finney ether seconds minutes hours days weeks years ' +
+		  getStr()
+		}
+
+	COMMONS = [].concat.apply(COMMONS.contains, [FUNC, CONTRACT])
+
+	return {
+		aliases: ['sol'],
+		keywords: KEYWORDS,
+		contains: COMMONS
+	}
+}

--- a/test/detect/solidity/default.txt
+++ b/test/detect/solidity/default.txt
@@ -1,0 +1,140 @@
+pragma solidity ^0.4.11;
+
+contract BlindAuction {
+    struct Bid {
+        bytes32 blindedBid;
+        uint deposit;
+    }
+
+    address public beneficiary;
+    uint public biddingEnd;
+    uint public revealEnd;
+    bool public ended;
+
+    mapping(address => Bid[]) public bids;
+
+    address public highestBidder;
+    uint public highestBid;
+
+    // Allowed withdrawals of previous bids
+    mapping(address => uint) pendingReturns;
+
+    event AuctionEnded(address winner, uint highestBid);
+
+    /// Modifiers are a convenient way to validate inputs to
+    /// functions. `onlyBefore` is applied to `bid` below:
+    /// The new function body is the modifier's body where
+    /// `_` is replaced by the old function body.
+    modifier onlyBefore(uint _time) { require(now < _time); _; }
+    modifier onlyAfter(uint _time) { require(now > _time); _; }
+
+    function BlindAuction(
+        uint _biddingTime,
+        uint _revealTime,
+        address _beneficiary
+    ) {
+        beneficiary = _beneficiary;
+        biddingEnd = now + _biddingTime;
+        revealEnd = biddingEnd + _revealTime;
+    }
+
+    /// Place a blinded bid with `_blindedBid` = keccak256(value,
+    /// fake, secret).
+    /// The sent ether is only refunded if the bid is correctly
+    /// revealed in the revealing phase. The bid is valid if the
+    /// ether sent together with the bid is at least "value" and
+    /// "fake" is not true. Setting "fake" to true and sending
+    /// not the exact amount are ways to hide the real bid but
+    /// still make the required deposit. The same address can
+    /// place multiple bids.
+    function bid(bytes32 _blindedBid)
+        payable
+        onlyBefore(biddingEnd)
+    {
+        bids[msg.sender].push(Bid({
+            blindedBid: _blindedBid,
+            deposit: msg.value
+        }));
+    }
+
+    /// Reveal your blinded bids. You will get a refund for all
+    /// correctly blinded invalid bids and for all bids except for
+    /// the totally highest.
+    function reveal(
+        uint[] _values,
+        bool[] _fake,
+        bytes32[] _secret
+    )
+        onlyAfter(biddingEnd)
+        onlyBefore(revealEnd)
+    {
+        uint length = bids[msg.sender].length;
+        require(_values.length == length);
+        require(_fake.length == length);
+        require(_secret.length == length);
+
+        uint refund;
+        for (uint i = 0; i < length; i++) {
+            var bid = bids[msg.sender][i];
+            var (value, fake, secret) =
+                    (_values[i], _fake[i], _secret[i]);
+            if (bid.blindedBid != keccak256(value, fake, secret)) {
+                // Bid was not actually revealed.
+                // Do not refund deposit.
+                continue;
+            }
+            refund += bid.deposit;
+            if (!fake && bid.deposit >= value) {
+                if (placeBid(msg.sender, value))
+                    refund -= value;
+            }
+            // Make it impossible for the sender to re-claim
+            // the same deposit.
+            bid.blindedBid = bytes32(0);
+        }
+        msg.sender.transfer(refund);
+    }
+
+    // This is an "internal" function which means that it
+    // can only be called from the contract itself (or from
+    // derived contracts).
+    function placeBid(address bidder, uint value) internal
+            returns (bool success)
+    {
+        if (value <= highestBid) {
+            return false;
+        }
+        if (highestBidder != 0) {
+            // Refund the previously highest bidder.
+            pendingReturns[highestBidder] += highestBid;
+        }
+        highestBid = value;
+        highestBidder = bidder;
+        return true;
+    }
+
+    /// Withdraw a bid that was overbid.
+    function withdraw() {
+        uint amount = pendingReturns[msg.sender];
+        if (amount > 0) {
+            // It is important to set this to zero because the recipient
+            // can call this function again as part of the receiving call
+            // before `transfer` returns (see the remark above about
+            // conditions -> effects -> interaction).
+            pendingReturns[msg.sender] = 0;
+
+            msg.sender.transfer(amount);
+        }
+    }
+
+    /// End the auction and send the highest bid
+    /// to the beneficiary.
+    function auctionEnd()
+        onlyAfter(revealEnd)
+    {
+        require(!ended);
+        AuctionEnded(highestBidder, highestBid);
+        ended = true;
+        beneficiary.transfer(highestBid);
+    }
+}

--- a/test/markup/solidity/bidding_contract.expected.txt
+++ b/test/markup/solidity/bidding_contract.expected.txt
@@ -1,0 +1,140 @@
+<span class="hljs-keyword">pragma</span> solidity ^<span class="hljs-number">0.4</span><span class="hljs-number">.11</span>;
+
+<span class="hljs-keyword">contract</span> BlindAuction {
+    <span class="hljs-keyword">struct</span> Bid {
+        <span class="hljs-built_in">bytes32</span> blindedBid;
+        <span class="hljs-built_in">uint</span> deposit;
+    }
+
+    <span class="hljs-built_in">address</span> <span class="hljs-keyword">public</span> beneficiary;
+    <span class="hljs-built_in">uint</span> <span class="hljs-keyword">public</span> biddingEnd;
+    <span class="hljs-built_in">uint</span> <span class="hljs-keyword">public</span> revealEnd;
+    <span class="hljs-built_in">bool</span> <span class="hljs-keyword">public</span> ended;
+
+    <span class="hljs-keyword">mapping</span>(<span class="hljs-built_in">address</span> =&gt; Bid[]) <span class="hljs-keyword">public</span> bids;
+
+    <span class="hljs-built_in">address</span> <span class="hljs-keyword">public</span> highestBidder;
+    <span class="hljs-built_in">uint</span> <span class="hljs-keyword">public</span> highestBid;
+
+    <span class="hljs-comment">// Allowed withdrawals of previous bids</span>
+    <span class="hljs-keyword">mapping</span>(<span class="hljs-built_in">address</span> =&gt; <span class="hljs-built_in">uint</span>) pendingReturns;
+
+    <span class="hljs-keyword">event</span> AuctionEnded(<span class="hljs-built_in">address</span> winner, <span class="hljs-built_in">uint</span> highestBid);
+
+    <span class="hljs-comment">/// Modifiers are a convenient way to validate inputs to</span>
+    <span class="hljs-comment">/// functions. `onlyBefore` is applied to `bid` below:</span>
+    <span class="hljs-comment">/// The new function body is the modifier's body where</span>
+    <span class="hljs-comment">/// `_` is replaced by the old function body.</span>
+    <span class="hljs-keyword">modifier</span> onlyBefore(<span class="hljs-built_in">uint</span> _time) { <span class="hljs-built_in">require</span>(<span class="hljs-built_in">now</span> &lt; _time); _; }
+    <span class="hljs-keyword">modifier</span> onlyAfter(<span class="hljs-built_in">uint</span> _time) { <span class="hljs-built_in">require</span>(<span class="hljs-built_in">now</span> &gt; _time); _; }
+
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">BlindAuction</span>(<span class="hljs-params">
+        uint _biddingTime,
+        uint _revealTime,
+        address _beneficiary
+    </span>) </span>{
+        beneficiary = _beneficiary;
+        biddingEnd = <span class="hljs-built_in">now</span> + _biddingTime;
+        revealEnd = biddingEnd + _revealTime;
+    }
+
+    <span class="hljs-comment">/// Place a blinded bid with `_blindedBid` = keccak256(value,</span>
+    <span class="hljs-comment">/// fake, secret).</span>
+    <span class="hljs-comment">/// The sent ether is only refunded if the bid is correctly</span>
+    <span class="hljs-comment">/// revealed in the revealing phase. The bid is valid if the</span>
+    <span class="hljs-comment">/// ether sent together with the bid is at least "value" and</span>
+    <span class="hljs-comment">/// "fake" is not true. Setting "fake" to true and sending</span>
+    <span class="hljs-comment">/// not the exact amount are ways to hide the real bid but</span>
+    <span class="hljs-comment">/// still make the required deposit. The same address can</span>
+    <span class="hljs-comment">/// place multiple bids.</span>
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">bid</span>(<span class="hljs-params">bytes32 _blindedBid</span>)
+        <span class="hljs-title">payable</span>
+        <span class="hljs-title">onlyBefore</span>(<span class="hljs-params">biddingEnd</span>)
+    </span>{
+        bids[<span class="hljs-built_in">msg</span>.sender].push(Bid({
+            blindedBid: _blindedBid,
+            deposit: <span class="hljs-built_in">msg</span>.value
+        }));
+    }
+
+    <span class="hljs-comment">/// Reveal your blinded bids. You will get a refund for all</span>
+    <span class="hljs-comment">/// correctly blinded invalid bids and for all bids except for</span>
+    <span class="hljs-comment">/// the totally highest.</span>
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">reveal</span>(<span class="hljs-params">
+        uint[] _values,
+        bool[] _fake,
+        bytes32[] _secret
+    </span>)
+        <span class="hljs-title">onlyAfter</span>(<span class="hljs-params">biddingEnd</span>)
+        <span class="hljs-title">onlyBefore</span>(<span class="hljs-params">revealEnd</span>)
+    </span>{
+        <span class="hljs-built_in">uint</span> length = bids[<span class="hljs-built_in">msg</span>.sender].length;
+        <span class="hljs-built_in">require</span>(_values.length == length);
+        <span class="hljs-built_in">require</span>(_fake.length == length);
+        <span class="hljs-built_in">require</span>(_secret.length == length);
+
+        <span class="hljs-built_in">uint</span> refund;
+        <span class="hljs-keyword">for</span> (<span class="hljs-built_in">uint</span> i = <span class="hljs-number">0</span>; i &lt; length; i++) {
+            var bid = bids[<span class="hljs-built_in">msg</span>.sender][i];
+            var (value, fake, secret) =
+                    (_values[i], _fake[i], _secret[i]);
+            <span class="hljs-keyword">if</span> (bid.blindedBid != <span class="hljs-built_in">keccak256</span>(value, fake, secret)) {
+                <span class="hljs-comment">// Bid was not actually revealed.</span>
+                <span class="hljs-comment">// Do not refund deposit.</span>
+                <span class="hljs-keyword">continue</span>;
+            }
+            refund += bid.deposit;
+            <span class="hljs-keyword">if</span> (!fake &amp;&amp; bid.deposit &gt;= value) {
+                <span class="hljs-keyword">if</span> (placeBid(<span class="hljs-built_in">msg</span>.sender, value))
+                    refund -= value;
+            }
+            <span class="hljs-comment">// Make it impossible for the sender to re-claim</span>
+            <span class="hljs-comment">// the same deposit.</span>
+            bid.blindedBid = <span class="hljs-built_in">bytes32</span>(<span class="hljs-number">0</span>);
+        }
+        <span class="hljs-built_in">msg</span>.sender.transfer(refund);
+    }
+
+    <span class="hljs-comment">// This is an "internal" function which means that it</span>
+    <span class="hljs-comment">// can only be called from the contract itself (or from</span>
+    <span class="hljs-comment">// derived contracts).</span>
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">placeBid</span>(<span class="hljs-params">address bidder, uint value</span>) <span class="hljs-title">internal</span>
+            <span class="hljs-title">returns</span> (<span class="hljs-params">bool success</span>)
+    </span>{
+        <span class="hljs-keyword">if</span> (value &lt;= highestBid) {
+            <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
+        }
+        <span class="hljs-keyword">if</span> (highestBidder != <span class="hljs-number">0</span>) {
+            <span class="hljs-comment">// Refund the previously highest bidder.</span>
+            pendingReturns[highestBidder] += highestBid;
+        }
+        highestBid = value;
+        highestBidder = bidder;
+        <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
+    }
+
+    <span class="hljs-comment">/// Withdraw a bid that was overbid.</span>
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">withdraw</span>(<span class="hljs-params"></span>) </span>{
+        <span class="hljs-built_in">uint</span> amount = pendingReturns[<span class="hljs-built_in">msg</span>.sender];
+        <span class="hljs-keyword">if</span> (amount &gt; <span class="hljs-number">0</span>) {
+            <span class="hljs-comment">// It is important to set this to zero because the recipient</span>
+            <span class="hljs-comment">// can call this function again as part of the receiving call</span>
+            <span class="hljs-comment">// before `transfer` returns (see the remark above about</span>
+            <span class="hljs-comment">// conditions -&gt; effects -&gt; interaction).</span>
+            pendingReturns[<span class="hljs-built_in">msg</span>.sender] = <span class="hljs-number">0</span>;
+
+            <span class="hljs-built_in">msg</span>.sender.transfer(amount);
+        }
+    }
+
+    <span class="hljs-comment">/// End the auction and send the highest bid</span>
+    <span class="hljs-comment">/// to the beneficiary.</span>
+    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">auctionEnd</span>(<span class="hljs-params"></span>)
+        <span class="hljs-title">onlyAfter</span>(<span class="hljs-params">revealEnd</span>)
+    </span>{
+        <span class="hljs-built_in">require</span>(!ended);
+        AuctionEnded(highestBidder, highestBid);
+        ended = <span class="hljs-literal">true</span>;
+        beneficiary.transfer(highestBid);
+    }
+}

--- a/test/markup/solidity/bidding_contract.txt
+++ b/test/markup/solidity/bidding_contract.txt
@@ -1,0 +1,140 @@
+pragma solidity ^0.4.11;
+
+contract BlindAuction {
+    struct Bid {
+        bytes32 blindedBid;
+        uint deposit;
+    }
+
+    address public beneficiary;
+    uint public biddingEnd;
+    uint public revealEnd;
+    bool public ended;
+
+    mapping(address => Bid[]) public bids;
+
+    address public highestBidder;
+    uint public highestBid;
+
+    // Allowed withdrawals of previous bids
+    mapping(address => uint) pendingReturns;
+
+    event AuctionEnded(address winner, uint highestBid);
+
+    /// Modifiers are a convenient way to validate inputs to
+    /// functions. `onlyBefore` is applied to `bid` below:
+    /// The new function body is the modifier's body where
+    /// `_` is replaced by the old function body.
+    modifier onlyBefore(uint _time) { require(now < _time); _; }
+    modifier onlyAfter(uint _time) { require(now > _time); _; }
+
+    function BlindAuction(
+        uint _biddingTime,
+        uint _revealTime,
+        address _beneficiary
+    ) {
+        beneficiary = _beneficiary;
+        biddingEnd = now + _biddingTime;
+        revealEnd = biddingEnd + _revealTime;
+    }
+
+    /// Place a blinded bid with `_blindedBid` = keccak256(value,
+    /// fake, secret).
+    /// The sent ether is only refunded if the bid is correctly
+    /// revealed in the revealing phase. The bid is valid if the
+    /// ether sent together with the bid is at least "value" and
+    /// "fake" is not true. Setting "fake" to true and sending
+    /// not the exact amount are ways to hide the real bid but
+    /// still make the required deposit. The same address can
+    /// place multiple bids.
+    function bid(bytes32 _blindedBid)
+        payable
+        onlyBefore(biddingEnd)
+    {
+        bids[msg.sender].push(Bid({
+            blindedBid: _blindedBid,
+            deposit: msg.value
+        }));
+    }
+
+    /// Reveal your blinded bids. You will get a refund for all
+    /// correctly blinded invalid bids and for all bids except for
+    /// the totally highest.
+    function reveal(
+        uint[] _values,
+        bool[] _fake,
+        bytes32[] _secret
+    )
+        onlyAfter(biddingEnd)
+        onlyBefore(revealEnd)
+    {
+        uint length = bids[msg.sender].length;
+        require(_values.length == length);
+        require(_fake.length == length);
+        require(_secret.length == length);
+
+        uint refund;
+        for (uint i = 0; i < length; i++) {
+            var bid = bids[msg.sender][i];
+            var (value, fake, secret) =
+                    (_values[i], _fake[i], _secret[i]);
+            if (bid.blindedBid != keccak256(value, fake, secret)) {
+                // Bid was not actually revealed.
+                // Do not refund deposit.
+                continue;
+            }
+            refund += bid.deposit;
+            if (!fake && bid.deposit >= value) {
+                if (placeBid(msg.sender, value))
+                    refund -= value;
+            }
+            // Make it impossible for the sender to re-claim
+            // the same deposit.
+            bid.blindedBid = bytes32(0);
+        }
+        msg.sender.transfer(refund);
+    }
+
+    // This is an "internal" function which means that it
+    // can only be called from the contract itself (or from
+    // derived contracts).
+    function placeBid(address bidder, uint value) internal
+            returns (bool success)
+    {
+        if (value <= highestBid) {
+            return false;
+        }
+        if (highestBidder != 0) {
+            // Refund the previously highest bidder.
+            pendingReturns[highestBidder] += highestBid;
+        }
+        highestBid = value;
+        highestBidder = bidder;
+        return true;
+    }
+
+    /// Withdraw a bid that was overbid.
+    function withdraw() {
+        uint amount = pendingReturns[msg.sender];
+        if (amount > 0) {
+            // It is important to set this to zero because the recipient
+            // can call this function again as part of the receiving call
+            // before `transfer` returns (see the remark above about
+            // conditions -> effects -> interaction).
+            pendingReturns[msg.sender] = 0;
+
+            msg.sender.transfer(amount);
+        }
+    }
+
+    /// End the auction and send the highest bid
+    /// to the beneficiary.
+    function auctionEnd()
+        onlyAfter(revealEnd)
+    {
+        require(!ended);
+        AuctionEnded(highestBidder, highestBid);
+        ended = true;
+        beneficiary.transfer(highestBid);
+    }
+}


### PR DESCRIPTION
Solidity is Ethereums contract oriented language. 
It comes up in a few github repos but github doesnt have syntax highlighting for it yet. 
This is a rudimentary attempt to add syntax highlighting for it.

Sources:  
 - [Solidity Docs](https://solidity.readthedocs.io/en/develop/)  
 -  [Solidity Lexer from docs](https://github.com/ethereum/solidity/blob/b8d59422d15adcbbf4e0df24c12cf03f9a584aa1/docs/utils/SolidityLexer.py)  
- [Solidity lexer from sublime text plugin](https://github.com/davidhq/SublimeEthereum/blob/master/Solidity.YAML-tmLanguage)