### PR TITLE
Add missing "object" highlighting to Pony definition

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -272,3 +272,4 @@ Contributors:
 - Antoine Boisier-Michaud <aboisiermichaud@gmail.com>
 - Alejandro Isaza <al@isaza.ca>
 - Laurent Voullemier <laurent.voullemier@gmail.com>
+- Sean T. Allen <sean@monkeysnatchbanana.com>

--- a/src/languages/pony.js
+++ b/src/languages/pony.js
@@ -50,7 +50,7 @@ function(hljs) {
 
   var CLASS = {
     className: 'class',
-    beginKeywords: 'class actor', end: '$',
+    beginKeywords: 'class actor object', end: '$',
     contains: [
       hljs.TITLE_MODE,
       hljs.C_LINE_COMMENT_MODE


### PR DESCRIPTION
The original Pony highlighting definition that Joe did is missing a Pony
keyword for highlighting like a class. After consulting with other Pony
committers and comparing results, we feel this small change is a big
improvement when highlighting Pony's object literals.