### PR TITLE
added language for emacs org-mode

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -272,3 +272,4 @@ Contributors:
 - Antoine Boisier-Michaud <aboisiermichaud@gmail.com>
 - Alejandro Isaza <al@isaza.ca>
 - Laurent Voullemier <laurent.voullemier@gmail.com>
+- Jörn Reimerdes <joern.reimerdes@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Master
 
 New languages:
+- *emacs org-mode* A markup language see [https://orgmode.org]
 
 New styles:
 

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -1,0 +1,158 @@
+/*
+Language: emacs org-mode
+Requires: xml.js
+Author: Jörn Reimerdes <joern.reimerdes@gmail.com>
+Category: common, markup
+*/
+
+function(hljs) {
+  return {
+    aliases: ['org', 'org-mode'],
+    contains: [
+      // highlight headers
+      {
+        className: 'section',
+        begin: /^\*{0,6} /,
+        end: /$/
+      },
+      // inline html - TODO
+      {
+        begin: '<', end: '>',
+        subLanguage: 'xml',
+        relevance: 0
+      },
+      // lists (indicators only)
+      {
+        className: 'bullet',
+        begin: /^([+-]|(\d+\.))\s+/
+      },
+      // strong segments
+      {
+        className: 'strong',
+        begin: /\*((\S.*?\S)|(\S))\*/
+      },
+      // deleted segments
+      {
+        className: 'deletion',
+        begin: /\+((\S.*?\S)|(\S))\+/,
+        relevance: 0
+      },
+      // underline segments
+      {
+        className: 'underline',
+        begin: /_((\S.*?\S)|(\S))_/
+      },
+      // emphasis segments
+      {
+        className: 'emphasis',
+        variants: [
+          { begin: /\/((\S.*?\S)|(\S))\// },
+        ]
+      },
+      // table rows
+      {
+        className: 'table',
+        begin: /\|-*\+-*/, end: /\|/ ,
+        relevance:1
+        },
+      {
+        className: 'table',
+        begin: /\|/, end: /\|/ ,
+        relevance:0,
+        excludeBegin:false,
+        excludeEnd:false,
+        returnEnd: false,
+        returnBegin: true,
+        contians: [
+          {
+             //className: 'link',
+             begin: /\|/, end: /\|/,
+             excludeBegin: true, excludeEnd: true,
+             subLanguage: 'orgmode'
+           }
+         ]
+      },
+      // blockquotes
+      {
+        className: 'quote',
+        keywords: 'BEGIN_QUOTE END_QUOTE ',
+        begin: /^#\+BEGIN_QUOTE.*$/, end: /^#\+END_QUOTE.*$/
+      },
+      // code snippets
+      {
+        className: 'code',
+        keywords: 'BEGIN_SRC END_SRC BEGIN_EXAMPLE END_EXAMPLE',
+        variants: [
+          {
+            begin: /^#\+BEGIN_SRC.*$/, end: /^#\+END_SRC.*$/
+          },
+          {
+            begin: /^#\+BEGIN_EXAMPLE.*$/, end: /^#\+END_EXAMPLE.*$/
+          },
+          {
+            begin: /~((\S.*?\S)|(\S))~/
+          },
+          {
+            begin: /=((\S.*?\S)|(\S))=/
+          }
+        ]
+      },
+      // attributes
+      {
+        className: 'attribute',
+        variants: [
+        {
+          begin: /^\s*#\+.*$/
+        }
+      ]
+      },
+      // Tags
+      {
+        className: 'tags',
+        variants: [
+          {
+            begin: /TODO/
+          },
+          {
+            begin: /DONE/
+          }
+        ]
+      },
+      // horizontal rules
+      {
+        className: 'meta',
+        begin: /^-{5,}/, end: /$/
+      },
+
+      // using links - title and link
+      {
+        begin: /\[\[.+?\][\[\[].*?[\]\]]\]/,
+        returnBegin: true,
+        contains: [
+          {
+            className: 'link',
+            begin: /\[\[/, end: /\]/,
+            excludeBegin: true, excludeEnd: true
+          },
+          {
+            className: 'symbol',
+            begin: /\[/, end: /\]\]/,
+            excludeBegin: true, excludeEnd: true
+          }
+        ],
+        relevance: 10
+      },
+      {
+        begin: /\[\[[^\n]+\]\]/,
+        returnBegin: true,
+        contains: [
+          {
+            className: 'link',
+            begin: /\[\[/, end: /\]\]/,
+            excludeBegin: true, excludeEnd: true
+          }
+        ]
+      }
+    ]
+  };
+}

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -31,21 +31,21 @@ function(hljs) {
       // strong segments
       {
         className: 'strong',
-          begin: /\*((\S.*?\S)|(\S))\*/,
+          begin: /\s\*((\S.*?\S)|(\S))\*\s/,
           relevance:0
 
       },
       // deleted segments
       {
         className: 'deletion',
-          begin: /\+((\S.*?\S)|(\S))\+/,
+          begin: /\s\+((\S.*?\S)|(\S))\+\s/,
           relevance:0
 
       },
       // underline segments
       {
         className: 'underline',
-        begin: /_((\S.*?\S)|(\S))_/,
+        begin: /\s_((\S.*?\S)|(\S))_\s/,
         relevance:0
       },
       // emphasis segments
@@ -53,7 +53,7 @@ function(hljs) {
         className: 'emphasis',
         relevance:0,
         variants: [
-          { begin: /\/((\S.*?\S)|(\S))\// },
+          { begin: /\s\/((\S.*?\S)|(\S))\/\s/ },
         ]
       },
       // table rows

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -13,9 +13,10 @@ function(hljs) {
       {
         className: 'section',
         begin: /^\*{0,6} /,
-        end: /$/
+        end: /$/,
+        relevance:0
       },
-      // inline html - TODO
+      // inline html
       {
         begin: '<', end: '>',
         subLanguage: 'xml',
@@ -24,27 +25,33 @@ function(hljs) {
       // lists (indicators only)
       {
         className: 'bullet',
-        begin: /^([+-]|(\d+\.))\s+/
+        begin: /^([+-]|(\d+\.))\s+/,
+        relevance:0
       },
       // strong segments
       {
         className: 'strong',
-        begin: /\*((\S.*?\S)|(\S))\*/
+          begin: /\*((\S.*?\S)|(\S))\*/,
+          relevance:0
+
       },
       // deleted segments
       {
         className: 'deletion',
-        begin: /\+((\S.*?\S)|(\S))\+/,
-        relevance: 0
+          begin: /\+((\S.*?\S)|(\S))\+/,
+          relevance:0
+
       },
       // underline segments
       {
         className: 'underline',
-        begin: /_((\S.*?\S)|(\S))_/
+        begin: /_((\S.*?\S)|(\S))_/,
+        relevance:0
       },
       // emphasis segments
       {
         className: 'emphasis',
+        relevance:0,
         variants: [
           { begin: /\/((\S.*?\S)|(\S))\// },
         ]
@@ -53,7 +60,7 @@ function(hljs) {
       {
         className: 'table',
         begin: /\|-*\+-*/, end: /\|/ ,
-        relevance:1
+        relevance:10
         },
       {
         className: 'table',
@@ -65,7 +72,6 @@ function(hljs) {
         returnBegin: true,
         contians: [
           {
-             //className: 'link',
              begin: /\|/, end: /\|/,
              excludeBegin: true, excludeEnd: true,
              subLanguage: 'orgmode'
@@ -76,7 +82,8 @@ function(hljs) {
       {
         className: 'quote',
         keywords: 'BEGIN_QUOTE END_QUOTE ',
-        begin: /^#\+BEGIN_QUOTE.*$/, end: /^#\+END_QUOTE.*$/
+        begin: /^#\+BEGIN_QUOTE.*$/, end: /^#\+END_QUOTE.*$/,
+        relevance: 10
       },
       // code snippets
       {
@@ -84,13 +91,16 @@ function(hljs) {
         keywords: 'BEGIN_SRC END_SRC BEGIN_EXAMPLE END_EXAMPLE',
         variants: [
           {
-            begin: /^#\+BEGIN_SRC.*$/, end: /^#\+END_SRC.*$/
+            begin: /^#\+BEGIN_SRC.*$/, end: /^#\+END_SRC.*$/,
+            relevance: 10
           },
           {
-            begin: /^#\+BEGIN_EXAMPLE.*$/, end: /^#\+END_EXAMPLE.*$/
+            begin: /^#\+BEGIN_EXAMPLE.*$/, end: /^#\+END_EXAMPLE.*$/,
+            relevance: 10
           },
           {
-            begin: /~((\S.*?\S)|(\S))~/
+            begin: /~((\S.*?\S)|(\S))~/,
+            relevance: 10
           },
           {
             begin: /=((\S.*?\S)|(\S))=/
@@ -102,7 +112,8 @@ function(hljs) {
         className: 'attribute',
         variants: [
         {
-          begin: /^\s*#\+.*$/
+          begin: /^\s*#\+.*$/,
+          relevance: 10
         }
       ]
       },
@@ -127,6 +138,7 @@ function(hljs) {
       // using links - title and link
       {
         begin: /\[\[.+?\][\[\[].*?[\]\]]\]/,
+        relevance:10,
         returnBegin: true,
         contains: [
           {
@@ -139,11 +151,11 @@ function(hljs) {
             begin: /\[/, end: /\]\]/,
             excludeBegin: true, excludeEnd: true
           }
-        ],
-        relevance: 10
+        ]
       },
       {
         begin: /\[\[[^\n]+\]\]/,
+        relevance:0,
         returnBegin: true,
         contains: [
           {

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -25,7 +25,7 @@ function(hljs) {
       // lists (indicators only)
       {
         className: 'bullet',
-        begin: /^([+-]|(\d+\.))\s+/,
+        begin: /^\s*([+-]|(\d+\.)|[a-zA-Z]\.)\s+/,
         relevance:0
       },
       // strong segments

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -12,7 +12,7 @@ function(hljs) {
       // highlight headers
       {
         className: 'section',
-        begin: /^\*{0,6} /,
+        begin: /^\*{1,6} /,
         end: /$/,
         relevance:0
       },

--- a/src/languages/orgmode.js
+++ b/src/languages/orgmode.js
@@ -1,10 +1,9 @@
 /*
 Language: emacs org-mode
-Requires: xml.js
+Requires: lisp.js
 Author: Jörn Reimerdes <joern.reimerdes@gmail.com>
 Category: common, markup
 */
-
 function(hljs) {
   return {
     aliases: ['org', 'org-mode'],
@@ -31,16 +30,14 @@ function(hljs) {
       // strong segments
       {
         className: 'strong',
-          begin: /\s\*((\S.*?\S)|(\S))\*\s/,
-          relevance:0
-
+        begin: /\s\*((\S.*?\S)|(\S))\*\s/,
+        relevance:0
       },
       // deleted segments
       {
         className: 'deletion',
-          begin: /\s\+((\S.*?\S)|(\S))\+\s/,
-          relevance:0
-
+        begin: /\s\+((\S.*?\S)|(\S))\+\s/,
+        relevance:0
       },
       // underline segments
       {
@@ -91,7 +88,7 @@ function(hljs) {
         keywords: 'BEGIN_SRC END_SRC BEGIN_EXAMPLE END_EXAMPLE',
         variants: [
           {
-            begin: /^#\+BEGIN_SRC.*$/, end: /^#\+END_SRC.*$/,
+            begin: /^#\+BEGIN_SRC/, end: /^#\+END_SRC$/,
             relevance: 10
           },
           {
@@ -111,10 +108,31 @@ function(hljs) {
       {
         className: 'attribute',
         variants: [
-        {
-          begin: /^\s*#\+.*$/,
-          relevance: 10
-        }
+            {
+                begin: /^\s*#\+NAME.*$/,
+                relevance: 10
+            },
+            {
+                begin: /^\s*#\+STARTUP.*$/,
+                relevance: 10
+            },
+            {
+                begin: /^\s*#\+ATTR_ORG.*$/,
+                relevance: 10
+            },
+            {
+                begin: /^\s*#\+RESULTS.*$/,
+                relevance: 10
+            },
+            {
+                begin: /^\s*#\+TBLFM.*$/,
+                relevance: 10
+            },
+     // conflicts with code environment
+     //   {
+     //    begin: /^\s*#\+.*$/,
+     //    relevance: 10
+     //   }
       ]
       },
       // Tags

--- a/test/detect/orgmode/default.txt
+++ b/test/detect/orgmode/default.txt
@@ -1,0 +1,37 @@
+* hello world
+
+you can write text [[http://example.com][with links]] inline or [[http://example.com]].
+
+- one /thing/ has /em/phasis
+- two *things* are *bold*
+- two +things+ are +deleted+
+- two _things_ are _underlined_
+ 
+* hello world again
+
+#+BEGIN_SRC html
+<script type="text/javascript" src="org.js"></script>
+#+END_SRC
+
+because org-mode is cool
+
+#+NAME: Table
+|---------+--------+------------|
+|         | Symbol | Author     |
+|---------+--------+------------|
+| *Emacs* | ~M-x~  | /RMS/      |
+|---------+--------+------------|
+| *Vi*    | ~:~    | /Bill Joy/ |
+|---------+--------+------------|
+
+#+BEGIN_SRC
+    so are code segments
+#+END_SRC
+
+1. one thing (yeah!)
+2. two thing ~i can write code~, and =more= wipee!
+
+#+BEGIN_QUOTE
+To be or not to be, that is the question.
+#+END_QUOTE
+

--- a/test/detect/orgmode/default.txt
+++ b/test/detect/orgmode/default.txt
@@ -1,37 +1,17 @@
-* hello world
+* section
+** subsection
 
-you can write text [[http://example.com][with links]] inline or [[http://example.com]].
+you can write text [[http://example.com][with links]] 
 
 - one /thing/ has /em/phasis
 - two *things* are *bold*
 - two +things+ are +deleted+
 - two _things_ are _underlined_
  
-* hello world again
-
-#+BEGIN_SRC html
-<script type="text/javascript" src="org.js"></script>
-#+END_SRC
+* section 2
 
 because org-mode is cool
 
-#+NAME: Table
-|---------+--------+------------|
-|         | Symbol | Author     |
-|---------+--------+------------|
-| *Emacs* | ~M-x~  | /RMS/      |
-|---------+--------+------------|
-| *Vi*    | ~:~    | /Bill Joy/ |
-|---------+--------+------------|
-
-#+BEGIN_SRC
-    so are code segments
-#+END_SRC
-
 1. one thing (yeah!)
 2. two thing ~i can write code~, and =more= wipee!
-
-#+BEGIN_QUOTE
-To be or not to be, that is the question.
-#+END_QUOTE
 

--- a/test/markup/orgmode/code.expect.txt
+++ b/test/markup/orgmode/code.expect.txt
@@ -8,10 +8,10 @@ you can write text [[<span class="hljs-link">http://example.com</span>][<span cl
 </span><span class="hljs-bullet">- </span>two_<span class="hljs-underline"> _things_ </span>are<span class="hljs-underline"> _underlined._
 </span> 
 <span class="hljs-section">* hello world again</span>
-<span class="hljs-attribute">
-#+BEGIN_SRC html</span>
-<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text/javascript"</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"org.js"</span>&gt;</span><span class="undefined"></span></span><span class="xml"><span class="undefined"></span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></span>
-<span class="hljs-attribute">#+END_SRC</span>
+
+<span class="hljs-code">#+<span class="hljs-keyword">BEGIN_SRC</span> html
+&lt;script type="text/javascript" src="org.js"&gt;&lt;/script&gt;
+#+<span class="hljs-keyword">END_SRC</span></span>
 
 because org-mode is cool
 <span class="hljs-attribute">
@@ -23,14 +23,15 @@ because org-mode is cool
 <span class="hljs-table">|---------+--------+------------|</span>
 <span class="hljs-table">|</span><span class="hljs-strong"> *Vi* </span>   <span class="hljs-table">|</span> <span class="hljs-code">~:~</span>    <span class="hljs-table">|</span><span class="hljs-emphasis"> /Bill Joy/ </span><span class="hljs-table">|</span>
 <span class="hljs-table">|---------+--------+------------|</span>
-<span class="hljs-attribute">
-#+BEGIN_SRC</span>
+
+<span class="hljs-code">#+<span class="hljs-keyword">BEGIN_SRC</span>
     so are code segments
-<span class="hljs-attribute">#+END_SRC</span>
+#+<span class="hljs-keyword">END_SRC</span></span>
 <span class="hljs-bullet">
 1. </span>one thing (yeah!)
 <span class="hljs-bullet">2. </span>two thing <span class="hljs-code">~i can write code~</span>, and <span class="hljs-code">=more=</span> wipee!
-<span class="hljs-attribute">
-#+BEGIN_QUOTE</span>
+
+<span class="hljs-quote">#+<span class="hljs-keyword">BEGIN_QUOTE</span>
 To be or not to be, that is the question.
-<span class="hljs-attribute">#+END_QUOTE</span>
+#+<span class="hljs-keyword">END_QUOTE</span></span>
+

--- a/test/markup/orgmode/code.expect.txt
+++ b/test/markup/orgmode/code.expect.txt
@@ -1,0 +1,36 @@
+<span class="hljs-section">* hello world</span>
+
+you can write text [[<span class="hljs-link">http://example.com</span>][<span class="hljs-symbol">with links</span>]] inline or [[<span class="hljs-link">http://example.com</span>]].
+
+<span class="hljs-bullet">- </span>one <span class="hljs-emphasis">/thing/</span> has <span class="hljs-emphasis">/em/</span>phasis
+<span class="hljs-bullet">- </span>two <span class="hljs-strong">*things*</span> are <span class="hljs-strong">*bold*</span>
+<span class="hljs-bullet">- </span>two <span class="hljs-deletion">+things+</span> are <span class="hljs-deletion">+deleted+</span>
+<span class="hljs-bullet">- </span>two <span class="hljs-underline">_things_</span> are <span class="hljs-underline">_underlined_</span>
+<span class="hljs-section"> </span>
+<span class="hljs-section">* hello world again</span>
+<span class="hljs-attribute">
+#+BEGIN_SRC html</span>
+<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">script</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"text/javascript"</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"org.js"</span>&gt;</span><span class="undefined"></span></span><span class="xml"><span class="undefined"></span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></span>
+<span class="hljs-attribute">#+END_SRC</span>
+
+because org-mode is cool
+<span class="hljs-attribute">
+#+NAME: Table</span>
+<span class="hljs-table">|---------+--------+------------|</span>
+<span class="hljs-table">|</span>         <span class="hljs-table">|</span> Symbol <span class="hljs-table">|</span> Author     <span class="hljs-table">|</span>
+<span class="hljs-table">|---------+--------+------------|</span>
+<span class="hljs-table">|</span> <span class="hljs-strong">*Emacs*</span> <span class="hljs-table">|</span> <span class="hljs-code">~M-x~</span>  <span class="hljs-table">|</span> <span class="hljs-emphasis">/RMS/</span>      <span class="hljs-table">|</span>
+<span class="hljs-table">|---------+--------+------------|</span>
+<span class="hljs-table">|</span> <span class="hljs-strong">*Vi*</span>    <span class="hljs-table">|</span> <span class="hljs-code">~:~</span>    <span class="hljs-table">|</span> <span class="hljs-emphasis">/Bill Joy/</span> <span class="hljs-table">|</span>
+<span class="hljs-table">|---------+--------+------------|</span>
+<span class="hljs-attribute">
+#+BEGIN_SRC</span>
+<span class="hljs-section">    so are code segments</span>
+<span class="hljs-attribute">#+END_SRC</span>
+
+<span class="hljs-bullet">1. </span>one thing (yeah!)
+<span class="hljs-bullet">2. </span>two thing <span class="hljs-code">~i can write code~</span>, and <span class="hljs-code">=more=</span> wipee!
+<span class="hljs-attribute">
+#+BEGIN_QUOTE</span>
+To be or not to be, that is the question.
+<span class="hljs-attribute">#+END_QUOTE</span>

--- a/test/markup/orgmode/code.expect.txt
+++ b/test/markup/orgmode/code.expect.txt
@@ -2,11 +2,11 @@
 
 you can write text [[<span class="hljs-link">http://example.com</span>][<span class="hljs-symbol">with links</span>]] inline or [[<span class="hljs-link">http://example.com</span>]].
 <span class="hljs-bullet">
-- </span>one <span class="hljs-emphasis">/thing/</span> has <span class="hljs-emphasis">/em/</span>phasis
-<span class="hljs-bullet">- </span>two <span class="hljs-strong">*things*</span> are <span class="hljs-strong">*bold*</span>
-<span class="hljs-bullet">- </span>two <span class="hljs-deletion">+things+</span> are <span class="hljs-deletion">+deleted+</span>
-<span class="hljs-bullet">- </span>two <span class="hljs-underline">_things_</span> are <span class="hljs-underline">_underlined_</span>
- 
+- </span>one/<span class="hljs-emphasis"> /thing/ </span>has /em/phasis.
+<span class="hljs-bullet">- </span>two*<span class="hljs-strong"> *things* </span>are<span class="hljs-strong"> *bold.*
+</span><span class="hljs-bullet">- </span>two+<span class="hljs-deletion"> +things+ </span>are<span class="hljs-deletion"> +deleted.+
+</span><span class="hljs-bullet">- </span>two_<span class="hljs-underline"> _things_ </span>are<span class="hljs-underline"> _underlined._
+</span> 
 <span class="hljs-section">* hello world again</span>
 <span class="hljs-attribute">
 #+BEGIN_SRC html</span>
@@ -19,9 +19,9 @@ because org-mode is cool
 <span class="hljs-table">|---------+--------+------------|</span>
 <span class="hljs-table">|</span>         <span class="hljs-table">|</span> Symbol <span class="hljs-table">|</span> Author     <span class="hljs-table">|</span>
 <span class="hljs-table">|---------+--------+------------|</span>
-<span class="hljs-table">|</span> <span class="hljs-strong">*Emacs*</span> <span class="hljs-table">|</span> <span class="hljs-code">~M-x~</span>  <span class="hljs-table">|</span> <span class="hljs-emphasis">/RMS/</span>      <span class="hljs-table">|</span>
+<span class="hljs-table">|</span><span class="hljs-strong"> *Emacs* </span><span class="hljs-table">|</span> <span class="hljs-code">~M-x~</span>  <span class="hljs-table">|</span><span class="hljs-emphasis"> /RMS/ </span>     <span class="hljs-table">|</span>
 <span class="hljs-table">|---------+--------+------------|</span>
-<span class="hljs-table">|</span> <span class="hljs-strong">*Vi*</span>    <span class="hljs-table">|</span> <span class="hljs-code">~:~</span>    <span class="hljs-table">|</span> <span class="hljs-emphasis">/Bill Joy/</span> <span class="hljs-table">|</span>
+<span class="hljs-table">|</span><span class="hljs-strong"> *Vi* </span>   <span class="hljs-table">|</span> <span class="hljs-code">~:~</span>    <span class="hljs-table">|</span><span class="hljs-emphasis"> /Bill Joy/ </span><span class="hljs-table">|</span>
 <span class="hljs-table">|---------+--------+------------|</span>
 <span class="hljs-attribute">
 #+BEGIN_SRC</span>

--- a/test/markup/orgmode/code.expect.txt
+++ b/test/markup/orgmode/code.expect.txt
@@ -1,12 +1,12 @@
 <span class="hljs-section">* hello world</span>
 
 you can write text [[<span class="hljs-link">http://example.com</span>][<span class="hljs-symbol">with links</span>]] inline or [[<span class="hljs-link">http://example.com</span>]].
-
-<span class="hljs-bullet">- </span>one <span class="hljs-emphasis">/thing/</span> has <span class="hljs-emphasis">/em/</span>phasis
+<span class="hljs-bullet">
+- </span>one <span class="hljs-emphasis">/thing/</span> has <span class="hljs-emphasis">/em/</span>phasis
 <span class="hljs-bullet">- </span>two <span class="hljs-strong">*things*</span> are <span class="hljs-strong">*bold*</span>
 <span class="hljs-bullet">- </span>two <span class="hljs-deletion">+things+</span> are <span class="hljs-deletion">+deleted+</span>
 <span class="hljs-bullet">- </span>two <span class="hljs-underline">_things_</span> are <span class="hljs-underline">_underlined_</span>
-<span class="hljs-section"> </span>
+ 
 <span class="hljs-section">* hello world again</span>
 <span class="hljs-attribute">
 #+BEGIN_SRC html</span>
@@ -25,10 +25,10 @@ because org-mode is cool
 <span class="hljs-table">|---------+--------+------------|</span>
 <span class="hljs-attribute">
 #+BEGIN_SRC</span>
-<span class="hljs-section">    so are code segments</span>
+    so are code segments
 <span class="hljs-attribute">#+END_SRC</span>
-
-<span class="hljs-bullet">1. </span>one thing (yeah!)
+<span class="hljs-bullet">
+1. </span>one thing (yeah!)
 <span class="hljs-bullet">2. </span>two thing <span class="hljs-code">~i can write code~</span>, and <span class="hljs-code">=more=</span> wipee!
 <span class="hljs-attribute">
 #+BEGIN_QUOTE</span>

--- a/test/markup/orgmode/code.txt
+++ b/test/markup/orgmode/code.txt
@@ -1,0 +1,37 @@
+* hello world
+
+you can write text [[http://example.com][with links]] inline or [[http://example.com]].
+
+- one /thing/ has /em/phasis
+- two *things* are *bold*
+- two +things+ are +deleted+
+- two _things_ are _underlined_
+ 
+* hello world again
+
+#+BEGIN_SRC html
+<script type="text/javascript" src="org.js"></script>
+#+END_SRC
+
+because org-mode is cool
+
+#+NAME: Table
+|---------+--------+------------|
+|         | Symbol | Author     |
+|---------+--------+------------|
+| *Emacs* | ~M-x~  | /RMS/      |
+|---------+--------+------------|
+| *Vi*    | ~:~    | /Bill Joy/ |
+|---------+--------+------------|
+
+#+BEGIN_SRC
+    so are code segments
+#+END_SRC
+
+1. one thing (yeah!)
+2. two thing ~i can write code~, and =more= wipee!
+
+#+BEGIN_QUOTE
+To be or not to be, that is the question.
+#+END_QUOTE
+

--- a/test/markup/orgmode/code.txt
+++ b/test/markup/orgmode/code.txt
@@ -2,10 +2,10 @@
 
 you can write text [[http://example.com][with links]] inline or [[http://example.com]].
 
-- one /thing/ has /em/phasis
-- two *things* are *bold*
-- two +things+ are +deleted+
-- two _things_ are _underlined_
+- one/ /thing/ has /em/phasis.
+- two* *things* are *bold.*
+- two+ +things+ are +deleted.+
+- two_ _things_ are _underlined._
  
 * hello world again
 


### PR DESCRIPTION
This is obviously not complete.
But I think some of the regex could also be used to extend the markdown support.

* I used `className:deletion` for text that should have a strikethough. In html it should result in something similar to `<del>`. I gues this could be improved to something else?
* I also added `className:underline` which doesn't have a representation in css yet.

Had problems executing the tests. I hope everything is ok.