### PR TITLE
feat(developer): add button to show parsed structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,11 +20,15 @@ Language Improvements:
 - (vbnet) add nameof operator to the keywords (#2329) [Youssef Victor][]
 - (stan) updated with improved coverage of language keywords and patterns. (#1829) [Jeffrey Arnold][]
 
+Developer Tools:
+
+- feat(developer): add button to show parsed structure (#2345) [Nils Knappmeier][]
+
 [Jeffrey Arnold]: https://github.com/jrnold
 [Josh Goebel]: https://github.com/yyyc514
 [Philipp Engel]: https://github.com/interkosmos
 [Youssef Victor]: https://github.com/Youssef1313
-
+[Nils Knappmeier]: https://github.com/nknapp
 
 ## Version 9.17.1
 

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -26,6 +26,24 @@
     .hljs-debug {
       color: red; font-weight: bold;
     }
+
+    .visible-structure pre code span {
+      display: block;
+      padding: 0.5em;
+      margin: 0.5em;
+      border: 1px dashed black;
+      position: relative;
+      white-space: pre;
+    }
+
+    .visible-structure pre code span:before {
+      display: block;
+      content: attr(class);
+      color: black;
+      font-size: 70%;
+      float:right;
+      margin-top: -0.5em;
+    }
   </style>
 </head>
 <body>
@@ -35,7 +53,8 @@
     <div>
       <textarea>Put code here…</textarea>
       <p>
-        <button>Update highlighting</button>
+        <button id="update-highlighting">Update highlighting</button>
+        <button id="show-structure">Show/hide structure</button>
         Language: <select class="languages"><option value="">(Auto)</option></select>
       </p>
     </div>
@@ -61,7 +80,7 @@
         select.append('<option>' + l + '</option>');
       });
 
-      $('.editor button').click(function(e) {
+      $('.editor button#update-highlighting').click(function(e) {
         var editor = $(this).parents('.editor');
         var language = editor.find('.languages').val();
         var source = editor.find('textarea').val();
@@ -77,6 +96,11 @@
         editor.find('.rendering_time').text(rendering_time);
         editor.find('output').text(result.value);
         SourceStore.save(source, language);
+      });
+
+      $('.editor button#show-structure').click(function(e) {
+        var editor = $(this).parents('.editor');
+        editor.toggleClass('visible-structure');
       });
     });
 


### PR DESCRIPTION
This is a small extension to the developer.html

* It adds a button "Show structure" that adds a class to the "editor"-div
* Once this happens, additional styles come into effect, that render highlighted spans as blocks with borders and a small label containing the class name.

While this is not perfect (I would rather like to see all modes) this was very helpful when I made that latest changes to the Handlebars language and I would like to see this in the master branch.