### PR TITLE
Correct for Fortran literal number

### DIFF
--- a/src/languages/fortran.js
+++ b/src/languages/fortran.js
@@ -66,9 +66,9 @@ function(hljs) {
         contains: [hljs.UNDERSCORE_TITLE_MODE, PARAMS]
       },
       hljs.COMMENT('!', '$', {relevance: 0}),
-      {
+{
         className: 'number',
-        begin: '(?=\\b|\\+|\\-|\\.)(?=\\.\\d|\\d)(?:\\d+)?(?:\\.?\\d*)(?:[de][+-]?\\d+)?\\b\\.?',
+        begin: '(?=\\b|\\+|\\-|\\.)[+-]?(?:\\.|\\d+\\.?)\\d*([de][+-]?\\d+)?(_[a-z\\d]+)?\\b',
         relevance: 0
       }
     ]

--- a/src/languages/fortran.js
+++ b/src/languages/fortran.js
@@ -66,10 +66,10 @@ function(hljs) {
         contains: [hljs.UNDERSCORE_TITLE_MODE, PARAMS]
       },
       hljs.COMMENT('!', '$', {relevance: 0}),
- {
-    cN:"number",
-    b:"(?=\\b|\\+|\\-|\\.)[-]?(?:\\.|\\d+\\.?)\\d*([de][+-]?\\d+)?(_[a-z\\d]+)?\\b\\.?",
-    r:0
+      {
+        cN:"number",
+        b:"(?=\\b|\\+|\\-|\\.)(?:\\.|\\d+\\.?)\\d*([de][+-]?\\d+)?(_[a-z\\d]+)?\\b\\.?",
+        r:0
       }
     ]
   };

--- a/src/languages/fortran.js
+++ b/src/languages/fortran.js
@@ -66,10 +66,10 @@ function(hljs) {
         contains: [hljs.UNDERSCORE_TITLE_MODE, PARAMS]
       },
       hljs.COMMENT('!', '$', {relevance: 0}),
-{
-        className: 'number',
-        begin: '(?=\\b|\\+|\\-|\\.)[+-]?(?:\\.|\\d+\\.?)\\d*([de][+-]?\\d+)?(_[a-z\\d]+)?\\b',
-        relevance: 0
+ {
+    cN:"number",
+    b:"(?=\\b|\\+|\\-|\\.)[-]?(?:\\.|\\d+\\.?)\\d*([de][+-]?\\d+)?(_[a-z\\d]+)?\\b\\.?",
+    r:0
       }
     ]
   };


### PR DESCRIPTION
In modern fortran you can define the **kind** of intrinsic data type. It means you can define additional intrinsic data type. When you do so, for literal constants you have to use the kind name attached to literal consonant using under score (like a prefix `_newtype`).
Example:
 a = 12.23_dp

# How the current code works
When using the current highlight.js to highlight a Fortran code contains such named constant, highlight.js fails to do the job! It highlights the remaining code (from the position of named constant) in a wrong way!
![current_bug](https://user-images.githubusercontent.com/830394/50420480-096a2a00-084c-11e9-9944-7875cc1a2eec.png)

Note to line 4. The literal number has a `_DBL` suffix and it makes the current code breaks. The remaining highlighting is wrong.


# The Corrected code
The below image shows the corrected code output. As you can see the literal constant is highlighted correctly and there is no more error in the following texts.

![corrected_code](https://user-images.githubusercontent.com/830394/50420583-c5c3f000-084c-11e9-840d-718ba6d6a1ae.png)

Note to line four and following lines. The literal constants are highlighted correctly. Also note to line 5 the `WRITE` keyword in two image.




