### PR TITLE
enh(gml) fix naming of keyword class (consistency fix)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- enh(gml) fix naming of keyword class (consistency fix) (#2254) [Liam Nobel][]
 - enh(powershell) major overhaul, huge improvements (#2224) 
 - enh(css) Improve @rule highlighting, including properties (#2241) [Josh Goebel][]
 - enh(css) Improve highlighting of numbers inside expr/func `calc(2px+3px)` (#2241)
@@ -16,7 +17,7 @@ Improvements:
 - fix(parser): Better errors when a language is missing (#2236) [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/yyyc514
-
+[Liam Nobel]: https://github.com/liamnobel
 
 ## Version 9.16.2
 

--- a/src/languages/gml.js
+++ b/src/languages/gml.js
@@ -8,7 +8,7 @@ Category: scripting
 
 function(hljs) {
   var GML_KEYWORDS = {
-    keywords: 'begin end if then else while do for break continue with until ' +
+    keyword: 'begin end if then else while do for break continue with until ' +
       'repeat exit and or xor not return mod div switch case default var ' +
       'globalvar enum #macro #region #endregion',
     built_in: 'is_real is_string is_array is_undefined is_int32 is_int64 ' +

--- a/src/styles/gml.css
+++ b/src/styles/gml.css
@@ -12,7 +12,7 @@ GML Theme - Meseta <meseta@gmail.com>
   color: #C0C0C0;
 }
 
-.hljs-keywords {
+.hljs-keyword {
   color: #FFB871;
   font-weight: bold;
 }


### PR DESCRIPTION
I believe the nested "keywords" variables are causing an issue. Since keywords must be returned to the hljs function, I am changing the inner "keywords" to "keyword" and the GML style to match.