### PR TITLE
enh(powershell) Add PowerShell 5.1 default aliases as "built_in"s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Language Improvements:
 - (fortran) Add Fortran 2018 keywords and coarray intrinsics (#2361) [Sam Miller][]
 - (delphi) highlight hexadecimal, octal, and binary numbers (#2370) [Robert Riebisch]()
 - enh(plaintext) added `text` and `txt` as alias (#2360) [Taufik Nurrohman][]
+- enh(powershell) added PowerShell v5.1/v7 default aliases as "built_in"s (#2423) [Sean Williams][]
 
 Developer Tools:
 
@@ -49,6 +50,7 @@ Developer Tools:
 [Robert Riebisch]: https://github.com/bttrx
 [Taufik Nurrohman]: https://github.com/taufik-nurrohman
 [Josh Goebel]: https://github.com/yyyc514
+[Sean Williams]: https://github.com/hmmwhatsthisdo
 
 
 ## Version 9.18.1

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -39,8 +39,9 @@ export default function(hljs){
     keyword: 'if else foreach return do while until elseif begin for trap data dynamicparam ' +
     'end break throw param continue finally in switch exit filter try process catch ' +
     'hidden static parameter',
+    // "echo" relevance has been set to 0 to avoid auto-detect conflicts with shell transcripts
     built_in: 'ac asnp cat cd CFS chdir clc clear clhy cli clp cls clv cnsn compare copy cp ' +
-    'cpi cpp curl cvpa dbp del diff dir dnsn ebp echo epal epcsv epsn erase etsn exsn fc fhx ' +
+    'cpi cpp curl cvpa dbp del diff dir dnsn ebp echo|0 epal epcsv epsn erase etsn exsn fc fhx ' +
     'fl ft fw gal gbp gc gcb gci gcm gcs gdr gerr ghy gi gin gjb gl gm gmo gp gps gpv group ' +
     'gsn gsnp gsv gtz gu gv gwmi h history icm iex ihy ii ipal ipcsv ipmo ipsn irm ise iwmi ' +
     'iwr kill lp ls man md measure mi mount move mp mv nal ndr ni nmo npssc nsn nv ogv oh ' +

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -42,6 +42,23 @@ export default function(hljs){
     // TODO: 'validate[A-Z]+' can't work in keywords
   };
 
+  // Default aliases as defined in Windows PowerShell 5.1 (with exception of %/?)
+  var ALIASES = [
+    'ac', 'asnp', 'cat', 'cd', 'CFS', 'chdir', 'clc', 'clear', 'clhy', 'cli', 'clp', 'cls', 
+    'clv', 'cnsn', 'compare', 'copy', 'cp', 'cpi', 'cpp', 'curl', 'cvpa', 'dbp', 'del', 
+    'diff', 'dir', 'dnsn', 'ebp', 'echo', 'epal', 'epcsv', 'epsn', 'erase', 'etsn', 'exsn', 
+    'fc', 'fhx', 'fl', 'foreach', 'ft', 'fw', 'gal', 'gbp', 'gc', 'gci', 'gcm', 'gcs', 'gdr', 
+    'ghy', 'gi', 'gjb', 'gl', 'gm', 'gmo', 'gp', 'gps', 'gpv', 'group', 'gsn', 'gsnp', 'gsv', 
+    'gu', 'gv', 'gwmi', 'h', 'history', 'icm', 'iex', 'ihy', 'ii', 'ipal', 'ipcsv', 'ipmo', 
+    'ipsn', 'irm', 'ise', 'iwmi', 'iwr', 'kill', 'lp', 'ls', 'man', 'md', 'measure', 'mi', 
+    'mount', 'move', 'mp', 'mv', 'nal', 'ndr', 'ni', 'nmo', 'npssc', 'nsn', 'nv', 'ogv', 
+    'oh', 'popd', 'ps', 'pushd', 'pwd', 'r', 'rbp', 'rcjb', 'rcsn', 'rd', 'rdr', 'ren', 
+    'ri', 'rjb', 'rm', 'rmdir', 'rmo', 'rni', 'rnp', 'rp', 'rsn', 'rsnp', 'rujb', 'rv', 
+    'rvpa', 'rwmi', 'sajb', 'sal', 'saps', 'sasv', 'sbp', 'sc', 'select', 'set', 'shcm', 
+    'si', 'sl', 'sleep', 'sls', 'sort', 'sp', 'spjb', 'spps', 'spsv', 'start', 'sujb', 
+    'sv', 'swmi', 'tee', 'trcm', 'type', 'wget', 'where', 'wjb', 'write'
+  ];
+
   var TITLE_NAME_RE = /\w[\w\d]*((-)[\w\d]+)*/;
 
   var BACKTICK_ESCAPE = {
@@ -113,6 +130,13 @@ export default function(hljs){
     className: 'built_in',
     variants: [
       { begin: '('.concat(VALID_VERBS, ')+(-)[\\w\\d]+') }
+    ]
+  };
+
+  var PS_ALIAS = {
+    className: 'built_in',
+    variants: [
+      { keywords: KEYWORDS }
     ]
   };
 
@@ -245,7 +269,8 @@ export default function(hljs){
       PS_FUNCTION,
       PS_USING,
       PS_ARGUMENTS,
-      PS_TYPE
+      PS_TYPE,
+      PS_ALIAS
     )
   };
 }

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -48,15 +48,15 @@ export default function(hljs){
     'clv', 'cnsn', 'compare', 'copy', 'cp', 'cpi', 'cpp', 'curl', 'cvpa', 'dbp', 'del', 
     'diff', 'dir', 'dnsn', 'ebp', 'echo', 'epal', 'epcsv', 'epsn', 'erase', 'etsn', 'exsn', 
     'fc', 'fhx', 'fl', 'foreach', 'ft', 'fw', 'gal', 'gbp', 'gc', 'gci', 'gcm', 'gcs', 'gdr', 
-    'ghy', 'gi', 'gjb', 'gl', 'gm', 'gmo', 'gp', 'gps', 'gpv', 'group', 'gsn', 'gsnp', 'gsv', 
-    'gu', 'gv', 'gwmi', 'h', 'history', 'icm', 'iex', 'ihy', 'ii', 'ipal', 'ipcsv', 'ipmo', 
-    'ipsn', 'irm', 'ise', 'iwmi', 'iwr', 'kill', 'lp', 'ls', 'man', 'md', 'measure', 'mi', 
-    'mount', 'move', 'mp', 'mv', 'nal', 'ndr', 'ni', 'nmo', 'npssc', 'nsn', 'nv', 'ogv', 
-    'oh', 'popd', 'ps', 'pushd', 'pwd', 'r', 'rbp', 'rcjb', 'rcsn', 'rd', 'rdr', 'ren', 
-    'ri', 'rjb', 'rm', 'rmdir', 'rmo', 'rni', 'rnp', 'rp', 'rsn', 'rsnp', 'rujb', 'rv', 
-    'rvpa', 'rwmi', 'sajb', 'sal', 'saps', 'sasv', 'sbp', 'sc', 'select', 'set', 'shcm', 
-    'si', 'sl', 'sleep', 'sls', 'sort', 'sp', 'spjb', 'spps', 'spsv', 'start', 'sujb', 
-    'sv', 'swmi', 'tee', 'trcm', 'type', 'wget', 'where', 'wjb', 'write'
+    'gerr', 'ghy', 'gi', 'gjb', 'gl', 'gm', 'gmo', 'gp', 'gps', 'gpv', 'group', 'gsn', 'gsnp', 
+    'gsv', 'gu', 'gv', 'gwmi', 'h', 'history', 'icm', 'iex', 'ihy', 'ii', 'ipal', 'ipcsv', 
+    'ipmo', 'ipsn', 'irm', 'ise', 'iwmi', 'iwr', 'kill', 'lp', 'ls', 'man', 'md', 'measure', 
+    'mi', 'mount', 'move', 'mp', 'mv', 'nal', 'ndr', 'ni', 'nmo', 'npssc', 'nsn', 'nv', 'ogv', 
+    'oh', 'popd', 'ps', 'pushd', 'pwd', 'r', 'rbp', 'rcjb', 'rcsn', 'rd', 'rdr', 'ren', 'ri', 
+    'rjb', 'rm', 'rmdir', 'rmo', 'rni', 'rnp', 'rp', 'rsn', 'rsnp', 'rujb', 'rv', 'rvpa', 
+    'rwmi', 'sajb', 'sal', 'saps', 'sasv', 'sbp', 'sc', 'select', 'set', 'shcm', 'si', 'sl', 
+    'sleep', 'sls', 'sort', 'sp', 'spjb', 'spps', 'spsv', 'start', 'sujb', 'sv', 'swmi', 'tee',
+    'trcm', 'type', 'wget', 'where', 'wjb', 'write'
   ];
 
   var TITLE_NAME_RE = /\w[\w\d]*((-)[\w\d]+)*/;

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -246,7 +246,7 @@ export default function(hljs){
   return {
     name: 'PowerShell',
     aliases: ["ps", "ps1"],
-    lexemes: /-?[A-z\.\-]+/,
+    lexemes: /-?[A-z\.\-]+\b/,
     case_insensitive: true,
     keywords: KEYWORDS,
     contains: GENTLEMANS_SET.concat(

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -136,7 +136,7 @@ export default function(hljs){
   var PS_ALIAS = {
     className: 'built_in',
     variants: [
-      { keywords: KEYWORDS }
+      { keywords: ALIASES.join(' ') }
     ]
   };
 

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -38,26 +38,17 @@ export default function(hljs){
   var KEYWORDS = {
     keyword: 'if else foreach return do while until elseif begin for trap data dynamicparam ' +
     'end break throw param continue finally in switch exit filter try process catch ' +
-    'hidden static parameter'
+    'hidden static parameter',
+    built_in: 'ac asnp cat cd CFS chdir clc clear clhy cli clp cls clv cnsn compare copy cp ' +
+    'cpi cpp curl cvpa dbp del diff dir dnsn ebp echo epal epcsv epsn erase etsn exsn fc fhx ' +
+    'fl ft fw gal gbp gc gcb gci gcm gcs gdr gerr ghy gi gin gjb gl gm gmo gp gps gpv group ' +
+    'gsn gsnp gsv gtz gu gv gwmi h history icm iex ihy ii ipal ipcsv ipmo ipsn irm ise iwmi ' +
+    'iwr kill lp ls man md measure mi mount move mp mv nal ndr ni nmo npssc nsn nv ogv oh ' +
+    'popd ps pushd pwd r rbp rcjb rcsn rd rdr ren ri rjb rm rmdir rmo rni rnp rp rsn rsnp ' +
+    'rujb rv rvpa rwmi sajb sal saps sasv sbp sc scb select set shcm si sl sleep sls sort sp ' +
+    'spjb spps spsv start stz sujb sv swmi tee trcm type wget where wjb write'
     // TODO: 'validate[A-Z]+' can't work in keywords
   };
-
-  // Default aliases as defined in Windows PowerShell 5.1 (with exception of %/?)
-  var ALIASES = [
-    'ac', 'asnp', 'cat', 'cd', 'CFS', 'chdir', 'clc', 'clear', 'clhy', 'cli', 'clp', 'cls', 
-    'clv', 'cnsn', 'compare', 'copy', 'cp', 'cpi', 'cpp', 'curl', 'cvpa', 'dbp', 'del', 
-    'diff', 'dir', 'dnsn', 'ebp', 'echo', 'epal', 'epcsv', 'epsn', 'erase', 'etsn', 'exsn', 
-    'fc', 'fhx', 'fl', 'foreach', 'ft', 'fw', 'gal', 'gbp', 'gc', 'gci', 'gcm', 'gcs', 'gdr', 
-    'gerr', 'ghy', 'gi', 'gjb', 'gl', 'gm', 'gmo', 'gp', 'gps', 'gpv', 'group', 'gsn', 'gsnp', 
-    'gsv', 'gu', 'gv', 'gwmi', 'h', 'history', 'icm', 'iex', 'ihy', 'ii', 'ipal', 'ipcsv', 
-    'ipmo', 'ipsn', 'irm', 'ise', 'iwmi', 'iwr', 'kill', 'lp', 'ls', 'man', 'md', 'measure', 
-    'mi', 'mount', 'move', 'mp', 'mv', 'nal', 'ndr', 'ni', 'nmo', 'npssc', 'nsn', 'nv', 'ogv', 
-    'oh', 'popd', 'ps', 'pushd', 'pwd', 'r', 'rbp', 'rcjb', 'rcsn', 'rd', 'rdr', 'ren', 'ri', 
-    'rjb', 'rm', 'rmdir', 'rmo', 'rni', 'rnp', 'rp', 'rsn', 'rsnp', 'rujb', 'rv', 'rvpa', 
-    'rwmi', 'sajb', 'sal', 'saps', 'sasv', 'sbp', 'sc', 'select', 'set', 'shcm', 'si', 'sl', 
-    'sleep', 'sls', 'sort', 'sp', 'spjb', 'spps', 'spsv', 'start', 'sujb', 'sv', 'swmi', 'tee',
-    'trcm', 'type', 'wget', 'where', 'wjb', 'write'
-  ];
 
   var TITLE_NAME_RE = /\w[\w\d]*((-)[\w\d]+)*/;
 
@@ -130,13 +121,6 @@ export default function(hljs){
     className: 'built_in',
     variants: [
       { begin: '('.concat(VALID_VERBS, ')+(-)[\\w\\d]+') }
-    ]
-  };
-
-  var PS_ALIAS = {
-    className: 'built_in',
-    variants: [
-      { keywords: ALIASES.join(' ') }
     ]
   };
 
@@ -269,8 +253,7 @@ export default function(hljs){
       PS_FUNCTION,
       PS_USING,
       PS_ARGUMENTS,
-      PS_TYPE,
-      PS_ALIAS
+      PS_TYPE
     )
   };
 }


### PR DESCRIPTION
This PR adds a list of default aliases pulled from two versions of PowerShell:
* Windows PowerShell 5.1, using the following expression:
  ```powershell
  (gal | ? Name -notin '?','%' | % name | % {"'$_'"}) -join ', '
  ```
* PowerShell Core, based on the list defined within [`[System.Management.Automation.Runspaces.InitialSessionState]::BuiltInAliases`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/InitialSessionState.cs#L4592) in the PowerShell Core source.

Resolves #1338.