### PR TITLE
fix(crystal): correctly highlight `!~` after `def`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
 - *Night Owl* by [Carl Baxter][]
 
 Improvements:
+- fix(crystal): correctly highlight `!~` method definition (#2222)
 - fix dropping characters if we choke up on a 0-width match (#2219)
 - (accesslog) improve accesslog relevancy scoring (#2172)
 - fix(shell): fix parsing of prompts with forward slash (#2218)

--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -8,7 +8,7 @@ function(hljs) {
   var INT_SUFFIX = '(_*[ui](8|16|32|64|128))?';
   var FLOAT_SUFFIX = '(_*f(32|64))?';
   var CRYSTAL_IDENT_RE = '[a-zA-Z_]\\w*[!?=]?';
-  var CRYSTAL_METHOD_RE = '[a-zA-Z_]\\w*[!?=]?|[-+~]\\@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~|]|//|//=|&[-+*]=?|&\\*\\*|\\[\\][=?]?';
+  var CRYSTAL_METHOD_RE = '[a-zA-Z_]\\w*[!?=]?|[-+~]\\@|<<|>>|[=!]~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~|]|//|//=|&[-+*]=?|&\\*\\*|\\[\\][=?]?';
   var CRYSTAL_PATH_RE = '[A-Za-z_]\\w*(::\\w+)*(\\?|\\!)?';
   var CRYSTAL_KEYWORDS = {
     keyword:

--- a/test/markup/crystal/defs.expect.txt
+++ b/test/markup/crystal/defs.expect.txt
@@ -1,0 +1,14 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span></span>
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">*</span></span>(other)
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">**</span></span>(other)
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">=~</span></span>(other)
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">!~</span></span>(other)
+<span class="hljs-keyword">end</span>

--- a/test/markup/crystal/defs.txt
+++ b/test/markup/crystal/defs.txt
@@ -1,0 +1,14 @@
+def foo
+end
+
+def *(other)
+end
+
+def **(other)
+end
+
+def =~(other)
+end
+
+def !~(other)
+end


### PR DESCRIPTION
It is simple edge case fix.

For example, this code:

```crystal
def !~
end
```

is currently highlighted as:

```html
<span class="hljs-function"><span class="hljs-keyword">def</span> !<span class="hljs-title">~</span></span>(other)
<span class="hljs-keyword">end</span>
```

But correct highlight is:

```html
<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">!~</span></span>(other)
<span class="hljs-keyword">end</span>
```

Thank you.