### PR TITLE
(sql) Backslash should not escape in string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New styles:
   none.
 
 Improvements:
+- fix(sql): backslash is not used to escape in strings in standard SQL (#1748) [Mike Schall][]
 - chore(javascript): add esm related extensions to aliases (#2298) [Rongjian Zhang][]
 - fix(kotlin): fix termination of """ string literals (#2295) [Josh Goebel][]
 - fix(parser/docs): disallow `self` mode at the top-level of a language (#2294) [Josh Goebel][]
@@ -42,6 +43,7 @@ Improvements:
 [Chris Marchesi]: https://github.com/vancluever
 [Adrian Ostrowski]: https://github.com/aostrowski
 [Rongjian Zhang]: https://github.com/pd4d10
+[Mike Schall]: https://github.com/schallm
 
 
 ## Version 9.16.2

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -142,17 +142,16 @@ function(hljs) {
           {
             className: 'string',
             begin: '\'', end: '\'',
-            contains: [hljs.BACKSLASH_ESCAPE, {begin: '\'\''}]
+            contains: [{begin: '\'\''}]
           },
           {
             className: 'string',
             begin: '"', end: '"',
-            contains: [hljs.BACKSLASH_ESCAPE, {begin: '""'}]
+            contains: [{begin: '""'}]
           },
           {
             className: 'string',
-            begin: '`', end: '`',
-            contains: [hljs.BACKSLASH_ESCAPE]
+            begin: '`', end: '`'
           },
           hljs.C_NUMBER_MODE,
           hljs.C_BLOCK_COMMENT_MODE,

--- a/test/markup/sql/string-types.expect.txt
+++ b/test/markup/sql/string-types.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">'\'</span>;
+
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">"\"</span>;
+
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">`\`</span>;

--- a/test/markup/sql/string-types.txt
+++ b/test/markup/sql/string-types.txt
@@ -1,0 +1,5 @@
+SELECT '\';
+
+SELECT "\";
+
+SELECT `\`;


### PR DESCRIPTION
Remove backslash_escape with in strings in standard SQL

Closes #1748.