### PR TITLE
Make clean.js less greedy

### DIFF
--- a/src/languages/clean.js
+++ b/src/languages/clean.js
@@ -14,6 +14,8 @@ function(hljs) {
         'implementation definition system module from import qualified as ' +
         'special code inline foreign export ccall stdcall generic derive ' +
         'infix infixl infixr',
+      built_in:
+        'Int Real Char Bool',
       literal:
         'True False'
     },
@@ -25,7 +27,7 @@ function(hljs) {
       hljs.QUOTE_STRING_MODE,
       hljs.C_NUMBER_MODE,
 
-      {begin: '->|<-[|:]?|::|#!?|>>=|\\{\\||\\|\\}|:==|=:|\\.\\.|<>|`'} // relevance booster
+      {begin: '->|<-[|:]?|#!?|>>=|\\{\\||\\|\\}|:==|=:|<>'} // relevance booster
     ]
   };
 }


### PR DESCRIPTION
- Removed very common cross-language symbols from the list of
  relevance boosters (`::`, `..`, back-tick).
- Added built-in types to increase relevance in a natural way.

(Found it when a random Rust fragment got auto-detected as Clean.)