### PR TITLE
Language pollution due to `inherit()`

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -113,12 +113,19 @@ https://highlightjs.org/
     var result = {};
     var objects = Array.prototype.slice.call(arguments, 1);
 
-    for (key in parent)
-      result[key] = parent[key];
+    for (key in parent) {
+      if (Array.isArray(parent[key])) {
+        result[key] = parent[key].slice();
+      } else {
+        result[key] = parent[key];
+      }
+    }
+
     objects.forEach(function(obj) {
       for (key in obj)
         result[key] = obj[key];
     });
+
     return result;
   }
 


### PR DESCRIPTION
By reading through `inherit()`, it seems to me that its purpose is to clone an object and copy over all its values.

The existing behavior right now is that Mercury is making a "copy" of `hljs.QUOTE_STRING_MODE` by using `inherit`. But because `inherit()` is just making a shallow copy, when `STRING.contains.push(STRING_FMT);` is called, Mercury is actually pushing `STRING_FMT` into `hljs.QUOTE_STRING_MODE.contains`.

https://github.com/highlightjs/highlight.js/blob/980ac21791b6760ed69ed83cb05a7c66b1fbad67/src/languages/mercury.js#L45-L52

At the moment, `mercury` is polluting `armasm`.

https://github.com/highlightjs/highlight.js/blob/980ac21791b6760ed69ed83cb05a7c66b1fbad67/src/languages/armasm.js#L63-L65