### PR TITLE
Add An Old Hope syntax theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ too big. If you don't see the language you need in the ["Common" section][5],
 it can be added manually:
 
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/go.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
 ```
 
 **On Almond.** You need to use the optimizer to give the module a name. For

--- a/src/styles/an-old-hope.css
+++ b/src/styles/an-old-hope.css
@@ -1,0 +1,90 @@
+/* 
+
+An Old Hope – Star Wars Syntax
+Redesigned Gustavo Costa
+Original theme - Ocean Dark Theme – by https://github.com/gavsiu
+Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/JesseLeite/an-old-hope-syntax-atom
+
+*/
+
+/* Death Star Comment */
+.hljs-comment,
+.hljs-quote 
+{
+  color: #B6B18B;
+}
+
+/* Darth Vader */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-deletion 
+{
+  color: #EB3C54;
+}
+
+/* Threepio */
+.hljs-number,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params,
+.hljs-meta,
+.hljs-link 
+{
+  color: #E7CE56;
+}
+
+/* Luke Skywalker */
+.hljs-attribute 
+{
+  color: #EE7C2B;
+}
+
+/* Obi Wan Kenobi */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition 
+{
+  color: #4FB4D7;
+}
+
+/* Yoda */
+.hljs-title,
+.hljs-section 
+{
+  color: #78BB65;
+}
+
+/* Mace Windu */
+.hljs-keyword,
+.hljs-selector-tag 
+{
+  color: #B45EA4;
+}
+
+/* Millenium Falcon */
+.hljs 
+{
+  display: block;
+  overflow-x: auto;
+  background: #1C1D21;
+  color: #c0c5ce;
+  padding: 0.5em;
+}
+
+.hljs-emphasis 
+{
+  font-style: italic;
+}
+
+.hljs-strong 
+{
+  font-weight: bold;
+}

--- a/src/styles/an-old-hope.css
+++ b/src/styles/an-old-hope.css
@@ -1,7 +1,6 @@
 /* 
 
-An Old Hope – Star Wars Syntax
-Redesigned Gustavo Costa
+An Old Hope – Star Wars Syntax (c) Gustavo Costa <gusbemacbe@gmail.com>
 Original theme - Ocean Dark Theme – by https://github.com/gavsiu
 Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/JesseLeite/an-old-hope-syntax-atom
 


### PR DESCRIPTION
Hi @isagalaev!

As the film Star Wars VIII is arriving, I took an advantage to fork and rebuilt the theme of @gavsiu 

This syntax theme was based on @JesseLeite's Atom highlighting syntax theme. This is a Star Wars theme. 

### Colours:

* Red: Darth Vader (his lightsaber and because he ws a Sith)
* Light gold: Death Star
* Orange: Luke Skywalker (his rebel clothing)
* Black and white: Millennium Falcon
* Blue: Obi Wan Kenobi (his lightsaber)
* Yellow: C-3PO or Threepio
* Green: Yoda (his skin)

### Demo:

https://gusbemacbe.github.io/old-hope-highlightjs-demo/

This theme can be modified if you want. 

