### PR TITLE
Soft illegals

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -278,8 +278,11 @@ https://highlightjs.org/
           mode.end = mode.begin;
         if (!mode.end && !mode.endsWithParent)
           mode.end = /\B|\b/;
-        if (mode.end && soft_illegals && mode.illegal)
-          mode.endRe = langRe('(' + mode.end + '|' + mode.illegal + ')');
+        if (soft_illegals && mode.end && mode.illegal) {
+          var endSource = (mode.end instanceof RegExp ? mode.end.source : mode.end);
+          var illegalSource = (mode.illegal instanceof RegExp ? mode.illegal.source : mode.illegal);
+          mode.endRe = langRe(endSource + '|' + illegalSource);
+        }
         else if (mode.end)
           mode.endRe = langRe(mode.end);
         mode.terminator_end = reStr(mode.end) || '';


### PR DESCRIPTION
Instead of ignoring illegals completely, using "soft illegals" will cause highlight.js to use the illegal expressions as an alternate end expression. This way, it will still refuse to highlight illegal expressions, but without bailing out completely.

Please note my experience with JavaScript is limited. Perhaps there is a better way to achieve this behavior. However I tested it and it works very well! This is interesting for my use case because I want to be able to highlight small chunks of code at a time in my code editor, which are not necessarily correct, as the user might still be composing them.

---

For example. This illegal multi-line string is currently highlighted when using "ignore_illegals":

```c
char *string = "foo\
bash
baz";
```

<img width="201" alt="screen shot 2018-09-20 at 01 25 57" src="https://user-images.githubusercontent.com/2136642/45787164-25ba6180-bc74-11e8-8166-aaf53989c1b8.png">

---

Using soft illegals, the string expression is highlighted up to the "bash" word, after which the expression ends. The resulting highlight is better than not having any highlight at all, and actually matches exactly what Xcode highlights for the same expression:

<img width="212" alt="screen shot 2018-09-20 at 01 22 52" src="https://user-images.githubusercontent.com/2136642/45787077-b93f6280-bc73-11e8-9a49-cc968b9f1bd3.png">

In Xcode:

<img width="304" alt="screen shot 2018-09-20 at 01 22 42" src="https://user-images.githubusercontent.com/2136642/45787076-b93f6280-bc73-11e8-8112-f04b54a2af43.png">

Cheers!