### PR TITLE
:memo: chore: fixed missing import file

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ import hljs from 'highlight.js';
 The default import imports all languages! Therefore it is likely to be more efficient to import only the library and the languages you need:
 
 ```js
-import hljs from 'highlight.js/lib/core';
+import hljs from 'highlight.js/lib/highlight';
 import javascript from 'highlight.js/lib/languages/javascript';
 hljs.registerLanguage('javascript', javascript);
 ```
@@ -381,7 +381,7 @@ hljs.registerLanguage('javascript', javascript);
 To set the syntax highlighting style, if your build tool processes CSS from your JavaScript entry point, you can import the stylesheet directly into your CommonJS-module:
 
 ```js
-import hljs from 'highlight.js/lib/core';
+import hljs from 'highlight.js/lib/highlight';
 import 'highlight.js/styles/github.css';
 ```
 


### PR DESCRIPTION
- fixed old version documentation
  - adjusted [this page](https://highlightjs.org/usage/)