### PR TITLE
Elm no longer supports ' in variable names

### DIFF
--- a/src/languages/elm.js
+++ b/src/languages/elm.js
@@ -20,7 +20,7 @@ function(hljs) {
 
   var CONSTRUCTOR = {
     className: 'type',
-    begin: '\\b[A-Z][\\w\']*', // TODO: other constructors (built-in, infix).
+    begin: '\\b[A-Z][\\w]*', // TODO: other constructors (built-in, infix).
     relevance: 0
   };
 
@@ -79,7 +79,7 @@ function(hljs) {
       hljs.QUOTE_STRING_MODE,
       hljs.C_NUMBER_MODE,
       CONSTRUCTOR,
-      hljs.inherit(hljs.TITLE_MODE, {begin: '^[_a-z][\\w\']*'}),
+      hljs.inherit(hljs.TITLE_MODE, {begin: '^[_a-z][\\w]*'}),
       COMMENT,
 
       {begin: '->|<-'} // No markup, relevance booster


### PR DESCRIPTION
This feature was removed in Elm 0.18 in November 2016.

See documentation of change here: https://github.com/elm/compiler/blob/master/upgrade-docs/0.18.md#no-more-primes