### PR TITLE
Kotlin parenthesized types in function declaration

### DIFF
--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -107,6 +107,19 @@ function(hljs) {
     '/\\*', '\\*/',
     { contains: [ hljs.C_BLOCK_COMMENT_MODE ] }
   );
+  var KOTLIN_PAREN_TYPE = {
+    variants: [
+	  { className: 'type',
+	    begin: hljs.UNDERSCORE_IDENT_RE
+	  },
+	  { begin: /\(/, end: /\)/,
+	    contains: [] //defined later
+	  }
+	]
+  };
+  var KOTLIN_PAREN_TYPE2 = KOTLIN_PAREN_TYPE;
+  KOTLIN_PAREN_TYPE2.variants[1].contains = [ KOTLIN_PAREN_TYPE ];
+  KOTLIN_PAREN_TYPE.variants[1].contains = [ KOTLIN_PAREN_TYPE2 ];
 
   return {
     aliases: ['kt'],
@@ -158,7 +171,7 @@ function(hljs) {
               {
                 begin: /:/, end: /[=,\/]/, endsWithParent: true,
                 contains: [
-                  {className: 'type', begin: hljs.UNDERSCORE_IDENT_RE},
+                  KOTLIN_PAREN_TYPE,
                   hljs.C_LINE_COMMENT_MODE,
                   KOTLIN_NESTED_COMMENT
                 ],

--- a/test/markup/kotlin/function.expect.txt
+++ b/test/markup/kotlin/function.expect.txt
@@ -11,3 +11,6 @@
     b : <span class="hljs-type">String</span> <span class="hljs-comment">//b</span>
 )</span></span>
 {}
+
+
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;OUT&gt;</span> <span class="hljs-title">handle</span><span class="hljs-params">(lambda: (<span class="hljs-type">IN</span>) <span class="hljs-comment">/* parenthesized type */</span> -&gt; <span class="hljs-type">OUT</span>)</span></span> {}

--- a/test/markup/kotlin/function.txt
+++ b/test/markup/kotlin/function.txt
@@ -11,3 +11,6 @@ fun e(
     b : String //b
 )
 {}
+
+
+fun <OUT> handle(lambda: (IN) /* parenthesized type */ -> OUT) {}


### PR DESCRIPTION
Fixes  #2091