### PR TITLE
String continuations are not recommended by google closure compiler

### DIFF
--- a/src/languages/tp.js
+++ b/src/languages/tp.js
@@ -17,8 +17,8 @@ function(hljs) {
   };
   var TPDATA = {
     className: 'built_in',
-    begin: '(AR|P|PAYLOAD|PR|R|SR|RSR|LBL|VR|UALM|MESSAGE|UTOOL|UFRAME|TIMER|\
-    TIMER_OVERFLOW|JOINT_MAX_SPEED|RESUME_PROG|DIAG_REC)\\[', end: '\\]',
+    begin: '(AR|P|PAYLOAD|PR|R|SR|RSR|LBL|VR|UALM|MESSAGE|UTOOL|UFRAME|TIMER|' +
+    'TIMER_OVERFLOW|JOINT_MAX_SPEED|RESUME_PROG|DIAG_REC)\\[', end: '\\]',
     contains: [
       'self',
       TPID,


### PR DESCRIPTION
https://google.github.io/styleguide/jsguide.html#features-strings-no-line-continuations
Fixes:  #1770 #1722 .
