### PR TITLE
fix(javascript) comma is allowed in a "value container"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Core Changes:
 
 Language Improvements:
 
+- fix(javascript) comma is allowed in a "value container" (#2403) [Josh Goebel][]
 - enh(apache) add `deny` and `allow` keywords [Josh Goebel][]
 - enh(apache) highlight numeric attributes values [Josh Goebel][]
 - enh(apache) highlight IP addresses, ports, and strings in sections [Josh Goebel][]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -189,6 +189,9 @@ export default function(hljs) {
               }
             ]
           },
+          { // could be a comma delimited list of params to a function call
+            begin: /,/, relevance: 0,
+          },
           {
             className: '',
             begin: /\s/,
@@ -229,6 +232,7 @@ export default function(hljs) {
       {
         begin: /\$[(.]/ // relevance booster for a pattern common to JS libs: `$(something)` and `$.something`
       },
+
       hljs.METHOD_GUARD,
       { // ES6 class
         className: 'class',

--- a/test/markup/javascript/method-call.expect.txt
+++ b/test/markup/javascript/method-call.expect.txt
@@ -1,1 +1,6 @@
 x.continue(<span class="hljs-number">0</span>);
+
+x = [
+hljs.COMMENT(<span class="hljs-regexp">/\{%\s*comment\s*%}/</span>, <span class="hljs-regexp">/\{%\s*endcomment\s*%}/</span>),
+hljs.COMMENT(<span class="hljs-regexp">/\{#/</span>, <span class="hljs-regexp">/#}/</span>),
+]

--- a/test/markup/javascript/method-call.txt
+++ b/test/markup/javascript/method-call.txt
@@ -1,1 +1,7 @@
 x.continue(0);
+
+x = [
+hljs.COMMENT(/\{%\s*comment\s*%}/, /\{%\s*endcomment\s*%}/),
+hljs.COMMENT(/\{#/, /#}/),
+]
+


### PR DESCRIPTION
- fixes case where a regex would not be detected if it was anything
  other than the first parameter of a function call
- in some cases this could actually cause the whole snippet to
  be flagged as illegal if the regex contained characters that
  were invalid at the top level (such as #)

This complexity is because we only detect regexs inside "value
containers" to prevent false positivies.

This issue was found when asking Highlight.js to highlight it's
own non-minified 1.2mb browser build.

Example of failing code (this was flagged illegal):

```
hljs.COMMENT(/\{#/, /#}/),
```