### PR TITLE
Fix change added in the wrong version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@ New styles:
 
 Improvements:
 
+- Fixed Dockerfile definition when using highlight continuation parameter, by [Laurent Voullemier][]
 - Added tests & new `annotation` and `verbatim` keywords to *Crystal*, by [Benoit de Chezelles][]
 
+[Laurent Voullemier]: https://github.com/l-vo
 [Benoit de Chezelles]: https://github.com/bew
 
 ## Version 9.13.1
@@ -20,13 +22,11 @@ Improvements:
 - Added support for multiline strings to *Swift*, by [Alejandro Isaza][]
 - Fixed issue that was causing some minifiers to fail.
 - Fixed `autoDetection` to accept language aliases.
-- Fixed Dockerfile definition when using highlight continuation parameter, by [Laurent Voullemier][]
 
 [JeremyTCD]: https://github.com/JeremyTCD
 [Melissa Geels]: https://github.com/codecat
 [Antoine Boisier-Michaud]: https://github.com/Aboisier
 [Alejandro Isaza]: https://github.com/alejandro-isaza
-[Laurent Voullemier]: https://github.com/l-vo
 
 ## Version 9.13.0
 


### PR DESCRIPTION
In the PR #1771, I added my changes in the already released version 9.13.1 instead of master.

I'm sorry for that, this fixes that mistake.