### PR TITLE
(Python) Support comments in function parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Improvements:
 - fix(Go): improve function declaration matching
 - fix(python): added support for f-string literal curly braces (#2195)
 - fix(cpp): add `future` built-in (#1610)
+- fix(python): support comments within function parameters (#2214)
 
 [Carl Baxter]: https://github.com/cdbax
 

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -87,7 +87,7 @@ function(hljs) {
   var PARAMS = {
     className: 'params',
     begin: /\(/, end: /\)/,
-    contains: ['self', PROMPT, NUMBER, STRING]
+    contains: ['self', PROMPT, NUMBER, STRING, hljs.HASH_COMMENT_MODE]
   };
   SUBST.contains = [STRING, NUMBER, PROMPT];
   return {

--- a/test/markup/python/function-header-comments.expect.txt
+++ b/test/markup/python/function-header-comments.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span><span class="hljs-params">(
+  bar, <span class="hljs-comment"># commment</span>
+)</span>:</span>
+    <span class="hljs-keyword">pass</span>
+
+
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span><span class="hljs-params">(collections.namedtuple<span class="hljs-params">(<span class="hljs-string">'Test'</span>)</span>, <span class="hljs-params">(
+    <span class="hljs-string">'name'</span>, <span class="hljs-comment"># comment</span>
+)</span>)</span>:</span>
+    <span class="hljs-keyword">pass</span>

--- a/test/markup/python/function-header-comments.txt
+++ b/test/markup/python/function-header-comments.txt
@@ -1,0 +1,10 @@
+def foo(
+  bar, # commment
+):
+    pass
+
+
+class Foo(collections.namedtuple('Test'), (
+    'name', # comment
+)):
+    pass


### PR DESCRIPTION
Fixes #1963 and #1627 (which are duplicate issues)

I couldn't get `npm test` to work on my machine, and I kinda didn't want to down that rabbit-hole, so I'm just gunna use Travis for my automated tests :pray:.