### PR TITLE
(ebnf) add backtick (grave symbol) as string character

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- enh(ebnf) add backticks as allowed string character (#2290) [Chris Marchesi][]
 - fix(kotlin): fix termination of """ string literals (#2295) [Josh Goebel][]
 - fix(parser/docs): disallow `self` mode at the top-level of a language (#2294) [Josh Goebel][]
 - fix(mercury): don't change global STRING modes (#2271) [Josh Goebel][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ New styles:
   none.
 
 Improvements:
-- enh(ebnf) add backticks as allowed string character (#2290) [Chris Marchesi][]
+- enh(ebnf) add backticks as additional string variant (#2290) [Chris Marchesi][]
 - fix(kotlin): fix termination of """ string literals (#2295) [Josh Goebel][]
 - fix(parser/docs): disallow `self` mode at the top-level of a language (#2294) [Josh Goebel][]
 - fix(mercury): don't change global STRING modes (#2271) [Josh Goebel][]

--- a/src/languages/ebnf.js
+++ b/src/languages/ebnf.js
@@ -22,8 +22,15 @@ function(hljs) {
         contains: [
             commentMode,
             specialSequenceMode,
-            // terminals
-            hljs.APOS_STRING_MODE, hljs.QUOTE_STRING_MODE
+            {
+              // terminals
+              className: 'string',
+              variants: [
+                hljs.APOS_STRING_MODE,
+                hljs.QUOTE_STRING_MODE,
+                {begin: '`', end: '`'},
+              ]
+            },
         ]
     };
 

--- a/test/markup/ebnf/quote-symbols.expect.txt
+++ b/test/markup/ebnf/quote-symbols.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-attribute">first_quote_symbol</span>  = <span class="hljs-string">"'"</span> .
+<span class="hljs-attribute">second_quote_symbol</span> = <span class="hljs-string">'"'</span> .
+
+<span class="hljs-comment">(* escaped_quote_symbol tests backticks, which does not interfere
+ * with backslashes. It has precedent in some language
+ * specifications.
+ *)</span>
+<span class="hljs-attribute">escaped_quote_symbol</span> = <span class="hljs-string">`\`</span> ( first_quote_symbol | second_quote_symbol ) .

--- a/test/markup/ebnf/quote-symbols.txt
+++ b/test/markup/ebnf/quote-symbols.txt
@@ -1,0 +1,8 @@
+first_quote_symbol  = "'" .
+second_quote_symbol = '"' .
+
+(* escaped_quote_symbol tests backticks, which does not interfere
+ * with backslashes. It has precedent in some language
+ * specifications.
+ *)
+escaped_quote_symbol = `\` ( first_quote_symbol | second_quote_symbol ) .


### PR DESCRIPTION
This adds backticks as an allowed character for terminal strings.

This is necessary for describing backslashes properly as using single or
double quotes seems to cause parsing issues with highlight.js. It also
has precedent in some EBNF-described specifications such as the Go
specification.