### PR TITLE
Fixed syntax highlighting for floating points in C#

### DIFF
--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -1,7 +1,7 @@
 /*
 Language: C#
 Author: Jason Diamond <jason@diamond.name>
-Contributor: Nicolas LLOBERA <nllobera@gmail.com>
+Contributor: Nicolas LLOBERA <nllobera@gmail.com>, Pieter Vantorre <pietervantorre@gmail.com>
 Category: common
 */
 
@@ -21,7 +21,15 @@ function(hljs) {
     literal:
       'null false true'
   };
-
+  var NUMBERS = {
+    className: 'number',
+    variants: [
+      { begin: '\\b(0b[01\']+)' },
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
+      { begin: '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)' }
+    ],
+    relevance: 0
+  };
   var VERBATIM_STRING = {
     className: 'string',
     begin: '@"', end: '"',
@@ -55,7 +63,7 @@ function(hljs) {
     VERBATIM_STRING,
     hljs.APOS_STRING_MODE,
     hljs.QUOTE_STRING_MODE,
-    hljs.C_NUMBER_MODE,
+    NUMBERS,
     hljs.C_BLOCK_COMMENT_MODE
   ];
   SUBST_NO_LF.contains = [
@@ -64,7 +72,7 @@ function(hljs) {
     VERBATIM_STRING_NO_LF,
     hljs.APOS_STRING_MODE,
     hljs.QUOTE_STRING_MODE,
-    hljs.C_NUMBER_MODE,
+    NUMBERS,
     hljs.inherit(hljs.C_BLOCK_COMMENT_MODE, {illegal: /\n/})
   ];
   var STRING = {
@@ -117,7 +125,7 @@ function(hljs) {
         }
       },
       STRING,
-      hljs.C_NUMBER_MODE,
+      NUMBERS,
       {
         beginKeywords: 'class interface', end: /[{;=]/,
         illegal: /[^\s:,]/,
@@ -170,7 +178,7 @@ function(hljs) {
             relevance: 0,
             contains: [
               STRING,
-              hljs.C_NUMBER_MODE,
+              NUMBERS,
               hljs.C_BLOCK_COMMENT_MODE
             ]
           },

--- a/test/markup/cs/floats.expect.txt
+++ b/test/markup/cs/floats.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-keyword">float</span> test = <span class="hljs-number">1.0f</span>;
+<span class="hljs-keyword">float</span> test2 = <span class="hljs-number">1.f</span>;
+<span class="hljs-keyword">float</span> test3 = <span class="hljs-number">1.0</span>;
+<span class="hljs-keyword">float</span> test4 = <span class="hljs-number">1</span>;

--- a/test/markup/cs/floats.txt
+++ b/test/markup/cs/floats.txt
@@ -1,0 +1,4 @@
+float test = 1.0f;
+float test2 = 1.f;
+float test3 = 1.0;
+float test4 = 1;


### PR DESCRIPTION
Numbers regexp copied from c++.

Before:
```
<span class="hljs-keyword">float</span> test = <span class="hljs-number">1.0</span>f;
```
After:
```
<span class="hljs-keyword">float</span> test = <span class="hljs-number">1.0f</span>;
```
