### PR TITLE
Swift: Add dynamicMemberLookup and propertyWrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ New styles:
 - *Night Owl* by [Carl Baxter][]
 
 Improvements:
+- fix(swift): support for `@dynamicMemberLookup` and `@propertyWrapper` (#2202)
 - fix(typescript): constructor in declaration doesn't break highlighting
 - fix(typescript): only match function keyword as a separate identifier (#2191)
 - feature(arduino) make arduino a super-set of cpp grammar

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -125,7 +125,8 @@ function(hljs) {
                   '@NSCopying|@NSManaged|@objc|@objcMembers|@convention|@required|' +
                   '@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|' +
                   '@infix|@prefix|@postfix|@autoclosure|@testable|@available|' +
-                  '@nonobjc|@NSApplicationMain|@UIApplicationMain)'
+                  '@nonobjc|@NSApplicationMain|@UIApplicationMain|@dynamicMemberLookup|' +
+                  '@propertyWrapper)'
 
       },
       {


### PR DESCRIPTION
This PR adds support for meta highlighting of [`@dynamicMemberLookup`](https://github.com/apple/swift-evolution/blob/master/proposals/0195-dynamic-member-lookup.md) and [`@propertyWrapper`](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md) in the Swift language.