### PR TITLE
(handlebars)  support for segment-literals and escaped mustaches

### DIFF
--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -6,8 +6,12 @@ Description: Matcher for Handlebars as well as EmberJS additions.
 Website: https://handlebarsjs.com
 Category: template
 */
-function(hljs) {
+function (hljs) {
   var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view lookup'};
+
+  var IDENTIFIER_PLAIN_OR_QUOTED = {
+    begin: /("[^"]+"|'[^']+'|\[[^\]]+\]|\w+)/
+  };
 
   function BLOCK_MUSTACHE_CONTENTS() {
     return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
@@ -23,7 +27,7 @@ function(hljs) {
   }
 
   function EXPRESSION_OR_HELPER_CALL() {
-    return  hljs.inherit(EXPRESSION(), {
+    return hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {
       keywords: BUILT_INS,
       starts: HELPER_PARAMETERS()
     });
@@ -34,16 +38,10 @@ function(hljs) {
       endsWithParent: true,
       relevance: 0,
       contains: [
-        hljs.inherit(EXPRESSION(), {
+        hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {
           relevance: 0
         })
       ]
-    };
-  }
-
-  function EXPRESSION() {
-    return  {
-      begin: /("[^"]+"|'[^']+'|\[[^\]]+\]|\w+)/
     };
   }
 

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -48,36 +48,6 @@ function (hljs) {
   var ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH = {begin: /\\\{\{/, skip: true};
   var PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH = {begin: /\\\\(?=\{\{)/, skip: true};
 
-  var OPEN_RAW_BLOCK = {
-    className: 'template-tag',
-    begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
-    contains: [BLOCK_MUSTACHE_CONTENTS()],
-    starts: {end: /\{\{\{\{\//, returnEnd: true, subLanguage: 'xml'}
-  };
-  var CLOSE_RAW_BLOCK = {
-    className: 'template-tag',
-    begin: /\{\{\{\{\//, end: /\}\}\}\}/,
-    contains: [BLOCK_MUSTACHE_CONTENTS()]
-  };
-  var STANDARD_BLOCK = {
-    className: 'template-tag',
-    begin: /\{\{[#\/]/, end: /\}\}/,
-    contains: [BLOCK_MUSTACHE_CONTENTS()],
-  };
-  var UNESCAPED_OUTPUT = {
-    className: 'template-variable',
-    begin: /\{\{\{/, end: /\}\}\}/,
-    keywords: BUILT_INS,
-    contains: [BASIC_MUSTACHE_CONTENTS()]
-  };
-  var HTML_ESCAPED_OUTPUT = {
-    className: 'template-variable',
-    begin: /\{\{/, end: /\}\}/,
-    keywords: BUILT_INS,
-    contains: [
-      BASIC_MUSTACHE_CONTENTS()
-    ]
-  };
   return {
     aliases: ['hbs', 'html.hbs', 'html.handlebars'],
     case_insensitive: true,
@@ -87,11 +57,41 @@ function (hljs) {
       PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH,
       hljs.COMMENT(/\{\{!--/, /--\}\}/),
       hljs.COMMENT(/\{\{!/, /\}\}/),
-      OPEN_RAW_BLOCK,
-      CLOSE_RAW_BLOCK,
-      STANDARD_BLOCK,
-      UNESCAPED_OUTPUT,
-      HTML_ESCAPED_OUTPUT
+      {
+        // open raw block "{{{{raw}}}} content not evaluated {{{{/raw}}}}"
+        className: 'template-tag',
+        begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
+        contains: [BLOCK_MUSTACHE_CONTENTS()],
+        starts: {end: /\{\{\{\{\//, returnEnd: true, subLanguage: 'xml'}
+      },
+      {
+        // close raw block
+        className: 'template-tag',
+        begin: /\{\{\{\{\//, end: /\}\}\}\}/,
+        contains: [BLOCK_MUSTACHE_CONTENTS()]
+      },
+      {
+        // open block statement
+        className: 'template-tag',
+        begin: /\{\{[#\/]/, end: /\}\}/,
+        contains: [BLOCK_MUSTACHE_CONTENTS()],
+      },
+      {
+        // template variable or helper-call that is NOT html-escaped
+        className: 'template-variable',
+        begin: /\{\{\{/, end: /\}\}\}/,
+        keywords: BUILT_INS,
+        contains: [BASIC_MUSTACHE_CONTENTS()]
+      },
+      {
+        // template variable or helper-call that is html-escaped
+        className: 'template-variable',
+        begin: /\{\{/, end: /\}\}/,
+        keywords: BUILT_INS,
+        contains: [
+          BASIC_MUSTACHE_CONTENTS()
+        ]
+      }
     ]
   };
 }

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -6,7 +6,7 @@ Description: Matcher for Handlebars as well as EmberJS additions.
 Website: https://handlebarsjs.com
 Category: template
 */
-function handlebars(hljs) {
+function(hljs) {
   var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view lookup'};
 
   function BLOCK_MUSTACHE_CONTENTS() {

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -45,8 +45,8 @@ function (hljs) {
     };
   }
 
-  var ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH = {begin: /\\{{/, skip: true};
-  var PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH = {begin: /\\\\(?={{)/, skip: true};
+  var ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH = {begin: /\\\{\{/, skip: true};
+  var PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH = {begin: /\\\\(?=\{\{)/, skip: true};
 
   var OPEN_RAW_BLOCK = {
     className: 'template-tag',

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -52,6 +52,10 @@ function (hljs) {
     contains: [
       hljs.COMMENT(/\{\{!--/, /--\}\}/),
       hljs.COMMENT(/\{\{!/, /\}\}/),
+      {
+        begin: /\\{{/,
+        skip: true
+      },
       // raw block (open) {{{{raw}}}} verbatim xml {{{{/raw}} {{handlebars}}
       {
         className: 'template-tag',

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -16,14 +16,14 @@ function (hljs) {
   function BLOCK_MUSTACHE_CONTENTS() {
     return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
       className: 'name'
-    })
+    });
   }
 
   function BASIC_MUSTACHE_CONTENTS() {
     return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
       // relevance 0 for backward compatibility concerning auto-detection
       relevance: 0
-    })
+    });
   }
 
   function EXPRESSION_OR_HELPER_CALL() {

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -45,70 +45,53 @@ function (hljs) {
     };
   }
 
+  var ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH = {begin: /\\{{/, skip: true};
+  var PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH = {begin: /\\\\(?={{)/, skip: true};
+
+  var OPEN_RAW_BLOCK = {
+    className: 'template-tag',
+    begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
+    contains: [BLOCK_MUSTACHE_CONTENTS()],
+    starts: {end: /\{\{\{\{\//, returnEnd: true, subLanguage: 'xml'}
+  };
+  var CLOSE_RAW_BLOCK = {
+    className: 'template-tag',
+    begin: /\{\{\{\{\//, end: /\}\}\}\}/,
+    contains: [BLOCK_MUSTACHE_CONTENTS()]
+  };
+  var STANDARD_BLOCK = {
+    className: 'template-tag',
+    begin: /\{\{[#\/]/, end: /\}\}/,
+    contains: [BLOCK_MUSTACHE_CONTENTS()],
+  };
+  var UNESCAPED_OUTPUT = {
+    className: 'template-variable',
+    begin: /\{\{\{/, end: /\}\}\}/,
+    keywords: BUILT_INS,
+    contains: [BASIC_MUSTACHE_CONTENTS()]
+  };
+  var HTML_ESCAPED_OUTPUT = {
+    className: 'template-variable',
+    begin: /\{\{/, end: /\}\}/,
+    keywords: BUILT_INS,
+    contains: [
+      BASIC_MUSTACHE_CONTENTS()
+    ]
+  };
   return {
     aliases: ['hbs', 'html.hbs', 'html.handlebars'],
     case_insensitive: true,
     subLanguage: 'xml',
     contains: [
+      ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH,
+      PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH,
       hljs.COMMENT(/\{\{!--/, /--\}\}/),
       hljs.COMMENT(/\{\{!/, /\}\}/),
-      // Prevent escaping mustaches
-      {
-        begin: /\\\\(?={{)/,
-        skip: true
-      },
-      // Escaped mustache
-      {
-        begin: /\\{{/,
-        skip: true
-      },
-      // raw block (open) {{{{raw}}}} verbatim xml {{{{/raw}} {{handlebars}}
-      {
-        className: 'template-tag',
-        begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
-        contains: [
-          BLOCK_MUSTACHE_CONTENTS()
-        ],
-        starts: {
-          end: /\{\{\{\{\//,
-          returnEnd: true,
-          subLanguage: 'xml'
-        }
-      },
-      // raw block (close)
-      {
-        className: 'template-tag',
-        begin: /\{\{\{\{\//, end: /\}\}\}\}/,
-        contains: [
-          BLOCK_MUSTACHE_CONTENTS()
-        ]
-      },
-      // standard blocks {{#block}} ... {{/block}}
-      {
-        className: 'template-tag',
-        begin: /\{\{[#\/]/, end: /\}\}/,
-        contains: [
-          BLOCK_MUSTACHE_CONTENTS()
-        ],
-      },
-      // triple mustaches {{{unescapedOutput}}}
-      {
-        className: 'template-variable',
-        begin: /\{\{\{/, end: /\}\}\}/,
-        keywords: BUILT_INS,
-        contains: [
-          BASIC_MUSTACHE_CONTENTS()
-        ]
-      },
-      // standard mustaches {{{htmlEscapedOutput}}}
-      {
-        className: 'template-variable',
-        begin: /\{\{/, end: /\}\}/,
-        keywords: BUILT_INS,
-        contains: [
-          BASIC_MUSTACHE_CONTENTS()
-        ]
-      }
+      OPEN_RAW_BLOCK,
+      CLOSE_RAW_BLOCK,
+      STANDARD_BLOCK,
+      UNESCAPED_OUTPUT,
+      HTML_ESCAPED_OUTPUT
     ]
   };
 }

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -52,6 +52,12 @@ function (hljs) {
     contains: [
       hljs.COMMENT(/\{\{!--/, /--\}\}/),
       hljs.COMMENT(/\{\{!/, /\}\}/),
+      // Prevent escaping mustaches
+      {
+        begin: /\\\\(?={{)/,
+        skip: true
+      },
+      // Escaped mustache
       {
         begin: /\\{{/,
         skip: true

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -7,7 +7,7 @@ Website: https://handlebarsjs.com
 Category: template
 */
 function (hljs) {
-  var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view lookup'};
+  var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view yield lookup'};
 
   var IDENTIFIER_PLAIN_OR_QUOTED = {
     begin: /".*?"|'.*?'|\[.*?\]|\w+/

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -10,7 +10,7 @@ function (hljs) {
   var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view lookup'};
 
   var IDENTIFIER_PLAIN_OR_QUOTED = {
-    begin: /("[^"]+"|'[^']+'|\[[^\]]+\]|\w+)/
+    begin: /".*?"|'.*?'|\[.*?\]|\w+/
   };
 
   function BLOCK_MUSTACHE_CONTENTS() {

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -6,19 +6,44 @@ Description: Matcher for Handlebars as well as EmberJS additions.
 Website: https://handlebarsjs.com
 Category: template
 */
-function(hljs) {
-  var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view yield lookup'};
-  function MUSTACHE_CONTENTS() {
-    return  {
-      className: 'name',
-      begin: /[a-zA-Z\.-]+/,
+function handlebars(hljs) {
+  var BUILT_INS = {'builtin-name': 'each in with if else unless bindattr action collection debugger log outlet template unbound view lookup'};
+
+  function BLOCK_MUSTACHE_CONTENTS() {
+    return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
+      className: 'name'
+    })
+  }
+
+  function BASIC_MUSTACHE_CONTENTS() {
+    return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
+      // relevance 0 for backward compatibility concerning auto-detection
+      relevance: 0
+    })
+  }
+
+  function EXPRESSION_OR_HELPER_CALL() {
+    return  hljs.inherit(EXPRESSION(), {
       keywords: BUILT_INS,
-      starts: {
-        endsWithParent: true, relevance: 0,
-        contains: [
-          hljs.QUOTE_STRING_MODE
-        ]
-      }
+      starts: HELPER_PARAMETERS()
+    });
+  }
+
+  function HELPER_PARAMETERS() {
+    return {
+      endsWithParent: true,
+      relevance: 0,
+      contains: [
+        hljs.inherit(EXPRESSION(), {
+          relevance: 0
+        })
+      ]
+    };
+  }
+
+  function EXPRESSION() {
+    return  {
+      begin: /("[^"]+"|'[^']+'|\[[^\]]+\]|\w+)/
     };
   }
 
@@ -33,7 +58,9 @@ function(hljs) {
       {
         className: 'template-tag',
         begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
-        contains: [MUSTACHE_CONTENTS()],
+        contains: [
+          BLOCK_MUSTACHE_CONTENTS()
+        ],
         starts: {
           end: /\{\{\{\{\//,
           returnEnd: true,
@@ -44,25 +71,35 @@ function(hljs) {
       {
         className: 'template-tag',
         begin: /\{\{\{\{\//, end: /\}\}\}\}/,
-        contains: [MUSTACHE_CONTENTS()]
+        contains: [
+          BLOCK_MUSTACHE_CONTENTS()
+        ]
       },
       // standard blocks {{#block}} ... {{/block}}
       {
         className: 'template-tag',
         begin: /\{\{[#\/]/, end: /\}\}/,
-        contains: [MUSTACHE_CONTENTS()],
+        contains: [
+          BLOCK_MUSTACHE_CONTENTS()
+        ],
       },
       // triple mustaches {{{unescapedOutput}}}
       {
         className: 'template-variable',
         begin: /\{\{\{/, end: /\}\}\}/,
-        keywords: BUILT_INS
+        keywords: BUILT_INS,
+        contains: [
+          BASIC_MUSTACHE_CONTENTS()
+        ]
       },
       // standard mustaches {{{htmlEscapedOutput}}}
       {
         className: 'template-variable',
         begin: /\{\{/, end: /\}\}/,
-        keywords: BUILT_INS
+        keywords: BUILT_INS,
+        contains: [
+          BASIC_MUSTACHE_CONTENTS()
+        ]
       }
     ]
   };

--- a/test/markup/handlebars/block-expression-variants-as-path-segment.expect.txt
+++ b/test/markup/handlebars/block-expression-variants-as-path-segment.expect.txt
@@ -1,0 +1,9 @@
+<span class="xml">text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> abcd.[lite"'ral}}segment] }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> abcd."lite]'ral}}segment" }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> abcd.'lite]"ral}}segment' }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text
+
+</span>

--- a/test/markup/handlebars/block-expression-variants-as-path-segment.txt
+++ b/test/markup/handlebars/block-expression-variants-as-path-segment.txt
@@ -1,0 +1,8 @@
+text {{#abc abcd.[lite"'ral}}segment] }}a{{/abc}}
+
+text {{#abc abcd."lite]'ral}}segment" }}a{{/abc}}
+
+text {{#abc abcd.'lite]"ral}}segment' }}a{{/abc}}
+
+text
+

--- a/test/markup/handlebars/block-expression-variants-in-helper-name.expect.txt
+++ b/test/markup/handlebars/block-expression-variants-in-helper-name.expect.txt
@@ -1,0 +1,8 @@
+<span class="xml">text </span><span class="hljs-template-tag">{{#<span class="hljs-name">[ab}}c]</span> param }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">[ab}}c]</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#[<span class="hljs-name">'ab}}c'</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">'ab}}c'</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">"ab}}c"</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">"ab}}c"</span>}}</span><span class="xml">
+
+text
+</span>

--- a/test/markup/handlebars/block-expression-variants-in-helper-name.expect.txt
+++ b/test/markup/handlebars/block-expression-variants-in-helper-name.expect.txt
@@ -1,8 +1,14 @@
 <span class="xml">text </span><span class="hljs-template-tag">{{#<span class="hljs-name">[ab}}c]</span> param }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">[ab}}c]</span>}}</span><span class="xml">
 
-text </span><span class="hljs-template-tag">{{#[<span class="hljs-name">'ab}}c'</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">'ab}}c'</span>}}</span><span class="xml">
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">'ab}}c'</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">'ab}}c'</span>}}</span><span class="xml">
 
 text </span><span class="hljs-template-tag">{{#<span class="hljs-name">"ab}}c"</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">"ab}}c"</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">""</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">""</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">''</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">''</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">[]</span> param}}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">[]</span>}}</span><span class="xml">
 
 text
 </span>

--- a/test/markup/handlebars/block-expression-variants-in-helper-name.txt
+++ b/test/markup/handlebars/block-expression-variants-in-helper-name.txt
@@ -1,0 +1,7 @@
+text {{#[ab}}c] param }}a{{/[ab}}c]}}
+
+text {{#['ab}}c' param}}a{{/'ab}}c'}}
+
+text {{#"ab}}c" param}}a{{/"ab}}c"}}
+
+text

--- a/test/markup/handlebars/block-expression-variants-in-helper-name.txt
+++ b/test/markup/handlebars/block-expression-variants-in-helper-name.txt
@@ -1,7 +1,13 @@
 text {{#[ab}}c] param }}a{{/[ab}}c]}}
 
-text {{#['ab}}c' param}}a{{/'ab}}c'}}
+text {{#'ab}}c' param}}a{{/'ab}}c'}}
 
 text {{#"ab}}c" param}}a{{/"ab}}c"}}
+
+text {{#"" param}}a{{/""}}
+
+text {{#'' param}}a{{/''}}
+
+text {{#[] param}}a{{/[]}}
 
 text

--- a/test/markup/handlebars/block-expression-variants-in-param.expect.txt
+++ b/test/markup/handlebars/block-expression-variants-in-param.expect.txt
@@ -1,0 +1,8 @@
+<span class="xml">text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> "lite]'ral}}segment" }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> 'lite]"ral}}segment' }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text </span><span class="hljs-template-tag">{{#<span class="hljs-name">abc</span> [lite"'ral}}segment] }}</span><span class="xml">a</span><span class="hljs-template-tag">{{/<span class="hljs-name">abc</span>}}</span><span class="xml">
+
+text
+</span>

--- a/test/markup/handlebars/block-expression-variants-in-param.txt
+++ b/test/markup/handlebars/block-expression-variants-in-param.txt
@@ -1,0 +1,7 @@
+text {{#abc "lite]'ral}}segment" }}a{{/abc}}
+
+text {{#abc 'lite]"ral}}segment' }}a{{/abc}}
+
+text {{#abc [lite"'ral}}segment] }}a{{/abc}}
+
+text

--- a/test/markup/handlebars/escaped-mustaches.expect.txt
+++ b/test/markup/handlebars/escaped-mustaches.expect.txt
@@ -5,4 +5,11 @@
 \{{#no}} block \{{/no}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
 
 \{{\{{no}}}} block \{{\{{/no}}}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\\</span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\\\</span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\\\\</span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
 </span>

--- a/test/markup/handlebars/escaped-mustaches.expect.txt
+++ b/test/markup/handlebars/escaped-mustaches.expect.txt
@@ -1,0 +1,8 @@
+<span class="xml">\{{no-expression}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\{{{no-expression}}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\{{#no}} block \{{/no}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+
+\{{\{{no}}}} block \{{\{{/no}}}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+</span>

--- a/test/markup/handlebars/escaped-mustaches.expect.txt
+++ b/test/markup/handlebars/escaped-mustaches.expect.txt
@@ -1,10 +1,16 @@
-<span class="xml">\{{no-expression}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+<span class="xml">\{{no-expression}}
 
-\{{{no-expression}}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+\{{{no-expression}}}
 
-\{{#no}} block \{{/no}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+\{{#no}} block \{{/no}}
 
-\{{\{{no}}}} block \{{\{{/no}}}} </span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
+\{{\{{no}}}} block \{{\{{/no}}}}
+
+\{{!-- no comment --}}
+
+\{{! no comment }}
+
+<span class="hljs-comment">&lt;!-- escaped escapings --&gt;</span>
 
 \\</span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
 
@@ -12,4 +18,5 @@
 
 \\\\</span><span class="hljs-template-variable">{{expression}}</span><span class="xml">
 
+\\\</span><span class="hljs-comment">{{! comment }}</span><span class="xml">
 </span>

--- a/test/markup/handlebars/escaped-mustaches.txt
+++ b/test/markup/handlebars/escaped-mustaches.txt
@@ -1,0 +1,7 @@
+\{{no-expression}} {{expression}}
+
+\{{{no-expression}}} {{expression}}
+
+\{{#no}} block \{{/no}} {{expression}}
+
+\{{\{{no}}}} block \{{\{{/no}}}} {{expression}}

--- a/test/markup/handlebars/escaped-mustaches.txt
+++ b/test/markup/handlebars/escaped-mustaches.txt
@@ -1,10 +1,16 @@
-\{{no-expression}} {{expression}}
+\{{no-expression}}
 
-\{{{no-expression}}} {{expression}}
+\{{{no-expression}}}
 
-\{{#no}} block \{{/no}} {{expression}}
+\{{#no}} block \{{/no}}
 
-\{{\{{no}}}} block \{{\{{/no}}}} {{expression}}
+\{{\{{no}}}} block \{{\{{/no}}}}
+
+\{{!-- no comment --}}
+
+\{{! no comment }}
+
+<!-- escaped escapings -->
 
 \\{{expression}}
 
@@ -12,3 +18,4 @@
 
 \\\\{{expression}}
 
+\\\{{! comment }}

--- a/test/markup/handlebars/escaped-mustaches.txt
+++ b/test/markup/handlebars/escaped-mustaches.txt
@@ -5,3 +5,10 @@
 \{{#no}} block \{{/no}} {{expression}}
 
 \{{\{{no}}}} block \{{\{{/no}}}} {{expression}}
+
+\\{{expression}}
+
+\\\{{expression}}
+
+\\\\{{expression}}
+

--- a/test/markup/handlebars/expression-variants.expect.txt
+++ b/test/markup/handlebars/expression-variants.expect.txt
@@ -1,0 +1,21 @@
+<span class="xml">text
+
+</span><span class="hljs-template-variable">{{ "lite]'ral}}segment" }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ 'lite]"ral}}segment' }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ [lite"'ral}}segment] }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abc "lite]'ral}}segment" }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abc 'lite]"ral}}segment' }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abc [lite"'ral}}segment] }}</span><span class="xml"> text
+
+
+</span><span class="hljs-template-variable">{{ abcd.[lite"'ral}}segment] }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abcd."lite]'ral}}segment" }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abcd.'lite]"ral}}segment' }}</span><span class="xml"> text
+</span>

--- a/test/markup/handlebars/expression-variants.expect.txt
+++ b/test/markup/handlebars/expression-variants.expect.txt
@@ -18,4 +18,10 @@
 </span><span class="hljs-template-variable">{{ abcd."lite]'ral}}segment" }}</span><span class="xml"> text
 
 </span><span class="hljs-template-variable">{{ abcd.'lite]"ral}}segment' }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abcd.''}}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abcd."" }}</span><span class="xml"> text
+
+</span><span class="hljs-template-variable">{{ abcd.[] }}</span><span class="xml"> text
 </span>

--- a/test/markup/handlebars/expression-variants.txt
+++ b/test/markup/handlebars/expression-variants.txt
@@ -1,0 +1,20 @@
+text
+
+{{ "lite]'ral}}segment" }} text
+
+{{ 'lite]"ral}}segment' }} text
+
+{{ [lite"'ral}}segment] }} text
+
+{{ abc "lite]'ral}}segment" }} text
+
+{{ abc 'lite]"ral}}segment' }} text
+
+{{ abc [lite"'ral}}segment] }} text
+
+
+{{ abcd.[lite"'ral}}segment] }} text
+
+{{ abcd."lite]'ral}}segment" }} text
+
+{{ abcd.'lite]"ral}}segment' }} text

--- a/test/markup/handlebars/expression-variants.txt
+++ b/test/markup/handlebars/expression-variants.txt
@@ -18,3 +18,9 @@ text
 {{ abcd."lite]'ral}}segment" }} text
 
 {{ abcd.'lite]"ral}}segment' }} text
+
+{{ abcd.''}} text
+
+{{ abcd."" }} text
+
+{{ abcd.[] }} text


### PR DESCRIPTION
This PR adds support for rather exotic expressions like 

```handlebars
{{[property name containing spaces]}}
{{"property name containing spaces and [] square brackets"}}
{{'property name containing spaces and "" quotes'}}

{{helper [property name containing spaces]}}
{{property.[property name containing spaces]}}
```
and most importantly

```handlebars
{{"property containing a closing }} mustache"}} followed by xml {{and another mustache}}
```

I have set the `relevance` values such that no changes in auto-detection heuristics takes place.

Update: Added support for escaped mustaches as well:

```handlebars
\{{no-expression}} {{expression}}

\{{{no-expression}}} {{expression}}

\{{#no}} block \{{/no}} {{expression}}

\{{\{{no}}}} block \{{\{{/no}}}} {{expression}}
```

Update 2: looks like GitHub's syntax highlighter isn't supporting that.
