### PR TITLE
fix(python) if incorrectly identified as f-string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ New styles:
   none.
 
 Improvements:
-- enh(powershell) major overhaul, huge improvements (#2224) 
+- fix(python) fix `if` getting confused as an f-string (#2200) [Josh Goebel][] and [Carl Baxter][]
+- enh(powershell) major overhaul, huge improvements (#2224)
 - enh(css) Improve @rule highlighting, including properties (#2241) [Josh Goebel][]
 - enh(css) Improve highlighting of numbers inside expr/func `calc(2px+3px)` (#2241)
 - enh(scss) Pull some of the CSS improvements back into SCSS (#2241)
@@ -16,6 +17,7 @@ Improvements:
 - fix(parser): Better errors when a language is missing (#2236) [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/yyyc514
+[Carl Baxter]: https://github.com/cdbax
 
 
 ## Version 9.16.2

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -33,43 +33,43 @@ function(hljs) {
     contains: [hljs.BACKSLASH_ESCAPE],
     variants: [
       {
-        begin: /\b(u|b)?r?'''/, end: /'''/,
+        begin: /(u|b)?r?'''/, end: /'''/,
         contains: [hljs.BACKSLASH_ESCAPE, PROMPT],
         relevance: 10
       },
       {
-        begin: /\b(u|b)?r?"""/, end: /"""/,
+        begin: /(u|b)?r?"""/, end: /"""/,
         contains: [hljs.BACKSLASH_ESCAPE, PROMPT],
         relevance: 10
       },
       {
-        begin: /\b(fr|rf|f)'''/, end: /'''/,
+        begin: /(fr|rf|f)'''/, end: /'''/,
         contains: [hljs.BACKSLASH_ESCAPE, PROMPT, LITERAL_BRACKET, SUBST]
       },
       {
-        begin: /\b(fr|rf|f)"""/, end: /"""/,
+        begin: /(fr|rf|f)"""/, end: /"""/,
         contains: [hljs.BACKSLASH_ESCAPE, PROMPT, LITERAL_BRACKET, SUBST]
       },
       {
-        begin: /\b(u|r|ur)'/, end: /'/,
+        begin: /(u|r|ur)'/, end: /'/,
         relevance: 10
       },
       {
-        begin: /\b(u|r|ur)"/, end: /"/,
+        begin: /(u|r|ur)"/, end: /"/,
         relevance: 10
       },
       {
-        begin: /\b(b|br)'/, end: /'/
+        begin: /(b|br)'/, end: /'/
       },
       {
-        begin: /\b(b|br)"/, end: /"/
+        begin: /(b|br)"/, end: /"/
       },
       {
-        begin: /\b(fr|rf|f)'/, end: /'/,
+        begin: /(fr|rf|f)'/, end: /'/,
         contains: [hljs.BACKSLASH_ESCAPE, LITERAL_BRACKET, SUBST]
       },
       {
-        begin: /\b(fr|rf|f)"/, end: /"/,
+        begin: /(fr|rf|f)"/, end: /"/,
         contains: [hljs.BACKSLASH_ESCAPE, LITERAL_BRACKET, SUBST]
       },
       hljs.APOS_STRING_MODE,
@@ -97,6 +97,9 @@ function(hljs) {
     contains: [
       PROMPT,
       NUMBER,
+      // eat "if" prior to string so that it won't accidentally be
+      // labeled as an f-string as in:
+      { beginKeywords: "if", relevance: 0 },
       STRING,
       hljs.HASH_COMMENT_MODE,
       {

--- a/test/detect/python/default.txt
+++ b/test/detect/python/default.txt
@@ -1,9 +1,6 @@
 @requires_authorization
 def somefunc(param1='', param2=0):
-    x = r'''A docstring'''
-    def someInnerFunc():
-        nonlocal x
-        x = r"some string"
+    r'''A docstring'''
     if param1 > param2: # interesting
         print 'Gre\'ater'
     return (param2 - param1 + 1 + 0b10l) or None


### PR DESCRIPTION
Fixes #1809 

Putting this up in the hope that someone can help with the auto-detect issue.

Per the suggestion from @yyyc514 this adds a requirement for a word boundary at the start of Python's string literals. This suggestion does indeed fix the f-string issue.

The weird part that I don't understand, is the auto-detect now thinks the Python sample is `awk`. Even after adding to the sample, and increasing the Python score to 52, the auto-detect still comes up with awk (34) and ruby (24). If it isn't highest-score wins, then what is the logic?