### PR TITLE
languages: add HashiCorp Sentinel

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -282,3 +282,4 @@ Contributors:
 - Carl Baxter <carl@cbax.tech>
 - Thomas Reichel <tom.p.reichel@gmail.com>
 - G8t Guy <g8tguy@g8tguy.com>
+- Chris Marchesi <chrism@vancluevertech.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ New languages:
   none.
 
 New styles:
-  none.
+- *HashiCorp Sentinel* by [Chris Marchesi][]
 
 Improvements:
 - fix(makefile) fix double relevance for assigns, improves auto-detection (#2278)[Josh Goebel][]
@@ -30,6 +30,7 @@ Improvements:
 [Milutin Kristofic]: https://github.com/milutin
 [w3suli]: https://github.com/w3suli
 [David Benjamin]: https://github.com/davidben
+[Chris Marchesi]: https://github.com/vancluever
 
 
 ## Version 9.16.2

--- a/src/languages/sentinel.js
+++ b/src/languages/sentinel.js
@@ -1,0 +1,70 @@
+/*
+Language: Sentinel
+Author: Chris Marchesi <chrism@vancluevertech.com>
+Description: Sentinel, HashiCorp's policy as code language
+Website: https://docs.hashicorp.com/sentinel
+*/
+
+/**
+ * Adapted from the Go language support (src/languages/go.js):
+ *   Author: Stephan Kountso aka StepLg <steplg@gmail.com>
+ *   Contributors: Evgeny Stepanischev <imbolk@gmail.com>
+ */
+
+function(hljs) {
+  var SENTINEL_KEYWORDS = {
+    keyword:
+      'as default func rule return break continue when if case for any all import param',
+    literal: 'true false null undefined',
+    built_in:
+      'append delete error keys length print range values int float string bool'
+  };
+  return {
+    aliases: ['sentinel'],
+    keywords: SENTINEL_KEYWORDS,
+    illegal: '</',
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.COMMENT("#", "$"),
+      {
+        className: 'string',
+        variants: [hljs.QUOTE_STRING_MODE, { begin: '`', end: '`' }]
+      },
+      {
+        className: 'number',
+        variants: [
+          { begin: hljs.C_NUMBER_RE + '[i]', relevance: 1 },
+          hljs.C_NUMBER_MODE
+        ]
+      },
+      {
+        className: 'function',
+        beginKeywords: 'func',
+        end: '\\w*(\\{|$)',
+        excludeEnd: true,
+        contains: [
+          hljs.TITLE_MODE,
+          {
+            className: 'params',
+            begin: /\(/,
+            end: /\)/,
+            keywords: SENTINEL_KEYWORDS,
+            illegal: /["']/
+          }
+        ]
+      },
+      {
+        // only highlight else when it's a label (not an operator)
+        begin: /else\s*:/,
+        keywords: 'else',
+      },
+      {
+        // hack: prevents detection of keywords after dots - adapted
+        // from old hljs JS support.
+        begin: '\\.' + hljs.IDENT_RE,
+        relevance: 0
+      },
+    ]
+  };
+}

--- a/test/detect/sentinel/default.txt
+++ b/test/detect/sentinel/default.txt
@@ -1,0 +1,22 @@
+// This policy is fairly frivolous, but should describe a Sentinel
+// policy enough for it to be detected as Sentinel code.
+
+import "types"
+
+// A parameter with a default.
+param foo default "42"
+
+to_int = func(x) {
+	case types.type_of(x) {
+		when "int", "float":
+			return x
+		when "string":
+			return int(x)
+		else:
+			error("not a valid type")
+	}
+
+	return undefined
+}
+
+main = rule { to_int(foo) is 42 }

--- a/test/markup/sentinel/basic.expect.txt
+++ b/test/markup/sentinel/basic.expect.txt
@@ -1,0 +1,22 @@
+<span class="hljs-comment">// This policy is fairly frivolous, but should describe a Sentinel</span>
+<span class="hljs-comment">// policy enough for it to be detected as Sentinel code.</span>
+
+<span class="hljs-keyword">import</span> <span class="hljs-string">"types"</span>
+
+<span class="hljs-comment">// A parameter with a default.</span>
+<span class="hljs-keyword">param</span> foo <span class="hljs-keyword">default</span> <span class="hljs-string">"42"</span>
+
+to_int = <span class="hljs-function"><span class="hljs-keyword">func</span><span class="hljs-params">(x)</span> </span>{
+	<span class="hljs-keyword">case</span> types.type_of(x) {
+		<span class="hljs-keyword">when</span> <span class="hljs-string">"int"</span>, <span class="hljs-string">"float"</span>:
+			<span class="hljs-keyword">return</span> x
+		<span class="hljs-keyword">when</span> <span class="hljs-string">"string"</span>:
+			<span class="hljs-keyword">return</span> <span class="hljs-built_in">int</span>(x)
+		<span class="hljs-keyword">else</span>:
+			<span class="hljs-built_in">error</span>(<span class="hljs-string">"not a valid type"</span>)
+	}
+
+	<span class="hljs-keyword">return</span> <span class="hljs-literal">undefined</span>
+}
+
+main = <span class="hljs-keyword">rule</span> { to_int(foo) is <span class="hljs-number">42</span> }

--- a/test/markup/sentinel/basic.txt
+++ b/test/markup/sentinel/basic.txt
@@ -1,0 +1,22 @@
+// This policy is fairly frivolous, but should describe a Sentinel
+// policy enough for it to be detected as Sentinel code.
+
+import "types"
+
+// A parameter with a default.
+param foo default "42"
+
+to_int = func(x) {
+	case types.type_of(x) {
+		when "int", "float":
+			return x
+		when "string":
+			return int(x)
+		else:
+			error("not a valid type")
+	}
+
+	return undefined
+}
+
+main = rule { to_int(foo) is 42 }

--- a/test/markup/sentinel/else.expect.txt
+++ b/test/markup/sentinel/else.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">case</span> foo {
+	<span class="hljs-keyword">else</span>:
+		bar
+}
+
+bar else baz

--- a/test/markup/sentinel/else.txt
+++ b/test/markup/sentinel/else.txt
@@ -1,0 +1,6 @@
+case foo {
+	else:
+		bar
+}
+
+bar else baz

--- a/test/markup/sentinel/selector.exepct.txt
+++ b/test/markup/sentinel/selector.exepct.txt
@@ -1,0 +1,1 @@
+foo.print(bar)

--- a/test/markup/sentinel/selector.txt
+++ b/test/markup/sentinel/selector.txt
@@ -1,0 +1,1 @@
+foo.print(bar)


### PR DESCRIPTION
This adds HashiCorp's Sentinel policy-as-code language as a supported
language.

https://docs.hashicorp.com/sentinel