### PR TITLE
ini/toml: Support comments on the same line.

### DIFF
--- a/src/languages/ini.js
+++ b/src/languages/ini.js
@@ -45,6 +45,8 @@ function(hljs) {
             begin: /=/, endsWithParent: true,
             relevance: 0,
             contains: [
+              hljs.COMMENT(';', '$'),
+              hljs.HASH_COMMENT_MODE,
               {
                 className: 'literal',
                 begin: /\bon|off|true|false|yes|no\b/

--- a/test/markup/ini/comments.expect.txt
+++ b/test/markup/ini/comments.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-comment"># Comment</span>
+<span class="hljs-comment">; ini-style comment</span>
+<span class="hljs-attr">x</span> = <span class="hljs-string">"abc"</span> <span class="hljs-comment"># Comment on same line</span>
+<span class="hljs-attr">y</span> = <span class="hljs-number">123</span> <span class="hljs-comment">; Comment on same line</span>
+<span class="hljs-section">[table]</span> <span class="hljs-comment">; Comment on same line</span>

--- a/test/markup/ini/comments.txt
+++ b/test/markup/ini/comments.txt
@@ -1,0 +1,5 @@
+# Comment
+; ini-style comment
+x = "abc" # Comment on same line
+y = 123 ; Comment on same line
+[table] ; Comment on same line

--- a/test/markup/ini/tables.expect.txt
+++ b/test/markup/ini/tables.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-section">[table]</span>
+<span class="hljs-section">[[array]]</span>
+<span class="hljs-section">[dotted.table.name]</span>
+<span class="hljs-section">[target.'cfg(unix)']</span>

--- a/test/markup/ini/tables.txt
+++ b/test/markup/ini/tables.txt
@@ -1,0 +1,4 @@
+[table]
+[[array]]
+[dotted.table.name]
+[target.'cfg(unix)']

--- a/test/markup/ini/types.expect.txt
+++ b/test/markup/ini/types.expect.txt
@@ -1,0 +1,20 @@
+<span class="hljs-attr">i</span> = <span class="hljs-number">1_234</span>
+<span class="hljs-attr">f</span> = <span class="hljs-number">1.23</span>
+<span class="hljs-attr">f</span> = <span class="hljs-number">7</span>e+<span class="hljs-number">12</span>
+<span class="hljs-attr">f</span> = <span class="hljs-number">2</span>e3
+<span class="hljs-attr">f</span> = -<span class="hljs-number">1.234</span>e-<span class="hljs-number">12</span>
+<span class="hljs-attr">basic</span> = <span class="hljs-string">"string"</span>
+<span class="hljs-attr">multi_basic</span> = <span class="hljs-string">"""multiple
+lines"""</span>
+<span class="hljs-attr">literal</span> = <span class="hljs-string">'string'</span>
+<span class="hljs-attr">multi_literal</span> = <span class="hljs-string">'''multiple
+lines'''</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">true</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">false</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">on</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">off</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">yes</span>
+<span class="hljs-attr">b</span> = <span class="hljs-literal">no</span>
+<span class="hljs-attr">dotted.key</span> = <span class="hljs-number">1</span>
+<span class="hljs-attr">array</span> = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]
+<span class="hljs-attr">inline</span> = {name = <span class="hljs-string">"foo"</span>, id = <span class="hljs-number">123</span>}

--- a/test/markup/ini/types.txt
+++ b/test/markup/ini/types.txt
@@ -1,0 +1,20 @@
+i = 1_234
+f = 1.23
+f = 7e+12
+f = 2e3
+f = -1.234e-12
+basic = "string"
+multi_basic = """multiple
+lines"""
+literal = 'string'
+multi_literal = '''multiple
+lines'''
+b = true
+b = false
+b = on
+b = off
+b = yes
+b = no
+dotted.key = 1
+array = [1, 2, 3]
+inline = {name = "foo", id = 123}

--- a/test/markup/ini/variable.expect.txt
+++ b/test/markup/ini/variable.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-attr">memory_limit</span> = <span class="hljs-variable">${PHP_MEMORY_LIMIT}</span>
+<span class="hljs-attr">key</span> = <span class="hljs-variable">$VAR1</span>

--- a/test/markup/ini/variable.txt
+++ b/test/markup/ini/variable.txt
@@ -1,0 +1,2 @@
+memory_limit = ${PHP_MEMORY_LIMIT}
+key = $VAR1


### PR DESCRIPTION
TOML supports comments on the end of the line:

```toml
x = 1 # comment on same line
```

And AFAIK, ini files tend to support it as well.

```ini
x = 1 ; comment
```