### PR TITLE
Fix TypeScript function issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
 
 Improvements:
 - fix(typescript): constructor in declaration doesn't break highlighting
+- fix(typescript): only match function keyword as a separate identifier (#2191)
 - feature(arduino) make arduino a super-set of cpp grammar
 - fix(javascript): fix object attributes immediately following line comments
 - fix(xml): remove `vbscript` as potential script tag subLanguage

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -171,7 +171,7 @@ function(hljs) {
       },
       {
         className: 'function',
-        begin: 'function', end: /[\{;]/, excludeEnd: true,
+        beginKeywords: 'function', end: /[\{;]/, excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
           'self',

--- a/test/markup/typescript/functions.expect.txt
+++ b/test/markup/typescript/functions.expect.txt
@@ -9,3 +9,7 @@
 <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getArray</span>(<span class="hljs-params"></span>): <span class="hljs-title">number</span>[] </span>{
   <span class="hljs-keyword">return</span> [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>];
 }
+
+<span class="hljs-keyword">type</span> Foo = {
+    functionInFoo(): <span class="hljs-built_in">void</span>;
+};

--- a/test/markup/typescript/functions.txt
+++ b/test/markup/typescript/functions.txt
@@ -9,3 +9,7 @@ function println(value: string);
 function getArray(): number[] {
   return [1, 2];
 }
+
+type Foo = {
+    functionInFoo(): void;
+};


### PR DESCRIPTION
Fixes #2191 

The problem here seems to be that TypeScript is using `begin` whereas JavaScript is using `beginKeywords` and therefore doesn't suffer the same problem. The solution seems self-evident.