### PR TITLE
Revert "Add `apache` alias"

### DIFF
--- a/src/languages/apache.js
+++ b/src/languages/apache.js
@@ -10,7 +10,7 @@ Category: common, config
 function(hljs) {
   var NUMBER = {className: 'number', begin: '[\\$%]\\d+'};
   return {
-    aliases: ['apacheconf', 'apache'],
+    aliases: ['apacheconf'],
     case_insensitive: true,
     contains: [
       hljs.HASH_COMMENT_MODE,


### PR DESCRIPTION
Reverts highlightjs/highlight.js#1751

The change is unnecessary since the file name works as the main language name. Aliases only hold additional names.

/cc @ldct 