### PR TITLE
feat(javascript): Add big number syntax (n postfix)

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -28,9 +28,9 @@ function(hljs) {
   var NUMBER = {
     className: 'number',
     variants: [
-      { begin: '\\b(0[bB][01]+)' },
-      { begin: '\\b(0[oO][0-7]+)' },
-      { begin: hljs.C_NUMBER_RE }
+      { begin: '\\b(0[bB][01]+)n?' },
+      { begin: '\\b(0[oO][0-7]+)n?' },
+      { begin: hljs.C_NUMBER_RE + 'n?' }
     ],
     relevance: 0
   };

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -61,9 +61,9 @@ function(hljs) {
   var NUMBER = {
     className: 'number',
     variants: [
-      { begin: '\\b(0[bB][01]+)' },
-      { begin: '\\b(0[oO][0-7]+)' },
-      { begin: hljs.C_NUMBER_RE }
+      { begin: '\\b(0[bB][01]+)n?' },
+      { begin: '\\b(0[oO][0-7]+)n?' },
+      { begin: hljs.C_NUMBER_RE + 'n?' }
     ],
     relevance: 0
   };


### PR DESCRIPTION
Fixes #1797 - allows a `n` postfix for the JavaScript big integer syntax: https://github.com/tc39/proposal-bigint