### PR TITLE
Add instructions for importing CSS when using the npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ import javascript from 'highlight.js/lib/languages/javascript';
 hljs.registerLanguage('javascript', javascript);
 ```
 
+To set the syntax highlighting style, if your build tool processes CSS from your JavaScript entry point, you can import the stylesheet directly into your CommonJS-module:
+
+```javascript
+import hljs from 'highlight.js/lib/highlight';
+import 'highlight.js/styles/github.css'
+```
 
 ## License
 


### PR DESCRIPTION
Connects #1284 

Would be convenient for all npm users to know how to access the stylesheets for the different themes.