### PR TITLE
Typescript decorator factories

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -270,3 +270,4 @@ Contributors:
 - Harmon <Harmon.Public@gmail.com>
 - Eric Bailey <eric.w.bailey@gmail.com>
 - Gustavo Costa <gusbemacbe@gmail.com>
+- Antoine Boisier-Michaud <aboisiermichaud@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,11 @@ Improvements:
 
 - *C#* function declarations no longer include trailing whitespace, by [JeremyTCD][]
 - Added new and missing keywords to *AngelScript*, by [Melissa Geels][]
+- *TypeScript* decorator factories highlighting fix, by [Antoine Boisier-Michaud][]
 
 [JeremyTCD]: https://github.com/JeremyTCD
 [Melissa Geels]: https://github.com/codecat
+[Antoine Boisier-Michaud]: https://github.com/Aboisier
 
 ## Version 9.13.0
 

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -7,6 +7,7 @@ Category: scripting
 */
 
 function(hljs) {
+  var JS_IDENT_RE = '[A-Za-z$_][0-9A-Za-z$_]*';
   var KEYWORDS = {
     keyword:
       'in if for while finally var new function do return void else break catch ' +
@@ -24,6 +25,38 @@ function(hljs) {
       'Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array ' +
       'Uint8Array Uint8ClampedArray ArrayBuffer DataView JSON Intl arguments require ' +
       'module console window document any number boolean string void Promise'
+  };
+
+  var DECORATOR = {
+    className: 'meta',
+    begin: '@' + JS_IDENT_RE,
+  };
+
+  var ARGS =
+  {
+    begin: '\\(',
+    end: /\)/,
+    keywords: KEYWORDS,
+    contains: [
+      'self',
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      hljs.NUMBER_MODE
+    ]
+  };
+
+  var PARAMS = {
+    className: 'params',
+    begin: /\(/, end: /\)/,
+    excludeBegin: true,
+    excludeEnd: true,
+    keywords: KEYWORDS,
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      DECORATOR,
+      ARGS
+    ]
   };
 
   return {
@@ -102,19 +135,8 @@ function(hljs) {
         keywords: KEYWORDS,
         contains: [
           'self',
-          hljs.inherit(hljs.TITLE_MODE, {begin: /[A-Za-z$_][0-9A-Za-z$_]*/}),
-          {
-            className: 'params',
-            begin: /\(/, end: /\)/,
-            excludeBegin: true,
-            excludeEnd: true,
-            keywords: KEYWORDS,
-            contains: [
-              hljs.C_LINE_COMMENT_MODE,
-              hljs.C_BLOCK_COMMENT_MODE
-            ],
-            illegal: /["'\(]/
-          }
+          hljs.inherit(hljs.TITLE_MODE, { begin: JS_IDENT_RE }),
+          PARAMS
         ],
         illegal: /%/,
         relevance: 0 // () => {} is more typical in TypeScript
@@ -123,23 +145,12 @@ function(hljs) {
         beginKeywords: 'constructor', end: /\{/, excludeEnd: true,
         contains: [
           'self',
-          {
-            className: 'params',
-            begin: /\(/, end: /\)/,
-            excludeBegin: true,
-            excludeEnd: true,
-            keywords: KEYWORDS,
-            contains: [
-              hljs.C_LINE_COMMENT_MODE,
-              hljs.C_BLOCK_COMMENT_MODE
-            ],
-            illegal: /["'\(]/
-          }
+          PARAMS
         ]
       },
       { // prevent references like module.id from being higlighted as module definitions
         begin: /module\./,
-        keywords: {built_in: 'module'},
+        keywords: { built_in: 'module' },
         relevance: 0
       },
       {
@@ -155,9 +166,8 @@ function(hljs) {
       {
         begin: '\\.' + hljs.IDENT_RE, relevance: 0 // hack: prevents detection of keywords after dots
       },
-      {
-        className: 'meta', begin: '@[A-Za-z]+'
-      }
+      DECORATOR,
+      ARGS
     ]
   };
 }

--- a/test/markup/typescript/decorator-factories.expect.txt
+++ b/test/markup/typescript/decorator-factories.expect.txt
@@ -1,0 +1,13 @@
+<span class="hljs-meta">@foo</span>(<span class="hljs-string">'foo'</span>)
+<span class="hljs-keyword">export</span> <span class="hljs-keyword">class</span> MyClass {
+    <span class="hljs-meta">@baz</span>(<span class="hljs-number">123</span>)
+    <span class="hljs-keyword">private</span> myAttribute: <span class="hljs-built_in">string</span>;
+
+    <span class="hljs-keyword">constructor</span>(<span class="hljs-params"><span class="hljs-meta">@bar</span>(<span class="hljs-literal">true</span>) <span class="hljs-keyword">private</span> x, 
+                <span class="hljs-meta">@bar</span>(qux(quux(<span class="hljs-literal">true</span>))) <span class="hljs-keyword">private</span> y</span>) { }
+
+    <span class="hljs-meta">@bar</span>()
+    <span class="hljs-keyword">private</span> myMethod(<span class="hljs-meta">@bar</span>() z) {
+        <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Hello world.'</span>);
+    }
+}

--- a/test/markup/typescript/decorator-factories.txt
+++ b/test/markup/typescript/decorator-factories.txt
@@ -1,0 +1,13 @@
+@foo('foo')
+export class MyClass {
+    @baz(123)
+    private myAttribute: string;
+
+    constructor(@bar(true) private x, 
+                @bar(qux(quux(true))) private y) { }
+
+    @bar()
+    private myMethod(@bar() z) {
+        console.log('Hello world.');
+    }
+}


### PR DESCRIPTION
Fix for #1859. 

Currently, having a decorator factory in a constructor breaks the highlighting. 

Example:

```ts
constructor(@decorator() private bar: Bar) { }
```

Is rendered as (notice the `</span>` after `@decorator(` )
```html
<span class="hljs-keyword">constructor</span>(<span class="hljs-params">@decorator(</span>) private bar: Bar) { }
```

It should be rendered as 
```html
<span class="hljs-keyword">constructor</span>(<span class="hljs-params"><span class="hljs-meta">@decorator</span>() <span class="hljs-keyword">private</span> bar: Bar</span>) { }
```

There are also a couple more scenarios to take into account:
```ts
constructor(@decorator('Hello') private bar: Bar) { }
constructor(@decorator(123) private bar: Bar) { }
constructor(@decorator(true) private bar: Bar) { }
constructor(@decorator(someFunction('Hello')) private bar: Bar) { }
function(@decorator() param: Param) { }
```

This pull request adds decorators and arguments. These constructs may be contained in the root, in functions definitions, and in constructors. I added a test with different scenarios. I reduced duplication by creating the PARAMS object. Finally, the current decorators definition did not allow decorators names to start with `$` or `_`, which is a valid. I also fixed that.

Thanks for considering this fix!
Antoine
