### PR TITLE
(go) Fix escaped character literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,12 +19,14 @@ Improvements:
 - fix(parser): Fix merger HTML attribute quoting (#2235) [Josh Goebel][]
 - fix(parser): Look-ahead regex now work for end matches also (#2237) [Josh Goebel][]
 - fix(parser): Better errors when a language is missing (#2236) [Josh Goebel][]
+- fix(go): Fix escaped character literals (#2266) [David Benjamin][]
 
 [Josh Goebel]: https://github.com/yyyc514
 [Liam Nobel]: https://github.com/liamnobel
 [Carl Baxter]: https://github.com/cdbax
 [Milutin Kristofic]: https://github.com/milutin
 [w3suli]: https://github.com/w3suli
+[David Benjamin]: https://github.com/davidben
 
 
 ## Version 9.16.2

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -30,7 +30,7 @@ function(hljs) {
         className: 'string',
         variants: [
           hljs.QUOTE_STRING_MODE,
-          {begin: '\'', end: '[^\\\\]\''},
+          hljs.APOS_STRING_MODE,
           {begin: '`', end: '`'},
         ]
       },

--- a/test/markup/go/strings.expect.txt
+++ b/test/markup/go/strings.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">main</span><span class="hljs-params">()</span></span> {
+	str := <span class="hljs-string">"Hello, 世界\nHello \"world\"\nHello 'world'"</span>
+	char := <span class="hljs-string">'a'</span>
+	char2 := <span class="hljs-string">'"'</span>
+	char3 := <span class="hljs-string">'\\'</span>
+	char3 := <span class="hljs-string">'\''</span>
+}

--- a/test/markup/go/strings.txt
+++ b/test/markup/go/strings.txt
@@ -1,0 +1,7 @@
+func main() {
+	str := "Hello, 世界\nHello \"world\"\nHello 'world'"
+	char := 'a'
+	char2 := '"'
+	char3 := '\\'
+	char3 := '\''
+}


### PR DESCRIPTION
Fixes #1411