### PR TITLE
Don't try to release 10.0.0 just yet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Version 10.0.0 (master)
+## Version (master)
 
 New languages:
 


### PR DESCRIPTION
As per docs/maintainers-guide.rst, CHANGES.md is where the site
looks for the new version number and tries to update itself.
Mentioning "10.0.0" in the header triggered an unsusccesful update.
This reverts this line.

(Sorry for yet another idiosyncrasy!)