### PR TITLE
Fix Elm characters

### DIFF
--- a/src/languages/elm.js
+++ b/src/languages/elm.js
@@ -38,6 +38,12 @@ function(hljs) {
     contains: LIST.contains
   };
 
+  var CHARACTER = {
+    className: 'string',
+    begin: '\'\\\\?.', end: '\'',
+    illegal: '.'
+  };
+
   return {
     keywords:
       'let in if then else case of where module import exposing ' +
@@ -75,7 +81,7 @@ function(hljs) {
 
       // Literals and names.
 
-      // TODO: characters.
+      CHARACTER,
       hljs.QUOTE_STRING_MODE,
       hljs.C_NUMBER_MODE,
       CONSTRUCTOR,

--- a/test/detect/elm/default.txt
+++ b/test/detect/elm/default.txt
@@ -13,3 +13,6 @@ main =
 view model =
     div [] [ div [] [ text (toString model) ]
            , button [ onClick Increment ] [ text "+" ] ]
+
+chars =
+    String.cons 'C' <| String.cons 'h' <| "ars"


### PR DESCRIPTION
The line
```elm
cons 'C' <| cons 'h' "ars"
```
currently renders as
```html
cons '<span class="hljs-type">C'</span> &lt;| cons 'h' <span class="hljs-string">"ars"</span>
```

This change renders it as
```html
cons <span class="hljs-string">'C'</span> &lt;| cons <span class="hljs-string">'h'</span> &lt;| <span class="hljs-string">"ars"</span>
```

The same change could be copied over to Haskell, since that suffers from the same issue.