### PR TITLE
endWithParent inside a starts block needs it's own mode and starts mode deep cloned (with handlebars converted)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ New styles:
 Improvements:
 - blacklist super-common keywords from having relevance (#2179)
 - fix(swift): support for `@dynamicMemberLookup` and `@propertyWrapper` (#2202)
+- fix: `endWithParent` inside `starts` now always works (#2201)
 - fix(typescript): constructor in declaration doesn't break highlighting
 - fix(typescript): only match function keyword as a separate identifier (#2191)
 - feature(arduino) make arduino a super-set of cpp grammar

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -801,6 +801,7 @@ https://highlightjs.org/
     }
   }
 
+  // needed to unhook test languages after adding
   function deregisterLanguage(name, language) {
     var lang = languages[name]
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -801,6 +801,15 @@ https://highlightjs.org/
     }
   }
 
+  function deregisterLanguage(name, language) {
+    var lang = languages[name]
+
+    delete languages[name]
+    if (lang.aliases) {
+      lang.aliases.forEach(function(alias) {delete aliases[alias];});
+    }
+  }
+
   function listLanguages() {
     return objectKeys(languages);
   }
@@ -825,6 +834,7 @@ https://highlightjs.org/
   hljs.initHighlighting = initHighlighting;
   hljs.initHighlightingOnLoad = initHighlightingOnLoad;
   hljs.registerLanguage = registerLanguage;
+  hljs.deregisterLanguage = deregisterLanguage;
   hljs.listLanguages = listLanguages;
   hljs.getLanguage = getLanguage;
   hljs.autoDetection = autoDetection;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -247,7 +247,7 @@ https://highlightjs.org/
     // instance of ourselves, so we can be reused with many
     // different parents without issue
     if (dependencyOnParent(mode))
-      return [inherit(mode, { starts: inherit(mode.starts)})]
+      return [inherit(mode, { starts: mode.starts ? inherit(mode.starts) : null })]
 
     // no special dependency issues, just return ourselves
     return [mode]

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -223,13 +223,34 @@ https://highlightjs.org/
 
   /* Initialization */
 
-  function expand_mode(mode) {
+  function dependencyOnParent(mode) {
+    if (!mode) return false;
+
+    return mode.endsWithParent || dependencyOnParent(mode.starts)
+  }
+
+  function expand_or_clone_mode(mode) {
     if (mode.variants && !mode.cached_variants) {
       mode.cached_variants = mode.variants.map(function(variant) {
         return inherit(mode, {variants: null}, variant);
       });
     }
-    return mode.cached_variants || (mode.endsWithParent && [inherit(mode)]) || [mode];
+
+    // EXPAND
+    // if we have variants then essentually "replace" the mode with the variants
+    // this happens in compileMode, where this function is called from
+    if (mode.cached_variants)
+      return mode.cached_variants;
+
+    // CLONE
+    // if we have dependencies on parents then we need a unique
+    // instance of ourselves, so we can be reused with many
+    // different parents without issue
+    if (dependencyOnParent(mode))
+      return [inherit(mode, { starts: inherit(mode.starts)})]
+
+    // no special dependency issues, just return ourselves
+    return [mode]
   }
 
   function restoreLanguageApi(obj) {
@@ -369,7 +390,7 @@ https://highlightjs.org/
         mode.contains = [];
       }
       mode.contains = Array.prototype.concat.apply([], mode.contains.map(function(c) {
-        return expand_mode(c === 'self' ? mode : c);
+        return expand_or_clone_mode(c === 'self' ? mode : c);
       }));
       mode.contains.forEach(function(c) {compileMode(c, mode);});
 

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -13,37 +13,24 @@ function (hljs) {
     begin: /".*?"|'.*?'|\[.*?\]|\w+/
   };
 
-  function BLOCK_MUSTACHE_CONTENTS() {
-    return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
-      className: 'name'
-    });
-  }
-
-  function BASIC_MUSTACHE_CONTENTS() {
-    return hljs.inherit(EXPRESSION_OR_HELPER_CALL(), {
-      // relevance 0 for backward compatibility concerning auto-detection
-      relevance: 0
-    });
-  }
-
-  function EXPRESSION_OR_HELPER_CALL() {
-    return hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {
-      keywords: BUILT_INS,
-      starts: HELPER_PARAMETERS()
-    });
-  }
-
-  function HELPER_PARAMETERS() {
-    return {
+  var EXPRESSION_OR_HELPER_CALL = hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {
+    keywords: BUILT_INS,
+    starts: {
+      // helper params
       endsWithParent: true,
       relevance: 0,
-      contains: [
-        hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {
-          relevance: 0
-        })
-      ]
-    };
-  }
+      contains: [hljs.inherit(IDENTIFIER_PLAIN_OR_QUOTED, {relevance: 0})]
+    }
+  });
+
+  var BLOCK_MUSTACHE_CONTENTS = hljs.inherit(EXPRESSION_OR_HELPER_CALL, {
+    className: 'name'
+  });
+
+  var BASIC_MUSTACHE_CONTENTS = hljs.inherit(EXPRESSION_OR_HELPER_CALL, {
+    // relevance 0 for backward compatibility concerning auto-detection
+    relevance: 0
+  });
 
   var ESCAPE_MUSTACHE_WITH_PRECEEDING_BACKSLASH = {begin: /\\\{\{/, skip: true};
   var PREVENT_ESCAPE_WITH_ANOTHER_PRECEEDING_BACKSLASH = {begin: /\\\\(?=\{\{)/, skip: true};
@@ -61,36 +48,34 @@ function (hljs) {
         // open raw block "{{{{raw}}}} content not evaluated {{{{/raw}}}}"
         className: 'template-tag',
         begin: /\{\{\{\{(?!\/)/, end: /\}\}\}\}/,
-        contains: [BLOCK_MUSTACHE_CONTENTS()],
+        contains: [BLOCK_MUSTACHE_CONTENTS],
         starts: {end: /\{\{\{\{\//, returnEnd: true, subLanguage: 'xml'}
       },
       {
         // close raw block
         className: 'template-tag',
         begin: /\{\{\{\{\//, end: /\}\}\}\}/,
-        contains: [BLOCK_MUSTACHE_CONTENTS()]
+        contains: [BLOCK_MUSTACHE_CONTENTS]
       },
       {
         // open block statement
         className: 'template-tag',
         begin: /\{\{[#\/]/, end: /\}\}/,
-        contains: [BLOCK_MUSTACHE_CONTENTS()],
+        contains: [BLOCK_MUSTACHE_CONTENTS],
       },
       {
         // template variable or helper-call that is NOT html-escaped
         className: 'template-variable',
         begin: /\{\{\{/, end: /\}\}\}/,
         keywords: BUILT_INS,
-        contains: [BASIC_MUSTACHE_CONTENTS()]
+        contains: [BASIC_MUSTACHE_CONTENTS]
       },
       {
         // template variable or helper-call that is html-escaped
         className: 'template-variable',
         begin: /\{\{/, end: /\}\}/,
         keywords: BUILT_INS,
-        contains: [
-          BASIC_MUSTACHE_CONTENTS()
-        ]
+        contains: [BASIC_MUSTACHE_CONTENTS]
       }
     ]
   };

--- a/test/bugs/index.js
+++ b/test/bugs/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe('hljs', function() {
+  require('./reuse-endsWithParent');
+});

--- a/test/bugs/reuse-endsWithParent.js
+++ b/test/bugs/reuse-endsWithParent.js
@@ -1,0 +1,30 @@
+let hljs = require('../../build');
+
+describe("bugs", function () {
+  after(function() {
+    hljs.deregisterLanguage("test-language")
+  })
+
+  describe("modes containing 'endsWithParent'", function () {
+    it("should be allowed to be reused", function () {
+      hljs.registerLanguage('test-language', function (hljs) {
+
+        const TAG_CONTENTS = {className: 'name', begin: /\w+/, starts: {endsWithParent: true}};
+
+        const PAREN_TAG = {className: 'tag', begin: /\(/, end: /\)/, contains: [TAG_CONTENTS]};
+        const SQUARE_BRACKET_TAG = {className: 'tag', begin: /\[/, end: /\]/, contains: [TAG_CONTENTS]};
+
+        return {
+          contains: [PAREN_TAG, SQUARE_BRACKET_TAG]
+        };
+      });
+
+      hljs.highlight('test-language', '(abc 123) [abc 123] (abc 123)').value
+        .should.equal(
+        '<span class="hljs-tag">(<span class="hljs-name">abc</span> 123)</span> ' +
+        '<span class="hljs-tag">[<span class="hljs-name">abc</span> 123]</span> ' +
+        '<span class="hljs-tag">(<span class="hljs-name">abc</span> 123)</span>'
+      )
+    })
+  })
+})

--- a/test/bugs/reuse-endsWithParent.js
+++ b/test/bugs/reuse-endsWithParent.js
@@ -1,9 +1,6 @@
 let hljs = require('../../build');
 
 describe("bugs", function () {
-  after(function() {
-    hljs.deregisterLanguage("test-language")
-  })
 
   describe("modes containing 'endsWithParent'", function () {
     it("should be allowed to be reused", function () {

--- a/test/detect/index.js
+++ b/test/detect/index.js
@@ -2,6 +2,11 @@
 
 let bluebird = require('bluebird');
 let fs       = bluebird.promisifyAll(require('fs'));
+
+delete require.cache[require.resolve('../../build')]
+delete require.cache[require.resolve('../../build/lib/highlight')]
+
+
 let hljs     = require('../../build');
 let path     = require('path');
 let utility  = require('../utility');

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,9 @@
 // Right now, that only includes tests for several common regular expressions.
 require('./api');
 
+// Test weird bugs we've fixed over time
+require("./bugs")
+
 // Tests for auto detection of languages via `highlightAuto`.
 require('./detect');
 


### PR DESCRIPTION
@yyyc514 I have rebased your branch onto the master and converted the function calls in the handlebars-language into variables. Works like a charm. 

Replaces #2201 