### PR TITLE
Fix Dockerfile sublanguage keywords which produce no highlighting

### DIFF
--- a/src/languages/dockerfile.js
+++ b/src/languages/dockerfile.js
@@ -19,7 +19,7 @@ function(hljs) {
       {
         beginKeywords: 'run cmd entrypoint volume add copy workdir label healthcheck shell',
         starts: {
-          end: /[^\\]\n/,
+          end: '[^\\\\]$',
           subLanguage: 'bash'
         }
       }


### PR DESCRIPTION
When using a Dockerfile sublanguage keyword, all the following instructions are not colored. This PR fix this bug.