### PR TITLE
Fixed version number in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ it can be added manually:
 ```html
 <script
  charset="UTF-8"
- src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/go.min.js"></script>
+ src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.9/languages/go.min.js"></script>
 ```
 
 **On Almond.** You need to use the optimizer to give the module a name. For


### PR DESCRIPTION
The current version number of `go.min.js` is wrong.