### PR TITLE
Ask travis to test against stable and LTS node.js releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "node"
 env:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "lts/*"
   - "node"
 env:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "5"
+  - "node"
 env:
   -
   - BROWSER=1


### PR DESCRIPTION
The currently specified node.js versions that travis tests against are 4 and 5, which are quite old. This PR adds the latest stable version of node to that list. 

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions

I am not sure what build infra or other things might be running node 4 and 5; we can delete those versions at a later time.