### PR TITLE
enh: add Safe Mode.  Better error handling for crashes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ New styles:
   none.
 
 Improvements:
-- enh(parser) add safe & debug modes.  Better error handling for crash conditions. [Josh Goebel][]
+- enh(parser) add safe & debug modes.  Better error handling for crash conditions. (#2286) [Josh Goebel][]
 - enh(ebnf) add underscore as allowed meta identifier character, and dot as terminator (#2281) [Chris Marchesi][]
 - fix(makefile) fix double relevance for assigns, improves auto-detection (#2278) [Josh Goebel][]
 - enh(xml) support for highlighting entities (#2260) [w3suli][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,9 @@ New styles:
   none.
 
 Improvements:
+- enh(parser) add safe & debug modes.  Better error handling for crash conditions. [Josh Goebel][]
 - enh(ebnf) add underscore as allowed meta identifier character, and dot as terminator (#2281) [Chris Marchesi][]
-- fix(makefile) fix double relevance for assigns, improves auto-detection (#2278)[Josh Goebel][]
+- fix(makefile) fix double relevance for assigns, improves auto-detection (#2278) [Josh Goebel][]
 - enh(xml) support for highlighting entities (#2260) [w3suli][]
 - enh(gml) fix naming of keyword class (consistency fix) (#2254) [Liam Nobel][]
 - enh(javascript): Add support for jsdoc comments (#2245) [Milutin Kristofic][]

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,6 +1,8 @@
 (function() {
   'use strict';
 
+  hljs.debugMode();
+
   var $window            = $(window),
       $languages         = $('#languages div'),
       $linkTitle         = $('link[title]'),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,3 +124,14 @@ Returns the languages names list.
 Looks up a language by name or alias.
 
 Returns the language object if found, ``undefined`` otherwise.
+
+
+``debugMode()``
+---------------
+
+Enables *debug/development* mode.  **This mode purposely makes Highlight.js more fragile!  It should only be used for testing and local development (of languages or the library itself).**  By default "Safe Mode" is used, providing the most reliable experience for production usage.
+
+For example, if a new version suddenly had a bug (or breaking change) that affected only a single language:
+
+* **In Safe Mode**: All other languages would continue to highlight just fine.  The broken language would appear as a code block without any highlighting (as if it were plaintext).
+* **In Debug Mode**: All highlighting would stop when an error was encountered and a JavaScript error would be thrown.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,5 +133,5 @@ Enables *debug/development* mode.  **This mode purposely makes Highlight.js more
 
 For example, if a new version suddenly had a bug (or breaking change) that affected only a single language:
 
-* **In Safe Mode**: All other languages would continue to highlight just fine.  The broken language would appear as a code block without any highlighting (as if it were plaintext).
+* **In Safe Mode**: All other languages would continue to highlight just fine.  The broken language would appear as a code block, but without any highlighting (as if it were plaintext).
 * **In Debug Mode**: All highlighting would stop when an error was encountered and a JavaScript error would be thrown.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,7 +131,7 @@ Returns the language object if found, ``undefined`` otherwise.
 
 Enables *debug/development* mode.  **This mode purposely makes Highlight.js more fragile!  It should only be used for testing and local development (of languages or the library itself).**  By default "Safe Mode" is used, providing the most reliable experience for production usage.
 
-For example, if a new version suddenly had a bug (or breaking change) that affected only a single language:
+For example, if a new version suddenly had a serious bug (or breaking change) that affected only a single language:
 
 * **In Safe Mode**: All other languages would continue to highlight just fine.  The broken language would appear as a code block, but without any highlighting (as if it were plaintext).
 * **In Debug Mode**: All highlighting would stop when an error was encountered and a JavaScript error would be thrown.

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -748,15 +748,23 @@ https://highlightjs.org/
         language: name,
         top: top
       };
-    } catch (e) {
-      if (e.message && e.message.indexOf('Illegal') !== -1) {
+    } catch (err) {
+      if (err.message && err.message.indexOf('Illegal') !== -1) {
         return {
           illegal: true,
           relevance: 0,
           value: escape(value)
         };
+      } else if (SAFE_MODE) {
+        return {
+          relevance: 0,
+          value: escape(value),
+          language: name,
+          top: top,
+          errorRaised: err
+        };
       } else {
-        throw e;
+        throw err;
       }
     }
   }

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -53,6 +53,8 @@
   <script src="../demo/jquery-2.1.1.min.js"></script>
 
   <script>
+    hljs.debugMode();
+
     $(document).ready(function() {
       var select = $('.languages');
       hljs.listLanguages().forEach(function(l) {


### PR DESCRIPTION
Closes #2276.

Makes Highlight.js more resilient in the face of serious errors:

- When registering languages a serious error will result in a "plaintext" equivalent being registered, rather than crashing completely. Related: https://github.com/highlightjs/highlight.js/pull/2271
- When parsing a serious error will result in the raw code (HTML encoded) being returned in the result object along with an `errorRaised` key, rather than crashing completely
- The old (more crash prone) behavior can be requested with `hljs.debugMode()`
- Both Demo & Developer Tool run in Debug Mode by default

These changes are intended to make Highlight.js more resilient when running in production:  That an error only affecting one code block or one language definition wouldn't prevent ALL code blocks from being highlighted.