### PR TITLE
Fix(cpp): Fix C++ string handling.

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -15,13 +15,16 @@ function(hljs) {
     className: 'string',
     variants: [
       {
-        begin: '(u8?|U)?L?"', end: '"',
+        begin: '(u8?|U|L)?"', end: '"',
         illegal: '\\n',
         contains: [hljs.BACKSLASH_ESCAPE]
       },
       {
-        begin: '(u8?|U)?R"', end: '"',
-        contains: [hljs.BACKSLASH_ESCAPE]
+        // TODO: This does not handle raw string literals with prefixes. Using
+        // a single regex with backreferences would work (note to use *?
+        // instead of * to make it non-greedy), but the mode.terminators
+        // computation in highlight.js breaks the counting.
+        begin: '(u8?|U|L)?R"\\(', end: '\\)"',
       },
       {
         begin: '\'\\\\?.', end: '\'',

--- a/test/markup/cpp/string-literals.expect.txt
+++ b/test/markup/cpp/string-literals.expect.txt
@@ -9,19 +9,19 @@
 
 <span class="hljs-comment">// Raw string literals (multiline)</span>
 <span class="hljs-keyword">auto</span> char_multi  = <span class="hljs-string">R"(Hello
-normal
+"normal"
 muliline
 string.)"</span>;
 <span class="hljs-keyword">auto</span> utf8_multi  = <span class="hljs-string">u8R"(Hello
-utf-8
+"utf-8"
 muliline
 string)"</span>;
 <span class="hljs-keyword">auto</span> utf16_multi = <span class="hljs-string">uR"(Hello
-utf-16
+"utf-16"
 muliline
 string)"</span>;
 <span class="hljs-keyword">auto</span> utf32_multi = <span class="hljs-string">UR"(Hello
-utf-32
+"utf-32"
 muliline
 string)"</span>;
 

--- a/test/markup/cpp/string-literals.txt
+++ b/test/markup/cpp/string-literals.txt
@@ -9,19 +9,19 @@ auto wide_char = L"Hello wchar_t string";
 
 // Raw string literals (multiline)
 auto char_multi  = R"(Hello
-normal
+"normal"
 muliline
 string.)";
 auto utf8_multi  = u8R"(Hello
-utf-8
+"utf-8"
 muliline
 string)";
 auto utf16_multi = uR"(Hello
-utf-16
+"utf-16"
 muliline
 string)";
 auto utf32_multi = UR"(Hello
-utf-32
+"utf-32"
 muliline
 string)";
 


### PR DESCRIPTION
See https://bugs.chromium.org/p/gerrit/issues/detail?id=7748 and the
grammar here:
http://en.cppreference.com/w/cpp/language/string_literal

u8 cannot be combined with L. Also fix the syntax for raw string
literals. This doesn't support the mode with a prefix, just the basic
R"( .... )" case.