### PR TITLE
enh(parser) Refactor parse tree and HTML render into components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ New themes:
 
 Core Changes:
 
+- split out parse tree generation and HTML rendering concerns (#2404) [Josh Goebel][]
 - every language can have a `name` attribute now (#2400) [Josh Goebel][]
 - improve regular expression detect (less false-positives) (#2380) [Josh Goebel][]
 - make `noHighlightRe` and `languagePrefixRe` configurable (#2374) [Josh Goebel][]

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -5,7 +5,6 @@ https://highlightjs.org/
 
 import deepFreeze from './vendor/deep_freeze';
 import TokenTreeEmitter from './lib/token_tree';
-import HTMLRenderer from './lib/html_renderer';
 import * as regex from './lib/regex';
 import * as utils from './lib/utils';
 import * as MODES from './lib/modes';
@@ -44,7 +43,10 @@ const HLJS = function(hljs) {
     classPrefix: 'hljs-',
     tabReplace: null,
     useBR: false,
-    languages: undefined
+    languages: undefined,
+    // beta configuration options, subject to change, welcome to discuss
+    // https://github.com/highlightjs/highlight.js/issues/1086
+    __emitter: TokenTreeEmitter
   };
 
   /* Utility functions */
@@ -322,7 +324,7 @@ const HLJS = function(hljs) {
     var top = continuation || language;
     var continuations = {}; // keep continuations for sub-languages
     var result;
-    var emitter = new TokenTreeEmitter();
+    var emitter = new options.__emitter(options);
     processContinuations();
     var mode_buffer = '';
     var relevance = 0;
@@ -341,7 +343,7 @@ const HLJS = function(hljs) {
       processLexeme(codeToHighlight.substr(index));
       emitter.closeAllNodes();
       emitter.finalize();
-      result = new HTMLRenderer(emitter, options).value();
+      result = emitter.toHTML();
 
       return {
         relevance: relevance,
@@ -395,7 +397,7 @@ const HLJS = function(hljs) {
     languageSubset = languageSubset || options.languages || Object.keys(languages);
     var result = {
       relevance: 0,
-      emitter: new TokenTreeEmitter(),
+      emitter: new options.__emitter(options),
       value: escape(code)
     };
     var second_best = result;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -34,7 +34,6 @@ const HLJS = function(hljs) {
   // Regular expressions used throughout the highlight.js library.
   var fixMarkupRe      = /((^(<[^>]+>|\t|)+|(?:\n)))/gm;
 
-  var spanEndTag = '</span>';
   var LANGUAGE_NOT_FOUND = "Could not find the language '{}', did you forget to load/include a language module?";
 
   // Global options used when within external APIs. This is modified when
@@ -50,7 +49,7 @@ const HLJS = function(hljs) {
 
   /* Utility functions */
 
-  function isNotHighlighted(language) {
+  function shouldNotHighlight(language) {
     return options.noHighlightRe.test(language);
   }
 
@@ -73,7 +72,7 @@ const HLJS = function(hljs) {
 
     return classes
       .split(/\s+/)
-      .find((_class) => isNotHighlighted(_class) || getLanguage(_class))
+      .find((_class) => shouldNotHighlight(_class) || getLanguage(_class))
   }
 
   /**
@@ -462,7 +461,7 @@ const HLJS = function(hljs) {
     var node, originalStream, result, resultNode, text;
     var language = blockLanguage(block);
 
-    if (isNotHighlighted(language))
+    if (shouldNotHighlight(language))
         return;
 
     fire("before:highlightBlock",

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -4,7 +4,7 @@ https://highlightjs.org/
 */
 
 import deepFreeze from './vendor/deep_freeze';
-import TokenTree from './lib/token_tree';
+import TokenTreeEmitter from './lib/token_tree';
 import HTMLRenderer from './lib/html_renderer';
 import * as regex from './lib/regex';
 import * as utils from './lib/utils';
@@ -322,7 +322,7 @@ const HLJS = function(hljs) {
     var top = continuation || language;
     var continuations = {}; // keep continuations for sub-languages
     var result;
-    var emitter = new TokenTree();
+    var emitter = new TokenTreeEmitter();
     processContinuations();
     var mode_buffer = '';
     var relevance = 0;
@@ -395,7 +395,7 @@ const HLJS = function(hljs) {
     languageSubset = languageSubset || options.languages || Object.keys(languages);
     var result = {
       relevance: 0,
-      emitter: new TokenTree(),
+      emitter: new TokenTreeEmitter(),
       value: escape(code)
     };
     var second_best = result;

--- a/src/lib/html_renderer.js
+++ b/src/lib/html_renderer.js
@@ -1,0 +1,46 @@
+const SPAN_CLOSE = '</span>';
+
+import {escapeHTML} from './utils';
+
+const emitsWrappingTags = (node) => {
+  return !!node.kind;
+}
+
+export default class HTMLRenderer {
+  constructor(tree, options) {
+    this.buffer = "";
+    this.classPrefix = options.classPrefix;
+    tree.walk(this);
+  }
+
+  // renderer API
+
+  addText(text) {
+    this.buffer += escapeHTML(text)
+  }
+
+  openNode(node) {
+    if (!emitsWrappingTags(node)) return;
+
+    let className = node.kind;
+    if (!node.sublanguage)
+      className = `${this.classPrefix}${className}`;
+    this.span(className);
+  }
+
+  closeNode(node) {
+    if (!emitsWrappingTags(node)) return;
+
+    this.buffer += SPAN_CLOSE;
+  }
+
+  // helpers
+
+  span(className) {
+    this.buffer += `<span class="${className}">`
+  }
+
+  value() {
+    return this.buffer;
+  }
+}

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -34,7 +34,7 @@ export default class TokenTree {
   }
 
   openNode(kind) {
-    var node = { kind, children: [] };
+    let node = { kind, children: [] };
     this.add(node);
     this.stack.push(node);
   }

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -1,3 +1,5 @@
+import HTMLRenderer from './html_renderer';
+
 class TokenTree {
   constructor() {
     this.rootNode = { children: [] };
@@ -68,17 +70,22 @@ class TokenTree {
   Currently this is all private API, but this is the minimal API necessary
   that an Emitter must implement to fully support the parser.
 
-  API:
+  Minimal interface:
 
   - addKeyword(text, kind)
   - addText(text)
   - addSublanguage(emitter, subLangaugeName)
   - finalize()
+  - openNode(kind)
+  - closeNode()
+  - closeAllNodes()
+  - toHTML()
 
 */
 export default class TokenTreeEmitter extends TokenTree {
-  constructor() {
+  constructor(options) {
     super();
+    this.options = options;
   }
 
   addKeyword(text, kind) {
@@ -100,6 +107,11 @@ export default class TokenTreeEmitter extends TokenTree {
     node.kind = name;
     node.sublanguage = true;
     this.add(node);
+  }
+
+  toHTML() {
+    let renderer = new HTMLRenderer(this, this.options);
+    return renderer.value();
   }
 
   finalize() {

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -1,0 +1,88 @@
+export default class TokenTree {
+  constructor() {
+    this.rootNode = { children: [] };
+    this.stack = [ this.rootNode ];
+  }
+
+  get top() {
+    return this.stack[this.stack.length - 1];
+  }
+
+  add(node) {
+    this.top.children.push(node);
+  }
+
+  addKeyword(text, kind) {
+    if (text === "") { return; }
+
+    this.openNode(kind);
+    this.addText(text);
+    this.closeNode();
+  }
+
+  addText(text) {
+    if (text === "") { return; }
+
+    this.add(text);
+  }
+
+  addSublanguage({rootNode}, name) {
+    let node = rootNode;
+    node.kind = name;
+    node.sublanguage = true;
+    this.add(node);
+  }
+
+  openNode(kind) {
+    var node = { kind, children: [] };
+    this.add(node);
+    this.stack.push(node);
+  }
+
+  closeNode() {
+    if (this.stack.length > 1)
+      return this.stack.pop();
+  }
+
+  closeAllNodes() {
+    while (this.closeNode());
+  }
+
+  toJSON() {
+    return JSON.stringify(this.rootNode, null, 4);
+  }
+
+  finalize() {
+    return;
+  }
+
+  walk(builder) {
+    return TokenTree._walk(builder, this.rootNode);
+  }
+
+  static _walk(builder, node) {
+    if (typeof node === "string") {
+      builder.addText(node);
+    } else if (node.children) {
+      builder.openNode(node);
+      node.children.forEach((child) => this._walk(builder, child))
+      builder.closeNode(node);
+    }
+    return builder;
+  }
+
+  static _collapse(node) {
+    if (!node.children) {
+      return
+    }
+    if (node.children.every(el => typeof el === "string")) {
+      node.text = node.children.join("")
+      delete node["children"]
+    } else {
+      node.children.forEach((child) => {
+        if (typeof child === "string") return;
+        TokenTree._collapse(child)
+      })
+    }
+  }
+}

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -1,4 +1,4 @@
-export default class TokenTree {
+class TokenTree {
   constructor() {
     this.rootNode = { children: [] };
     this.stack = [ this.rootNode ];
@@ -8,29 +8,10 @@ export default class TokenTree {
     return this.stack[this.stack.length - 1];
   }
 
+  get root() { return this.rootNode };
+
   add(node) {
     this.top.children.push(node);
-  }
-
-  addKeyword(text, kind) {
-    if (text === "") { return; }
-
-    this.openNode(kind);
-    this.addText(text);
-    this.closeNode();
-  }
-
-  addText(text) {
-    if (text === "") { return; }
-
-    this.add(text);
-  }
-
-  addSublanguage({rootNode}, name) {
-    let node = rootNode;
-    node.kind = name;
-    node.sublanguage = true;
-    this.add(node);
   }
 
   openNode(kind) {
@@ -52,12 +33,8 @@ export default class TokenTree {
     return JSON.stringify(this.rootNode, null, 4);
   }
 
-  finalize() {
-    return;
-  }
-
   walk(builder) {
-    return TokenTree._walk(builder, this.rootNode);
+    return this.constructor._walk(builder, this.rootNode);
   }
 
   static _walk(builder, node) {
@@ -73,7 +50,7 @@ export default class TokenTree {
 
   static _collapse(node) {
     if (!node.children) {
-      return
+      return;
     }
     if (node.children.every(el => typeof el === "string")) {
       node.text = node.children.join("")
@@ -85,4 +62,48 @@ export default class TokenTree {
       })
     }
   }
+}
+
+/**
+  Currently this is all private API, but this is the minimal API necessary
+  that an Emitter must implement to fully support the parser.
+
+  API:
+
+  - addKeyword(text, kind)
+  - addText(text)
+  - addSublanguage(emitter, subLangaugeName)
+  - finalize()
+
+*/
+export default class TokenTreeEmitter extends TokenTree {
+  constructor() {
+    super();
+  }
+
+  addKeyword(text, kind) {
+    if (text === "") { return; }
+
+    this.openNode(kind);
+    this.addText(text);
+    this.closeNode();
+  }
+
+  addText(text) {
+    if (text === "") { return; }
+
+    this.add(text);
+  }
+
+  addSublanguage(emitter, name) {
+    let node = emitter.root;
+    node.kind = name;
+    node.sublanguage = true;
+    this.add(node);
+  }
+
+  finalize() {
+    return;
+  }
+
 }


### PR DESCRIPTION
This refactors the storage of the parse tree and the HTML rendering into their own components and separates them from the tokenizer itself.

Closes #1086 