### PR TITLE
Support css custom properties

### DIFF
--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -6,7 +6,7 @@ Category: common, css
 function(hljs) {
   var IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
   var RULE = {
-    begin: /[A-Z\_\.\-]+\s*:/, returnBegin: true, end: ';', endsWithParent: true,
+    begin: /(?:[A-Z\_\.\-]+|--[a-zA-Z0-9_-]+)\s*:/, returnBegin: true, end: ';', endsWithParent: true,
     contains: [
       {
         className: 'attribute',


### PR DESCRIPTION
Support custom properties syntax:
```
.selector {
  --heading-1: 30px/32px Helvetica, sans-serif;
}
```

Since css vars have the same naming rules, digits could be used in naming.

Proofs:
https://drafts.csswg.org/css-variables-1/#custom-property
https://drafts.csswg.org/css-syntax-3/#identifier
https://drafts.csswg.org/css-syntax-3/#ident-token-diagram