### PR TITLE
fix(markdown): indented lists

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -27,7 +27,7 @@ function(hljs) {
       // lists (indicators only)
       {
         className: 'bullet',
-        begin: '^([*+-]|(\\d+\\.))\\s+'
+        begin: '^\\s*([*+-]|(\\d+\\.))\\s+'
       },
       // strong segments
       {

--- a/test/markup/markdown/list.expect.txt
+++ b/test/markup/markdown/list.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-bullet">- </span>this is a list
+<span class="hljs-bullet">- </span>this is another
+<span class="hljs-bullet">  - </span>nested list
+<span class="hljs-bullet">    - </span>another nested
+<span class="hljs-bullet">    * </span>nested alternative

--- a/test/markup/markdown/list.txt
+++ b/test/markup/markdown/list.txt
@@ -1,0 +1,5 @@
+- this is a list
+- this is another
+  - nested list
+    - another nested
+    * nested alternative


### PR DESCRIPTION
This fixes #1821. Markdown lists can be indented and can contain space before the list item begins.