### PR TITLE
feat(powershell): add ps1 as alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ work for you, you can specify the language in the `class` attribute:
 | Plaintext: no highlight | plaintext              |         |
 | Pony                    | pony                   |         |
 | PostgreSQL & PL/pgSQL   | pgsql, postgres, postgresql |    |
-| PowerShell              | powershell, ps         |         |
+| PowerShell              | powershell, ps, ps1    |         |
 | Processing              | processing             |         |
 | Prolog                  | prolog                 |         |
 | Properties              | properties             |         |

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -60,7 +60,7 @@ function(hljs){
   });
 
   return {
-    aliases: ["ps"],
+    aliases: ["ps", "ps1"],
     lexemes: /-?[A-z\.\-]+/,
     case_insensitive: true,
     keywords: {


### PR DESCRIPTION
PowerShell script files are suffixed by `.ps1`

Reference: https://en.wikipedia.org/wiki/PowerShell#Design