### PR TITLE
Added some missing keywords and upcoming try/catch keywords in AngelScript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,10 @@ New styles:
 Improvements:
 
 - *C#* function declarations no longer include trailing whitespace, by [JeremyTCD][]
+- Added new and missing keywords to *AngelScript*, by [Melissa Geels][]
 
 [JeremyTCD]: https://github.com/JeremyTCD
+[Melissa Geels]: https://github.com/codecat
 
 ## Version 9.13.0
 

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -30,7 +30,8 @@ function(hljs) {
     keywords:
       'for in|0 break continue while do|0 return if else case switch namespace is cast ' +
       'or and xor not get|0 in inout|10 out override set|0 private public const default|0 ' +
-      'final shared external mixin|10 enum typedef funcdef this super import from interface',
+      'final shared external mixin|10 enum typedef funcdef this super import from interface ' +
+      'abstract|0 try|0 catch|0',
 
     // avoid close detection with C# and JS
     illegal: '(^using\\s+[A-Za-z0-9_\\.]+;$|\\bfunction\s*[^\\(])',

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -31,7 +31,7 @@ function(hljs) {
       'for in|0 break continue while do|0 return if else case switch namespace is cast ' +
       'or and xor not get|0 in inout|10 out override set|0 private public const default|0 ' +
       'final shared external mixin|10 enum typedef funcdef this super import from interface ' +
-      'abstract|0 try|0 catch|0',
+      'abstract|0 try catch protected',
 
     // avoid close detection with C# and JS
     illegal: '(^using\\s+[A-Za-z0-9_\\.]+;$|\\bfunction\s*[^\\(])',

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -31,7 +31,7 @@ function(hljs) {
       'for in|0 break continue while do|0 return if else case switch namespace is cast ' +
       'or and xor not get|0 in inout|10 out override set|0 private public const default|0 ' +
       'final shared external mixin|10 enum typedef funcdef this super import from interface ' +
-      'abstract|0 try catch protected',
+      'abstract|0 try catch protected explicit',
 
     // avoid close detection with C# and JS
     illegal: '(^using\\s+[A-Za-z0-9_\\.]+;$|\\bfunction\s*[^\\(])',

--- a/test/detect/angelscript/default.txt
+++ b/test/detect/angelscript/default.txt
@@ -32,6 +32,15 @@ namespace MyApplication
                 print("  " + i + ": " + m_arr[i]);
             }
         }
+
+        protected void SomeProtectedFunction()
+        {
+            try {
+                DoSomething();
+            } catch {
+                print("Exception while doing something!");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The `abstract` and `protected` keywords were missing from the keywords list, and [as per the WIP version](http://www.angelcode.com/angelscript/wip.php), try/catch statements are being added in the next update of Angelscript.