### PR TITLE
Fix continuation for JS/TS regexps.

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -91,6 +91,7 @@ function(hljs) {
       },
       { // "value" container
         begin: '(' + hljs.RE_STARTERS_RE + '|\\b(case|return|throw)\\b)\\s*',
+        endsWithParent: true,
         keywords: 'return throw case',
         contains: [
           hljs.C_LINE_COMMENT_MODE,

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -93,6 +93,7 @@ function(hljs) {
       },
       { // "value" container
         begin: '(' + hljs.RE_STARTERS_RE + '|\\b(case|return|throw)\\b)\\s*',
+        endsWithParent: true,
         keywords: 'return throw case',
         contains: [
           hljs.C_LINE_COMMENT_MODE,

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -4,7 +4,7 @@ let hljs   = require('../../build');
 let should = require('should');
 
 describe('.highlight()', function() {
-  it('should works without continuation', function() {
+  it('should work without continuation', function() {
     const code   = "public void moveTo(int x, int y, int z);";
     const result = hljs.highlight('java', code, false, false);
 
@@ -15,5 +15,15 @@ describe('.highlight()', function() {
       '<span class="hljs-keyword">int</span> y, ' +
       '<span class="hljs-keyword">int</span> z)</span></span>;'
     );
+  });
+
+  it('should work with continuation', function() {
+    const code1 = 'var x =';
+    const code2 = '    /\w+/;';
+    const result1 = hljs.highlight('javascript', code1, true);
+    const result2 = hljs.highlight('javascript', code2, true, result1.top);
+
+    result1.value.should.equal('<span class="hljs-keyword">var</span> x =');
+    result2.value.should.equal('    <span class="hljs-regexp">/\w+/</span>;');
   });
 });


### PR DESCRIPTION
Verified this works in `tools/developer.html`, but did not manage to runs the tests with `npm test` (complains about ../../build not being there even though it is there...). Hopefully CI can check if the other tests and the new one I added pass.

Fixes #1962.