### PR TITLE
Docs(move-notice): lang names and aliases table (#2096)

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -131,3 +131,10 @@ Stylable classes
 +--------------------------+---------------------------------------------------+
 | module                   | ReasonML module reference within scope access     |
 +--------------------------+---------------------------------------------------+
+
+
+Language names and aliases
+--------------------------
+
+The language names and aliases table has moved to the project
+[README](https://github.com/highlightjs/highlight.js)


### PR DESCRIPTION
As an update to #2096 this PR adds a simple *Moved-Notice* to the original docs page. Also, by re-using the original section header text old hyperlinks referencing the original page with the `#language-names-and-aliases` page-anchor should work again.