### PR TITLE
Improve Crystal language to highlight regexes after some keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,14 @@ Improvements:
 - Fixed several issues with *Crystal* language definition, by [Johannes Müller][]
 - Added `C#` as an alias for *CSharp* language, by [Ahmed Atito][]
 - Added generic user-defined proc support, new compiler define, refactor to re-use rules, and add tests to *GAUSS*, by [Matthew Evans][]
+- Improve *Crystal* language to highlight regexes after some keywords, by [Tsuyusato Kitsune][]
 
 [Laurent Voullemier]: https://github.com/l-vo
 [Benoit de Chezelles]: https://github.com/bew
 [Johannes Müller]: https://github.com/straight-shoota
 [Ahmed Atito]: https://github.com/atitoa93
 [Matthew Evans]: https://github.com/matthewevans
+[Tsuyusato Kitsune]: https://github.com/MakeNowJust
 
 ## Version 9.13.1
 

--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -66,7 +66,8 @@ function(hljs) {
     relevance: 0,
   };
   var REGEXP = {
-    begin: '(?!%})(' + hljs.RE_STARTERS_RE + '|\\n)\\s*',
+    begin: '(?!%})(' + hljs.RE_STARTERS_RE + '|\\n|\\b(case|if|select|unless|until|when|while)\\b)\\s*',
+    keywords: 'case if select unless until when while',
     contains: [
       {
         className: 'regexp',

--- a/test/markup/crystal/regexes.expect.txt
+++ b/test/markup/crystal/regexes.expect.txt
@@ -1,0 +1,12 @@
+<span class="hljs-keyword">if</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">unless</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">case</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">select</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">when</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">while</span> <span class="hljs-regexp">/foo/</span>
+<span class="hljs-keyword">until</span> <span class="hljs-regexp">/foo/</span>
++<span class="hljs-regexp">/foo/</span>
+
+<span class="hljs-comment"># NG</span>
+xif /foo/
+ifx /foo/

--- a/test/markup/crystal/regexes.txt
+++ b/test/markup/crystal/regexes.txt
@@ -1,0 +1,12 @@
+if /foo/
+unless /foo/
+case /foo/
+select /foo/
+when /foo/
+while /foo/
+until /foo/
++/foo/
+
+# NG
+xif /foo/
+ifx /foo/


### PR DESCRIPTION
Highlight following as Crystal:

```
if /foo/ =~ foo
end
```

Before:

```html
<span class="hljs-keyword">if</span> /foo/ =~ foo
<span class="hljs-keyword">end</span>
```

After:

```html
<span class="hljs-keyword">if</span> <span class="hljs-regexp">/foo/</span> =~ foo
<span class="hljs-keyword">end</span>
```

/cc @straight-shoota @bew