### PR TITLE
Fix missing var declaration in arduino.js

### DIFF
--- a/src/languages/arduino.js
+++ b/src/languages/arduino.js
@@ -8,7 +8,7 @@ Website: https://www.arduino.cc
 
 function(hljs) {
 
-	ARDUINO_KW = {
+	var ARDUINO_KW = {
       keyword:
         'boolean byte word String',
       built_in:


### PR DESCRIPTION
Fixes `ARDUINO_KW is not defined` errors when executing in strict mode.