### PR TITLE
Include more built-ins for MATLAB

### DIFF
--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -42,7 +42,9 @@ function(hljs) {
         'triu fliplr flipud flipdim rot90 find sub2ind ind2sub bsxfun ndgrid permute ipermute ' +
         'shiftdim circshift squeeze isscalar isvector ans eps realmax realmin pi i inf nan ' +
         'isnan isinf isfinite j why compan gallery hadamard hankel hilb invhilb magic pascal ' +
-        'rosser toeplitz vander wilkinson'
+        'rosser toeplitz vander wilkinson max min nanmax nanmin mean nanmean type table ' +
+        'readtable writetable sortrows sort figure plot plot3 scatter scatter3 cellfun ' +
+        'legend intersect ismember procrustes hold num2cell '
     },
     illegal: '(//|"|#|/\\*|\\s+/\\w+)',
     contains: [


### PR DESCRIPTION
This PR includes more built-ins for MATLAB, some of which are essential (such as *mean, *min, *max, plot, scatter, sort, legend).