### PR TITLE
Csharp function fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ Improvements:
 - *Matlab*: transpose operators and double quote strings, by [JohnC32][] and [Egor Rogov][]
 - Various documentation typos and improvemets by [Jimmy Wärting][], [Lutz Büch][], [bcleland][]
 - *Cmake* updated with new keywords and commands by [Deniz Bahadir][]
+- *C#* function declarations no longer include trailing whitespace, by [JeremyTCD][]
 
 [Ahmad Awais]: https://github.com/ahmadawais
 [Arctic Ice Studio]: https://github.com/arcticicestudio
@@ -77,6 +78,7 @@ Improvements:
 [Jan T. Sott]: https://github.com/idleberg
 [Jimmy Wärting]: https://github.com/jimmywarting
 [Marcos Cáceres]: https://github.com/marcoscaceres
+[JeremyTCD]: https://github.com/JeremyTCD
 
 ## Version 9.12.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ New styles:
 
 Improvements:
 
+- *C#* function declarations no longer include trailing whitespace, by [JeremyTCD][]
+
+[JeremyTCD]: https://github.com/JeremyTCD
 
 ## Version 9.13.0
 
@@ -49,7 +52,6 @@ Improvements:
 - *Matlab*: transpose operators and double quote strings, by [JohnC32][] and [Egor Rogov][]
 - Various documentation typos and improvemets by [Jimmy Wärting][], [Lutz Büch][], [bcleland][]
 - *Cmake* updated with new keywords and commands by [Deniz Bahadir][]
-- *C#* function declarations no longer include trailing whitespace, by [JeremyTCD][]
 
 [Ahmad Awais]: https://github.com/ahmadawais
 [Arctic Ice Studio]: https://github.com/arcticicestudio
@@ -78,7 +80,6 @@ Improvements:
 [Jan T. Sott]: https://github.com/idleberg
 [Jimmy Wärting]: https://github.com/jimmywarting
 [Marcos Cáceres]: https://github.com/marcoscaceres
-[JeremyTCD]: https://github.com/JeremyTCD
 
 ## Version 9.12.0
 

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -161,7 +161,7 @@ function(hljs) {
       {
         className: 'function',
         begin: '(' + TYPE_IDENT_RE + '\\s+)+' + hljs.IDENT_RE + '\\s*\\(', returnBegin: true,
-        end: /[{;=]/, excludeEnd: true,
+        end: /([{;=]|(\n\s*{))/, excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
           {

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -161,7 +161,7 @@ function(hljs) {
       {
         className: 'function',
         begin: '(' + TYPE_IDENT_RE + '\\s+)+' + hljs.IDENT_RE + '\\s*\\(', returnBegin: true,
-        end: /([{;=]|(\n\s*{))/, excludeEnd: true,
+        end: /\s*[{;=]/, excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
           {

--- a/test/markup/cs/functions.expect.txt
+++ b/test/markup/cs/functions.expect.txt
@@ -1,8 +1,16 @@
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunction</span>(<span class="hljs-params"></span>)</span>
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunction1</span>(<span class="hljs-params"></span>)</span> {
+}
+
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunction2</span>(<span class="hljs-params"></span>)</span>
 {
 }
 
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunctionWithMultilineDeclaration</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> arg1,
-    <span class="hljs-keyword">string</span> arg2</span>)</span>
-{
-}
+<span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunctionDeclaration1</span>(<span class="hljs-params"></span>)</span>;
+
+<span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunctionDeclaration2</span>(<span class="hljs-params"></span>)</span>
+;
+
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction1</span>(<span class="hljs-params"></span>)</span> =&gt; <span class="hljs-string">"dummy"</span>;
+
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction2</span>(<span class="hljs-params"></span>)</span>
+    =&gt; <span class="hljs-string">"dummy"</span>;

--- a/test/markup/cs/functions.expect.txt
+++ b/test/markup/cs/functions.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunction</span>(<span class="hljs-params"></span>)</span>
+{
+}
+
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunctionWithMultilineDeclaration</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> arg1,
+    <span class="hljs-keyword">string</span> arg2</span>)</span>
+{
+}

--- a/test/markup/cs/functions.txt
+++ b/test/markup/cs/functions.txt
@@ -1,0 +1,8 @@
+public void ExampleFunction()
+{
+}
+
+public void ExampleFunctionWithMultilineDeclaration(string arg1,
+    string arg2)
+{
+}

--- a/test/markup/cs/functions.txt
+++ b/test/markup/cs/functions.txt
@@ -1,8 +1,16 @@
-public void ExampleFunction()
+public void ExampleFunction1() {
+}
+
+public void ExampleFunction2()
 {
 }
 
-public void ExampleFunctionWithMultilineDeclaration(string arg1,
-    string arg2)
-{
-}
+void ExampleFunctionDeclaration1();
+
+void ExampleFunctionDeclaration2()
+;
+
+public string ExampleExpressionBodiedFunction1() => "dummy";
+
+public string ExampleExpressionBodiedFunction2()
+    => "dummy";

--- a/test/markup/cs/titles.expect.txt
+++ b/test/markup/cs/titles.expect.txt
@@ -2,13 +2,13 @@
 {
     <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : <span class="hljs-title">Base</span>, <span class="hljs-title">Other</span> <span class="hljs-comment">// class</span>
     {
-        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> who</span>) <span class="hljs-comment">// function</span>
-        </span>{
+        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> who</span>) <span class="hljs-comment">// function</span></span>
+        {
             Who = who;
         }
 
-        <span class="hljs-function"><span class="hljs-keyword">int</span>[] <span class="hljs-title">f</span>(<span class="hljs-params"><span class="hljs-keyword">int</span> val = <span class="hljs-number">0</span></span>)
-        </span>{
+        <span class="hljs-function"><span class="hljs-keyword">int</span>[] <span class="hljs-title">f</span>(<span class="hljs-params"><span class="hljs-keyword">int</span> val = <span class="hljs-number">0</span></span>)</span>
+        {
             <span class="hljs-keyword">new</span> Type();
             <span class="hljs-keyword">return</span> getType();
             <span class="hljs-keyword">throw</span> getError();


### PR DESCRIPTION
At present, csharp function declarations include trailing newline characters. For example, the following csharp:

```csharp
public void ExampleFunction()
{
}
```

is rendered as:

```html
<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunction</span>(<span class="hljs-params"></span>)
</span>{
}
```

Note the second line, `</span>{`. 

This pull request fixes this issue by excluding the last newline character before `{`. I've added and updated tests as well. Kindly consider.