### PR TITLE
Add @objcMembers to Swift @attributes

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -109,7 +109,7 @@ function(hljs) {
       {
         className: 'meta', // @attributes
         begin: '(@discardableResult|@warn_unused_result|@exported|@lazy|@noescape|' +
-                  '@NSCopying|@NSManaged|@objc|@convention|@required|' +
+                  '@NSCopying|@NSManaged|@objc|@objcMembers|@convention|@required|' +
                   '@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|' +
                   '@infix|@prefix|@postfix|@autoclosure|@testable|@available|' +
                   '@nonobjc|@NSApplicationMain|@UIApplicationMain)'


### PR DESCRIPTION
Replacing #1634, as the fork was deleted:

> Adds @objcMembers to Swift's @attributes list. 🙋‍♀️
> 
> @objcMembers is introduced on Swift 4, as documented here: https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/WritingSwiftClassesWithObjective-CBehavior.html