### PR TITLE
yaml: Highlight local tags as types

### DIFF
--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -65,6 +65,10 @@ function(hljs) {
         excludeEnd: true,
         relevance: 0
       },
+      { // local tags
+        className: 'type',
+        begin: '!' + hljs.UNDERSCORE_IDENT_RE,
+      },
       { // data type
         className: 'type',
         begin: '!!' + hljs.UNDERSCORE_IDENT_RE,

--- a/test/markup/yaml/tag.expect.txt
+++ b/test/markup/yaml/tag.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-attr">key:</span> <span class="hljs-type">!!builtintagname</span> <span class="hljs-string">test</span>
+<span class="hljs-attr">key:</span> <span class="hljs-type">!localtagname</span> <span class="hljs-string">test</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">"!notatag"</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">'!!notatageither'</span>

--- a/test/markup/yaml/tag.txt
+++ b/test/markup/yaml/tag.txt
@@ -1,0 +1,4 @@
+key: !!builtintagname test
+key: !localtagname test
+key: "!notatag"
+key: '!!notatageither'


### PR DESCRIPTION
`!` (local tags) should be treated as types, just like `!!`.