### PR TITLE
Fix markdown in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Master
+
 New languages:
 
 New styles:
@@ -6,19 +7,26 @@ New styles:
 Improvements:
 
 ## Version 9.15.1
+
 New languages:
     none.
+
 New styles:
     none.
+
 Improvements:
+
 - Pony: Fixed keywords without spaces at line ends, highlighting of `iso` in class definitions, and function heads without bodies in traits and interfaces. Removed FUNCTION and CLASS modes until they are found to be needed and to provide some of the fixes.
  - Support external language files in minified version of highlight.js (#1888)
 
 ## Version 9.15
+
 New languages:
     none.
+
 New styles:
     none.
+
 Improvements:
  - new cli tool `hljs` - allows easier [building from command line](docs/building-testing.rst#building-a-bundle-from-the-command-line).
  - cpp: Fully support C++11 raw strings. (#1897)


### PR DESCRIPTION
Markdown ignores single line breaks, so everything was basically on
one line. Need to have empty lines between blocks of texts.