### PR TITLE
Fixing #1930 - Bash escaped double quotes

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -276,3 +276,4 @@ Contributors:
 - Sean T. Allen <sean@monkeysnatchbanana.com>
 - Greg Cline <gregrcline@gmail.com>
 - Sejin Jeon <jinaidy93@gmail.com>
+- Taif Alimov <inzeppelin@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ New languages:
 New styles:
 
 Improvements:
+- Issue #1930 - fix markup for escaped quotes in Bash
 
 ## Version 9.15.8
 

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -26,6 +26,11 @@ function(hljs) {
       }
     ]
   };
+  var ESCAPED_QUOTE = {
+    className: '',
+    begin: /\\"/
+
+  };
   var APOS_STRING = {
     className: 'string',
     begin: /'/, end: /'/
@@ -74,6 +79,7 @@ function(hljs) {
       },
       hljs.HASH_COMMENT_MODE,
       QUOTE_STRING,
+      ESCAPED_QUOTE,
       APOS_STRING,
       VAR
     ]

--- a/test/detect/bash/default.txt
+++ b/test/detect/bash/default.txt
@@ -13,3 +13,5 @@ fi
 genApacheConf(){
  echo -e "# Host ${HOME_DIR}$1/$2 :"
 }
+
+echo '"quoted"' | tr -d \" > text.txt

--- a/test/markup/bash/escaped-quote.expect.txt
+++ b/test/markup/bash/escaped-quote.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-comment"># Escaped double-quote is not a string</span>
+<span class="hljs-built_in">echo</span> <span class="hljs-string">'"quoted"'</span> | tr -d \" &gt; text.txt

--- a/test/markup/bash/escaped-quote.txt
+++ b/test/markup/bash/escaped-quote.txt
@@ -1,0 +1,2 @@
+# Escaped double-quote is not a string
+echo '"quoted"' | tr -d \" > text.txt


### PR DESCRIPTION
First PR broke Firefox due to negative lookbehind in regex  #2041 

This should fix #1930 

### Before:
hljs matches `\"` symbol as start position of string. And because of there is no ending quote, markup brakes after it.

<img width="527" alt="Screenshot 2019-05-27 at 13 06 42" src="https://user-images.githubusercontent.com/10027959/58413458-7b57d100-8081-11e9-88f1-dc66114f53c8.png">

### After:
Changing regexp helps to identify escaped quote and not use it as a string starter symbol.

<img width="528" alt="Screenshot 2019-05-27 at 13 06 21" src="https://user-images.githubusercontent.com/10027959/58413593-dbe70e00-8081-11e9-865f-f4ac63be5da8.png">


Speciall markup tests and example are also provided.