### PR TITLE
Fix Dockerfile definition when using highlight continuation parameter

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -272,3 +272,4 @@ Contributors:
 - Gustavo Costa <gusbemacbe@gmail.com>
 - Antoine Boisier-Michaud <aboisiermichaud@gmail.com>
 - Alejandro Isaza <al@isaza.ca>
+- Laurent Voullemier <laurent.voullemier@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,11 +16,13 @@ Improvements:
 - Added support for multiline strings to *Swift*, by [Alejandro Isaza][]
 - Fixed issue that was causing some minifiers to fail.
 - Fixed `autoDetection` to accept language aliases.
+- Fixed Dockerfile definition when using highlight continuation parameter, by [Laurent Voullemier][]
 
 [JeremyTCD]: https://github.com/JeremyTCD
 [Melissa Geels]: https://github.com/codecat
 [Antoine Boisier-Michaud]: https://github.com/Aboisier
 [Alejandro Isaza]: https://github.com/alejandro-isaza
+[Laurent Voullemier]: https://github.com/l-vo
 
 ## Version 9.13.0
 

--- a/src/languages/dockerfile.js
+++ b/src/languages/dockerfile.js
@@ -19,7 +19,7 @@ function(hljs) {
       {
         beginKeywords: 'run cmd entrypoint volume add copy workdir label healthcheck shell',
         starts: {
-          end: /[^\\]\n/,
+          end: /[^\\]$/,
           subLanguage: 'bash'
         }
       }


### PR DESCRIPTION
Let's consider this case:

```javascript
const str1 = 'FROM ubuntu:trusty';
const str2 = 'RUN echo "foo"';
const str3 = 'USER bar';

var html = '';
var result = hljs.highlight('docker', str1);
html += result.value;
result = hljs.highlight('docker', str2, false, result.top);
html += result.value;
result = hljs.highlight('docker', str3, false, result.top);
html += result.value;
console.log(html);
```

Before this fix, the previous chunk of code returns:

```xml
<span class="hljs-keyword">FROM</span> ubuntu:trusty<span class="hljs-keyword">RUN</span><span class="bash"> <span class="hljs-built_in">echo</span> <span class="hljs-string">"foo"</span></span><span class="bash">USER bar</span>
```
As we can see, the USER dockerfile directive isn't detected as a Docker keyword.

So, after the fix:

```xml
<span class="hljs-keyword">FROM</span> ubuntu:trusty<span class="hljs-keyword">RUN</span><span class="bash"> <span class="hljs-built_in">echo</span> <span class="hljs-string">"foo"</span></span><span class="hljs-keyword">USER</span> bar
```