### PR TITLE
fix(Tcl): removed apostrophe string delimiters (don't exist)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ New languages:
 New styles:
 
 Improvements:
+- fix(Tcl): removed apostrophe string delimiters (don't exist)
 
 ## Version 9.14.1
 

--- a/src/languages/tcl.js
+++ b/src/languages/tcl.js
@@ -52,7 +52,6 @@ function(hljs) {
         className: 'string',
         contains: [hljs.BACKSLASH_ESCAPE],
         variants: [
-          hljs.inherit(hljs.APOS_STRING_MODE, {illegal: null}),
           hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null})
         ]
       },

--- a/test/detect/tcl/default.txt
+++ b/test/detect/tcl/default.txt
@@ -11,7 +11,7 @@ proc give::recursive::count {base p} { ; # 2 mandatory params
     return $result
 }
 
-set a 'a'; set b "bcdef"; set lst [list "item"]
+set a {a}; set b "bcdef"; set lst [list "item"]
 puts [llength $a$b]
 
 set ::my::tid($id) $::my::tid(def)


### PR DESCRIPTION
Tcl only has " as String delimiters - removed the ' line from the language definition.