### PR TITLE
(ebnf) add underscore to productions and dot to terminators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- enh(ebnf) add underscore as allowed meta identifier character, and dot as terminator (#2281) [Chris Marchesi][]
 - fix(makefile) fix double relevance for assigns, improves auto-detection (#2278)[Josh Goebel][]
 - enh(xml) support for highlighting entities (#2260) [w3suli][]
 - enh(gml) fix naming of keyword class (consistency fix) (#2254) [Liam Nobel][]
@@ -30,6 +31,7 @@ Improvements:
 [Milutin Kristofic]: https://github.com/milutin
 [w3suli]: https://github.com/w3suli
 [David Benjamin]: https://github.com/davidben
+[Chris Marchesi]: https://github.com/vancluever
 
 
 ## Version 9.16.2

--- a/src/languages/ebnf.js
+++ b/src/languages/ebnf.js
@@ -9,7 +9,7 @@ function(hljs) {
 
     var nonTerminalMode = {
         className: "attribute",
-        begin: /^[ ]*[a-zA-Z][a-zA-Z-]*([\s-]+[a-zA-Z][a-zA-Z]*)*/
+        begin: /^[ ]*[a-zA-Z][a-zA-Z-_]*([\s-_]+[a-zA-Z][a-zA-Z]*)*/
     };
 
     var specialSequenceMode = {
@@ -18,7 +18,7 @@ function(hljs) {
     };
 
     var ruleBodyMode = {
-        begin: /=/, end: /;/,
+        begin: /=/, end: /[.;]/,
         contains: [
             commentMode,
             specialSequenceMode,

--- a/test/markup/ebnf/terminators.expect.txt
+++ b/test/markup/ebnf/terminators.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-attribute">full-stop</span> = <span class="hljs-string">"."</span> .
+<span class="hljs-attribute">semicolon</span> = <span class="hljs-string">";"</span> ;
+<span class="hljs-attribute">end-test</span> = <span class="hljs-string">"end"</span> ; <span class="hljs-comment">(* ending production to test semicolon *)</span>

--- a/test/markup/ebnf/terminators.txt
+++ b/test/markup/ebnf/terminators.txt
@@ -1,0 +1,3 @@
+full-stop = "." .
+semicolon = ";" ;
+end-test = "end" ; (* ending production to test semicolon *)

--- a/test/markup/ebnf/underscore-production.expect.txt
+++ b/test/markup/ebnf/underscore-production.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-attribute">a_production</span> = nonterminal ;

--- a/test/markup/ebnf/underscore-production.txt
+++ b/test/markup/ebnf/underscore-production.txt
@@ -1,0 +1,1 @@
+a_production = nonterminal ;


### PR DESCRIPTION
This adds the following:

* Underscores as a recognizable character in a production name
(meta-identifer). While I'm not necessarily sure if underscore is a
permitted character to the letter of ISO 14977, there are examples of
being used in practice, the Go spec being one of these.

* Adds "." as a production terminator. This is valid as per ISO 14977
(section 7.4 on alternate terminal characters).