### PR TITLE
Add `apache` alias

### DIFF
--- a/src/languages/apache.js
+++ b/src/languages/apache.js
@@ -10,7 +10,7 @@ Category: common, config
 function(hljs) {
   var NUMBER = {className: 'number', begin: '[\\$%]\\d+'};
   return {
-    aliases: ['apacheconf'],
+    aliases: ['apacheconf', 'apache'],
     case_insensitive: true,
     contains: [
       hljs.HASH_COMMENT_MODE,


### PR DESCRIPTION
Docs say that you can use `apache` alias, but it [does not work](https://md.bygeorgenet.me/doc/ORWJnmb)

![image](https://user-images.githubusercontent.com/11464592/40874623-09f38602-667a-11e8-936d-c80f7cc13509.png)