### PR TITLE
Improvements to the Xcode theme

### DIFF
--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -12,6 +12,11 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
   color: black;
 }
 
+/* Gray DOCTYPE selectors like WebKit */
+.xml .hljs-meta {
+  color: #c0c0c0;
+}
+
 .hljs-comment,
 .hljs-quote {
   color: #007400;

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -14,53 +14,59 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 
 .hljs-comment,
 .hljs-quote {
-  color: #006a00;
+  color: #007400;
 }
 
+.hljs-tag,
+.hljs-attribute,
 .hljs-keyword,
 .hljs-selector-tag,
-.hljs-literal {
-  color: #aa0d91;
-}
-
+.hljs-literal,
 .hljs-name {
-  color: #008;
+  color: #aa0d91;
 }
 
 .hljs-variable,
 .hljs-template-variable {
-  color: #660;
+  color: #3F6E74;
 }
 
-.hljs-string {
+.hljs-code,
+.hljs-string,
+.hljs-meta-string {
   color: #c41a16;
 }
 
 .hljs-regexp,
 .hljs-link {
-  color: #080;
+  color: #0E0EFF;
 }
 
 .hljs-title,
-.hljs-tag,
 .hljs-symbol,
 .hljs-bullet,
-.hljs-number,
-.hljs-meta {
+.hljs-number {
   color: #1c00cf;
 }
 
 .hljs-section,
+.hljs-meta {
+  color: #643820;
+}
+
+
 .hljs-class .hljs-title,
 .hljs-type,
-.hljs-attr,
 .hljs-built_in,
 .hljs-builtin-name,
 .hljs-params {
   color: #5c2699;
 }
 
-.hljs-attribute,
+.hljs-attr {
+  color: #836C28;
+}
+
 .hljs-subst {
   color: #000;
 }


### PR DESCRIPTION
Updated a few color rules in the Xcode theme to better match Xcode.
This also makes the HTML inspector look more like the WebKit/Blink web inspectors.

### Before:

Objective-C:
![screen shot 2018-02-15 at 3 21 23 pm](https://user-images.githubusercontent.com/6258309/36279088-f27289ca-1263-11e8-84cd-d258438c06c5.png) 

HTML:
![screen shot 2018-02-15 at 3 27 16 pm](https://user-images.githubusercontent.com/6258309/36279328-be75bf38-1264-11e8-9413-d916b36f582c.png)

Markdown:
![screen shot 2018-02-15 at 3 37 12 pm](https://user-images.githubusercontent.com/6258309/36279805-53fde124-1266-11e8-8d0a-5d388b248400.png)


### After:

Objective-C:
![screen shot 2018-02-15 at 3 20 00 pm](https://user-images.githubusercontent.com/6258309/36279087-f24601c0-1263-11e8-8787-5ccab893cfed.png) 

HTML:
![screen shot 2018-02-15 at 3 25 38 pm](https://user-images.githubusercontent.com/6258309/36279279-86f1a5ea-1264-11e8-8cd9-8eddef78cfef.png)

Markdown:
![screen shot 2018-02-15 at 3 37 41 pm](https://user-images.githubusercontent.com/6258309/36279813-5995e8a2-1266-11e8-82f6-118251c20b9d.png)


### Actual screenshots from Xcode:
(not the nicest ones I have taken)

Objective-C:
![screen shot 2018-02-15 at 3 34 20 pm](https://user-images.githubusercontent.com/6258309/36279655-bc2a2844-1265-11e8-89b6-30609fe3a0d4.png)

HTML:
![screen shot 2018-02-15 at 3 31 08 pm](https://user-images.githubusercontent.com/6258309/36279495-4d8b5e12-1265-11e8-97b3-dbc52ddbd93c.png)

Markdown:
![screen shot 2018-02-15 at 3 38 22 pm](https://user-images.githubusercontent.com/6258309/36279816-5c9f5a6a-1266-11e8-852c-5191527b59a8.png)
