### PR TITLE
fix(themes) Standardize the padding/spacing for all themes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- fix(themes): fix inconsistencies between some themes padding/spacing (#2300) [Josh Goebel][]
 - fix(mercury): don't change global STRING modes (#2271) [Josh Goebel][]
 - fix: freeze built-in modes to prevent grammars altering them (#2271) [Josh Goebel][]
 - enh(xml) expand and improve document type highlighting (#2287) [w3suli][]

--- a/src/styles/atom-one-dark-reasonable.css
+++ b/src/styles/atom-one-dark-reasonable.css
@@ -9,10 +9,8 @@ Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  line-height: 1.3em;
   color: #abb2bf;
   background: #282c34;
-  border-radius: 5px;
 }
 .hljs-keyword, .hljs-operator {
   color: #F92672;

--- a/src/styles/darcula.css
+++ b/src/styles/darcula.css
@@ -10,9 +10,6 @@ Darcula color scheme from the JetBrains family of IDEs
   overflow-x: auto;
   padding: 0.5em;
   background: #2b2b2b;
-}
-
-.hljs {
   color: #bababa;
 }
 

--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -10,7 +10,8 @@ Date: 2013-04-02
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  background: #eee; color: black;
+  background: #eee;
+  color: black;
 }
 
 .hljs-link,

--- a/src/styles/hopscotch.css
+++ b/src/styles/hopscotch.css
@@ -69,6 +69,7 @@
 
 .hljs {
   display: block;
+  overflow-x: auto;
   background: #322931;
   color: #b9b5b8;
   padding: 0.5em;

--- a/src/styles/isbl-editor-light.css
+++ b/src/styles/isbl-editor-light.css
@@ -14,9 +14,8 @@ ISBL Editor style light color schemec (c) Dmitriy Tarasov <dimatar@gmail.com>
 
 /* Base color: saturation 0; */
 
-.hljs,
 .hljs-subst {
-  color: #000000;
+  color: black;
 }
 
 .hljs-comment {

--- a/src/styles/lightfair.css
+++ b/src/styles/lightfair.css
@@ -8,6 +8,7 @@ Lightfair style (c) Tristian Kelly <tristian.kelly560@gmail.com>
   display: block;
   overflow-x: auto;
   padding: 0.5em;
+  /* TODO: background? */
 }
 
 .hljs-name {

--- a/src/styles/magula.css
+++ b/src/styles/magula.css
@@ -12,9 +12,9 @@ Music: Aphex Twin / Xtal
   overflow-x: auto;
   padding: 0.5em;
   background-color: #f4f4f4;
+  color: black;
 }
 
-.hljs,
 .hljs-subst {
   color: black;
 }

--- a/src/styles/mono-blue.css
+++ b/src/styles/mono-blue.css
@@ -6,9 +6,6 @@
   overflow-x: auto;
   padding: 0.5em;
   background: #eaeef3;
-}
-
-.hljs {
   color: #00193a;
 }
 

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -6,7 +6,8 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  background: #272822; color: #ddd;
+  background: #272822;
+  color: #ddd;
 }
 
 .hljs-tag,

--- a/src/styles/purebasic.css
+++ b/src/styles/purebasic.css
@@ -21,7 +21,7 @@ NOTE_2:	Color names provided in comments were derived using "Name that Color" on
 			http://chir.ag/projects/name-that-color
 */
 
-.hljs { /* Common set of rules required by highlight.js (don'r remove!) */
+.hljs {
 	display: block;
 	overflow-x: auto;
 	padding: 0.5em;

--- a/src/styles/shades-of-purple.css
+++ b/src/styles/shades-of-purple.css
@@ -11,8 +11,7 @@
   overflow-x: auto;
   /* Custom font is optional */
   /* font-family: 'Operator Mono', 'Fira Code', 'Menlo', 'Monaco', 'Courier New', 'monospace';  */
-  line-height: 1.45;
-  padding: 2rem;
+  padding: 0.5em;
   background: #2d2b57;
   font-weight: normal;
 }


### PR DESCRIPTION
It's very weird that 2-3 of our themes completely change the padding/text-layout.  I understand why the "school paper" one does, but otherwise our themes should be consistent when it comes to whitespace.

This standardizes on:

```
  display: block;
  overflow-x: auto;
  padding: 0.5em;
```

Only 3 themes were changed to bring all our themes into alignment.