### PR TITLE
fix(elixir) Support function names with a slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Core Changes:
 
 Language Improvements:
 
-- fix(elixir) Support function names with a slash (#) [Josh Goebel][]
+- fix(elixir) Support function names with a slash (#2406) [Josh Goebel][]
 - fix(javascript) comma is allowed in a "value container" (#2403) [Josh Goebel][]
 - enh(apache) add `deny` and `allow` keywords [Josh Goebel][]
 - enh(apache) highlight numeric attributes values [Josh Goebel][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Core Changes:
 
 Language Improvements:
 
+- fix(elixir) Support function names with a slash (#) [Josh Goebel][]
 - fix(javascript) comma is allowed in a "value container" (#2403) [Josh Goebel][]
 - enh(apache) add `deny` and `allow` keywords [Josh Goebel][]
 - enh(apache) highlight numeric attributes values [Josh Goebel][]

--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -19,7 +19,11 @@ export default function(hljs) {
     lexemes: ELIXIR_IDENT_RE,
     keywords: ELIXIR_KEYWORDS
   };
-
+  var NUMBER = {
+    className: 'number',
+    begin: '(\\b0o[0-7_]+)|(\\b0b[01_]+)|(\\b0x[0-9a-fA-F_]+)|(-?\\b[1-9][0-9_]*(.[0-9_]+([eE][-+]?[0-9]+)?)?)',
+    relevance: 0
+  };
   var SIGIL_DELIMITERS = '[/|([{<"\']'
   var LOWERCASE_SIGIL = {
     className: 'string',
@@ -128,11 +132,7 @@ export default function(hljs) {
       begin: ELIXIR_IDENT_RE + ':(?!:)',
       relevance: 0
     },
-    {
-      className: 'number',
-      begin: '(\\b0o[0-7_]+)|(\\b0b[01_]+)|(\\b0x[0-9a-fA-F_]+)|(-?\\b[1-9][0-9_]*(.[0-9_]+([eE][-+]?[0-9]+)?)?)',
-      relevance: 0
-    },
+    NUMBER,
     {
       className: 'variable',
       begin: '(\\$\\W)|((\\$|\\@\\@?)(\\w+))'
@@ -144,6 +144,15 @@ export default function(hljs) {
       begin: '(' + hljs.RE_STARTERS_RE + ')\\s*',
       contains: [
         hljs.HASH_COMMENT_MODE,
+        {
+          // to prevent false regex triggers for the division function:
+          // /:
+          begin: /\/: (?=\d+\s*[,\]])/,
+          relevance: 0,
+          contains: [
+            NUMBER
+          ]
+        },
         {
           className: 'regexp',
           illegal: '\\n',

--- a/test/markup/elixir/function-not-regex.expect.txt
+++ b/test/markup/elixir/function-not-regex.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">import</span> Kernel, <span class="hljs-symbol">except:</span> [
+    <span class="hljs-symbol">spawn:</span> <span class="hljs-number">1</span>,
+    +: <span class="hljs-number">2</span>,
+    /: <span class="hljs-number">2</span>,
+    <span class="hljs-symbol">Unless:</span> <span class="hljs-number">2</span>
+]

--- a/test/markup/elixir/function-not-regex.txt
+++ b/test/markup/elixir/function-not-regex.txt
@@ -1,0 +1,6 @@
+import Kernel, except: [
+    spawn: 1,
+    +: 2,
+    /: 2,
+    Unless: 2
+]


### PR DESCRIPTION
- Do not mistakenly recognize `/:` as the beginning of a regex,
  which causes highlighting to abort.
- Note: `/:`, `+:`, are still not considered symbols

This solves the problem by making the pattern `/: \d+` an exceptional case that is
never treated as a regex.  For most cases, most of the time this should be a win - as in the
use of these short functional symbols is much more common than an actual regex that starts with a literal like `/: 2` etc.

Resolves #730.