### PR TITLE
fix(kotlin): fix termination of """ string literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ New styles:
   none.
 
 Improvements:
-- fix(kotlin): fix termination of """ string literals () [Josh Goebel][]
+- fix(kotlin): fix termination of """ string literals (#2295) [Josh Goebel][]
 - fix(mercury): don't change global STRING modes (#2271) [Josh Goebel][]
 - fix: freeze built-in modes to prevent grammars altering them (#2271) [Josh Goebel][]
 - enh(xml) expand and improve document type highlighting (#2287) [w3suli][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- fix(kotlin): fix termination of """ string literals () [Josh Goebel][]
 - fix(mercury): don't change global STRING modes (#2271) [Josh Goebel][]
 - fix: freeze built-in modes to prevent grammars altering them (#2271) [Josh Goebel][]
 - enh(xml) expand and improve document type highlighting (#2287) [w3suli][]

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -50,7 +50,7 @@ function(hljs) {
     className: 'string',
     variants: [
       {
-        begin: '"""', end: '"""',
+        begin: '"""', end: '"""(?=[^"])',
         contains: [VARIABLE, SUBST]
       },
       // Can't use built-in modes easily, as we want to use STRING in the meta

--- a/test/markup/kotlin/string.expect.txt
+++ b/test/markup/kotlin/string.expect.txt
@@ -5,3 +5,4 @@ expression
 <span class="hljs-string">"""  <span class="hljs-subst">${
     ${subst}</span>
 } """</span>
+<span class="hljs-string">"""f="true""""</span>

--- a/test/markup/kotlin/string.txt
+++ b/test/markup/kotlin/string.txt
@@ -5,3 +5,4 @@ expression
 """  ${
     ${subst}
 } """
+"""f="true""""


### PR DESCRIPTION
- Properly handles cases: like """ends in a "quoted string""""
- Closes #2280.