### PR TITLE
Add some keywords newly appended in Kotlin v1.1 & v1.2

### DIFF
--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -9,7 +9,7 @@ function(hljs) {
     keyword:
       'abstract as val var vararg get set class object open private protected public noinline ' +
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
-      'import package is in fun override companion reified inline lateinit init' +
+      'import package is in fun override companion reified inline lateinit init ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
       // new from kotlin 1.1 & 1.2
       'suspend typealias external expect actual ' +

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -11,9 +11,7 @@ function(hljs) {
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
       'import package is in fun override companion reified inline lateinit init ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
-      'tailrec where const inner ' +
-      // new from kotlin 1.1 & 1.2
-      'suspend typealias external expect actual ' +
+      'tailrec where const inner suspend typealias external expect actual ' +
       // to be deleted soon
       'trait volatile transient native default',
     built_in:

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -11,6 +11,8 @@ function(hljs) {
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
       'import package is in fun override companion reified inline lateinit init' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
+      // new from kotlin 1.1 & 1.2
+      'suspend typealias external expect actual ' +
       // to be deleted soon
       'trait volatile transient native default',
     built_in:
@@ -78,6 +80,29 @@ function(hljs) {
         ]
       }
     ]
+  };
+
+  // https://kotlinlang.org/docs/reference/whatsnew11.html#underscores-in-numeric-literals
+  // According to the doc above, the number mode of kotlin is the same as java 8,
+  // so the code below is copied from java.js
+  var KOTLIN_NUMBER_RE = '\\b' +
+    '(' +
+      '0[bB]([01]+[01_]+[01]+|[01]+)' + // 0b...
+      '|' +
+      '0[xX]([a-fA-F0-9]+[a-fA-F0-9_]+[a-fA-F0-9]+|[a-fA-F0-9]+)' + // 0x...
+      '|' +
+      '(' +
+        '([\\d]+[\\d_]+[\\d]+|[\\d]+)(\\.([\\d]+[\\d_]+[\\d]+|[\\d]+))?' +
+        '|' +
+        '\\.([\\d]+[\\d_]+[\\d]+|[\\d]+)' +
+      ')' +
+      '([eE][-+]?\\d+)?' + // octal, decimal, float
+    ')' +
+    '[lLfF]?';
+  var KOTLIN_NUMBER_MODE = {
+    className: 'number',
+    begin: KOTLIN_NUMBER_RE,
+    relevance: 0
   };
 
   return {
@@ -173,7 +198,7 @@ function(hljs) {
         begin: "^#!/usr/bin/env", end: '$',
         illegal: '\n'
       },
-      hljs.C_NUMBER_MODE
+      KOTLIN_NUMBER_MODE
     ]
   };
 }

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -11,6 +11,7 @@ function(hljs) {
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
       'import package is in fun override companion reified inline lateinit init ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
+      'tailrec where const inner ' +
       // new from kotlin 1.1 & 1.2
       'suspend typealias external expect actual ' +
       // to be deleted soon


### PR DESCRIPTION
The new keywords in Kotlin 1.1
- [suspend](https://kotlinlang.org/docs/reference/coroutines.html#suspending-functions)
- [typealias](https://kotlinlang.org/docs/reference/whatsnew11.html#type-aliases)
- [external](https://kotlinlang.org/docs/reference/whatsnew11.html#the-external-modifier)

And the ones in Kotlin 1.2
- [expect & actual](https://kotlinlang.org/docs/reference/whatsnew12.html#multiplatform-projects-experimental)

Moreover, I have updated the number mode of Kotlin as the description [here](https://kotlinlang.org/docs/reference/whatsnew11.html#underscores-in-numeric-literals). I copied the code from [java.js](https://github.com/isagalaev/highlight.js/blob/master/src/languages/java.js) since I found the both's modes are the same.