### PR TITLE
fix escaping in markdown `code` rules

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -54,13 +54,13 @@ function(hljs) {
         className: 'code',
         variants: [
           {
-            begin: '^```\w*\s*$', end: '^```\s*$'
+            begin: '^```\\w*\\s*$', end: '^```[ ]*$'
           },
           {
             begin: '`.+?`'
           },
           {
-            begin: '^( {4}|\t)', end: '$',
+            begin: '^( {4}|\\t)', end: '$',
             relevance: 0
           }
         ]


### PR DESCRIPTION
The old ruleset only matched "by accident". I imagine the 2nd rule would trigger from the termination match and then when the tiny "```" lexeme was processed the first rule would now incorrectly trigger since it just happens to match even despite the typos.

Ditto for the end tag... otherwise I can't see how it was ever working.