### PR TITLE
[javascript] fix attributes following comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ New styles:
 - *Night Owl* by [Carl Baxter][]
 
 Improvements:
+- fix(javascript): fix object attributes immediately following line comments
 - fix(Elixir): improve regex for numbers
 - JSON: support for comments in JSON (#2016)
 - fix(cpp): improve string literal matching

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -106,7 +106,7 @@ function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE,
       NUMBER,
       { // object attr container
-        begin: /[{,]\s*/, relevance: 0,
+        begin: /[{,\n]\s*/, relevance: 0,
         contains: [
           {
             begin: IDENT_RE + '\\s*:', returnBegin: true,

--- a/test/markup/javascript/object-attr.expect.txt
+++ b/test/markup/javascript/object-attr.expect.txt
@@ -1,5 +1,5 @@
 {
-  <span class="hljs-attr">key</span>: value,
+  <span class="hljs-attr">key</span>: value, <span class="hljs-comment">// with comment</span>
   <span class="hljs-attr">key2</span>: value,
   <span class="hljs-string">'key-3'</span>: value,
   <span class="hljs-attr">key4</span>: <span class="hljs-literal">false</span> ? <span class="hljs-literal">undefined</span> : <span class="hljs-literal">true</span>

--- a/test/markup/javascript/object-attr.txt
+++ b/test/markup/javascript/object-attr.txt
@@ -1,5 +1,5 @@
 {
-  key: value,
+  key: value, // with comment
   key2: value,
   'key-3': value,
   key4: false ? undefined : true


### PR DESCRIPTION
Attributes are now allowed to start after a newline and nothing but empty space.  I couldn't think of what else that might be in Javascript other than an attribute, but correct me if I'm not thinking of something.

This matching is VERY fuzzy in the first place. :-)