### PR TITLE
Add new language: RPM Specfile

### DIFF
--- a/src/languages/rpm-specfile.js
+++ b/src/languages/rpm-specfile.js
@@ -1,0 +1,58 @@
+/*
+Language: rpm-specfile
+Description: RPM Specfile
+Author: Ryan Lerch <rlerch@redhat.com>
+Contributors: Neal Gompa <ngompa13@gmail.com>
+Category: config
+Requires: bash.js
+Website: https://rpm.org/
+*/
+
+function(hljs) {
+  return {
+    aliases: ['rpm', 'spec', 'rpm-spec', 'specfile'],
+    contains: [
+        hljs.COMMENT('%dnl'),
+        hljs.HASH_COMMENT_MODE,
+        hljs.APOS_STRING_MODE,
+        hljs.QUOTE_STRING_MODE,
+        {
+            className: "type",
+            begin:  /^(Name|BuildRequires|Version|Release|Epoch|Summary|Group|License|Packager|Vendor|Icon|URL|Distribution|Prefix|Patch[0-9]*|Source[0-9]*|Requires\(?[a-z]*\)?|[a-z]+Req|Obsoletes|Recommends|Suggests|Supplements|Enhances|Provides|Conflicts|RemovePathPostfixes|Build[a-z]+|[a-z]+Arch|Auto[a-z]+)(:)/,
+        },
+        {
+            className: "keyword",
+            begin: /(%)(?:package|prep|generate_buildrequires|sourcelist|patchlist|build|description|install|verifyscript|clean|changelog|check|pre[a-z]*|post[a-z]*|trigger[a-z]*|files)/,
+        },
+        {
+            className: "link",
+            begin: /(%)(if|ifarch|ifnarch|ifos|ifnos|elif|elifarch|elifos|else|endif)/,
+        },
+        {
+            className: "link",
+            begin: /%\{_/,
+            end: /}/,
+        },
+        {
+            className: "symbol",
+            begin: /%\{\?/,
+            end: /}/,
+        },
+        {
+            className: "link font-weight-bold",
+            begin: /%\{/,
+            end: /}/,
+        },
+        {
+            className: "link font-weight-bold",
+            begin: /%/,
+            end: /[ \t\n]/
+        },
+        {
+            className: "symbol font-weight-bold",
+            begin: /^\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun)/,
+            end: /$/,
+        },
+    ]
+  };
+}

--- a/test/detect/rpm-specfile/default.txt
+++ b/test/detect/rpm-specfile/default.txt
@@ -1,0 +1,56 @@
+Name:		hello
+Version:	2.10
+Release:	1%{?dist}
+Summary:	The "Hello World" program from GNU
+Group:		Unspecified
+License:	GPLv3+
+URL:		https://www.gnu.org/software/hello/
+Source:		https://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
+
+BuildRequires:	gettext
+
+
+%description
+The GNU Hello program produces a familiar, friendly greeting.
+
+Yes, this is another implementation of the classic program that prints
+"Hello, world!" when you run it.
+
+However, unlike the minimal version often seen, GNU Hello processes its
+argument list to modify its behavior, supports greetings in many languages,
+and so on.
+
+The primary purpose of GNU Hello is to demonstrate how to write other programs
+that do these things; it serves as a model for GNU coding standards and
+GNU maintainer practices.
+
+
+%prep
+# Unpacks the sources and applies patches...
+%autosetup
+
+
+%build
+# Configures the source tree and builds it...
+%configure
+%make_build
+
+
+%install
+# Installs to the buildroot to for wrapping in a package...
+%make_install
+%find_lang %{name}
+rm -f %{buildroot}/%{_infodir}/dir
+
+
+%files -f %{name}.lang
+%doc ChangeLog NEWS README TODO
+%license COPYING AUTHORS THANKS
+%{_bindir}/hello
+%{_mandir}/man1/hello.1*
+%{_infodir}/hello.info*
+
+
+%changelog
+* Fri Nov 14 00:00:00 UTC 2014 Ty Coon <tycoon@example.org> - 2.10-1
+- Initial version of the package


### PR DESCRIPTION
This adds basic RPM spec file syntax highlighting. This was originally implemented for [Pagure](https://pagure.io/pagure) when it switched to highlight.js.

This file was reworked for inclusion in upstream highlight.js.
