### PR TITLE
fix(dart): Corrects highlighting with string interpolation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Improvements:
 - Added generic user-defined proc support, new compiler define, refactor to re-use rules, and add tests to *GAUSS*, by [Matthew Evans][]
 - Improve *Crystal* language to highlight regexes after some keywords, by [Tsuyusato Kitsune][]
 - Fix filterByQualifiers: fileInfo can be null
+- Fixed String interpolation in Dart, by [Scott Hyndman][].
 
 [Laurent Voullemier]: https://github.com/l-vo
 [Benoit de Chezelles]: https://github.com/bew
@@ -22,6 +23,7 @@ Improvements:
 [Ahmed Atito]: https://github.com/atitoa93
 [Matthew Evans]: https://github.com/matthewevans
 [Tsuyusato Kitsune]: https://github.com/MakeNowJust
+[Scott Hyndman]: https://github.com/shyndman
 
 ## Version 9.13.1
 

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -10,10 +10,16 @@ function (hljs) {
   var SUBST = {
     className: 'subst',
     variants: [
-       {begin: '\\${', end: '}'},
        {begin: '\\$[A-Za-z0-9_]+'}
     ],
-    keywords: 'true false null this is new super'
+  };
+
+  var BRACED_SUBST = {
+    className: 'subst',
+    variants: [
+       {begin: '\\${', end: '}'},
+    ],
+    keywords: 'true false null this is new super',
   };
 
   var STRING = {
@@ -35,25 +41,25 @@ function (hljs) {
       },
       {
         begin: '\'\'\'', end: '\'\'\'',
-        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST, BRACED_SUBST]
       },
       {
         begin: '"""', end: '"""',
-        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST, BRACED_SUBST]
       },
       {
         begin: '\'', end: '\'',
         illegal: '\\n',
-        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST, BRACED_SUBST]
       },
       {
         begin: '"', end: '"',
         illegal: '\\n',
-        contains: [hljs.BACKSLASH_ESCAPE, SUBST]
+        contains: [hljs.BACKSLASH_ESCAPE, SUBST, BRACED_SUBST]
       }
     ]
   };
-  SUBST.contains = [
+  BRACED_SUBST.contains = [
     hljs.C_NUMBER_MODE, STRING
   ];
 

--- a/test/markup/dart/string-interpolation.expect.txt
+++ b/test/markup/dart/string-interpolation.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-string">'1234<span class="hljs-subst">$identifier</span> <span class="hljs-subst">$true</span>'</span>;
+<span class="hljs-comment">// comment</span>
+<span class="hljs-string">'1234<span class="hljs-subst">${<span class="hljs-number">1234</span> + <span class="hljs-keyword">true</span> + <span class="hljs-string">'foo'</span>}</span>'</span>;

--- a/test/markup/dart/string-interpolation.txt
+++ b/test/markup/dart/string-interpolation.txt
@@ -1,0 +1,3 @@
+'1234$identifier $true';
+// comment
+'1234${1234 + true + 'foo'}';


### PR DESCRIPTION
Fixes #1941.

String interpolation in Dart can take two forms:
`'${bracedInterpolation + 'with strings'}'` and `'$identifierOnly'`

The previous grammar indicated that both forms could contain strings, when in actuality only the braced variant has this ability.

What we were seeing was that an identifier-only variant in a string's tail position would think the string's closing delimiter was the beginning of a contained string. The parser would then swallow up all characters until the next string delimiter. 