### PR TITLE
Fix mismatched PHP close tag inside string in XML source

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -33,7 +33,6 @@ function(hljs) {
     ]
   };
   var PHP_STRING = {
-    className: 'string',
     contains: [hljs.BACKSLASH_ESCAPE, {begin: /<\?(php)?|\?>/}],
     variants: [
       {
@@ -44,7 +43,8 @@ function(hljs) {
       },
       hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
       hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null})
-    ]
+    ],
+    skip: true
   };
   return {
     aliases: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist'],

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -41,8 +41,8 @@ function(hljs) {
       {
         begin: 'b\'', end: '\''
       },
-      hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
-      hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null})
+      hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null, className: null}),
+      hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null, className: null})
     ],
     skip: true
   };

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -56,15 +56,18 @@ function(hljs) {
       {
         className: 'meta',
         begin: /<\?xml/, end: /\?>/, relevance: 10
-      }, {
+      },
+      {
         begin: /<\?(php)?/, end: /\?>/,
         subLanguage: 'php',
         contains: [
+          // We don't want the php closing tag ?> to close the PHP block when
+          // inside any of the following blocks:
           {begin: '/\\*', end: '\\*/', skip: true},
           {begin: 'b"', end: '"', skip: true},
           {begin: 'b\'', end: '\'', skip: true},
-          hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null, className: null, skip: true}),
-          hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null, className: null, skip: true})
+          hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null, className: null, contains: null, skip: true}),
+          hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null, className: null, contains: null, skip: true})
         ]
       },
       {

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -32,6 +32,20 @@ function(hljs) {
       }
     ]
   };
+  var PHP_STRING = {
+    className: 'string',
+    contains: [hljs.BACKSLASH_ESCAPE, {begin: /<\?(php)?|\?>/}],
+    variants: [
+      {
+        begin: 'b"', end: '"'
+      },
+      {
+        begin: 'b\'', end: '\''
+      },
+      hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
+      hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null})
+    ]
+  };
   return {
     aliases: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist'],
     case_insensitive: true,
@@ -60,7 +74,7 @@ function(hljs) {
       {
         begin: /<\?(php)?/, end: /\?>/,
         subLanguage: 'php',
-        contains: [{begin: '/\\*', end: '\\*/', skip: true}]
+        contains: [{begin: '/\\*', end: '\\*/', skip: true}, PHP_STRING]
       },
       {
         className: 'tag',

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -32,20 +32,6 @@ function(hljs) {
       }
     ]
   };
-  var PHP_STRING = {
-    contains: [hljs.BACKSLASH_ESCAPE, {begin: /<\?(php)?|\?>/}],
-    variants: [
-      {
-        begin: 'b"', end: '"'
-      },
-      {
-        begin: 'b\'', end: '\''
-      },
-      hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null, className: null}),
-      hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null, className: null})
-    ],
-    skip: true
-  };
   return {
     aliases: ['html', 'xhtml', 'rss', 'atom', 'xjb', 'xsd', 'xsl', 'plist'],
     case_insensitive: true,
@@ -70,11 +56,16 @@ function(hljs) {
       {
         className: 'meta',
         begin: /<\?xml/, end: /\?>/, relevance: 10
-      },
-      {
+      }, {
         begin: /<\?(php)?/, end: /\?>/,
         subLanguage: 'php',
-        contains: [{begin: '/\\*', end: '\\*/', skip: true}, PHP_STRING]
+        contains: [
+          {begin: '/\\*', end: '\\*/', skip: true},
+          {begin: 'b"', end: '"', skip: true},
+          {begin: 'b\'', end: '\'', skip: true},
+          hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null, className: null, skip: true}),
+          hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null, className: null, skip: true})
+        ]
       },
       {
         className: 'tag',


### PR DESCRIPTION
I noticed this bug has been fixed for the PHP source a while ago, but it still existed when parsing PHP embedded in an XML/HTML file.

Example source to test:

```php
<?php
if ($something)
{
	echo "This PHP string contains a closing tag. ?>";
	"this string doesn't get highlighted";
}
?>
<!DOCTYPE html>
```