### PR TITLE
fix(go): correctly highlight hex numbers, rather than stopping at last 'd' or 'f'.

### DIFF
--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -36,7 +36,7 @@ function(hljs) {
       {
         className: 'number',
         variants: [
-          {begin: hljs.C_NUMBER_RE + '[dflsi]?', relevance: 0},
+          {begin: hljs.C_NUMBER_RE + '[i]', relevance: 1},
           hljs.C_NUMBER_MODE
         ]
       },

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -36,7 +36,7 @@ function(hljs) {
       {
         className: 'number',
         variants: [
-          {begin: hljs.C_NUMBER_RE + '[dflsi]', relevance: 1},
+          {begin: hljs.C_NUMBER_RE + '[dflsi]?', relevance: 0},
           hljs.C_NUMBER_MODE
         ]
       },

--- a/test/markup/go/numbers.expect.txt
+++ b/test/markup/go/numbers.expect.txt
@@ -1,3 +1,3 @@
-float_var := <span class="hljs-number">1.0e10f</span>
+float_var := <span class="hljs-number">1.0e10</span>
 complex_var := <span class="hljs-number">1.2e5</span>+<span class="hljs-number">2.3i</span>
 hex_int := <span class="hljs-number">0xcf3e4028ac084aea</span>

--- a/test/markup/go/numbers.expect.txt
+++ b/test/markup/go/numbers.expect.txt
@@ -1,2 +1,3 @@
 float_var := <span class="hljs-number">1.0e10f</span>
 complex_var := <span class="hljs-number">1.2e5</span>+<span class="hljs-number">2.3i</span>
+hex_int := <span class="hljs-number">0xcf3e4028ac084aea</span>

--- a/test/markup/go/numbers.txt
+++ b/test/markup/go/numbers.txt
@@ -1,3 +1,3 @@
-float_var := 1.0e10f
+float_var := 1.0e10
 complex_var := 1.2e5+2.3i
 hex_int := 0xcf3e4028ac084aea

--- a/test/markup/go/numbers.txt
+++ b/test/markup/go/numbers.txt
@@ -1,2 +1,3 @@
 float_var := 1.0e10f
 complex_var := 1.2e5+2.3i
+hex_int := 0xcf3e4028ac084aea


### PR DESCRIPTION
Also had to lower number relevance to 0 to avoid misidentifying JS as Go in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highlightjs/highlight.js/2060)
<!-- Reviewable:end -->
