### PR TITLE
(bug) Fix `beginKeywords` to ignore . matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 New languages:
 
-- (php-template) Explicit language to detect PHP templates (vs xml) [Josh Goebel][]
+- add(php-template) Explicit language to detect PHP templates (vs xml) [Josh Goebel][]
 - enh(python) Added `python-repl` for Python REPL sessions
 
 New themes:
@@ -11,12 +11,13 @@ New themes:
 
 Parser Engine Changes:
 
-- add `before:highlight` plugin API callback (#2395) [Josh Goebel][]
-- add `after:highlight` plugin API callback (#2395) [Josh Goebel][]
-- split out parse tree generation and HTML rendering concerns (#2404) [Josh Goebel][]
-- every language can have a `name` attribute now (#2400) [Josh Goebel][]
-- improve regular expression detect (less false-positives) (#2380) [Josh Goebel][]
-- make `noHighlightRe` and `languagePrefixRe` configurable (#2374) [Josh Goebel][]
+- (bug) Fix `beginKeywords` to ignore . matches (#2434) [Josh Goebel][]
+- (enh) add `before:highlight` plugin API callback (#2395) [Josh Goebel][]
+- (enh) add `after:highlight` plugin API callback (#2395) [Josh Goebel][]
+- (enh) split out parse tree generation and HTML rendering concerns (#2404) [Josh Goebel][]
+- (enh) every language can have a `name` attribute now (#2400) [Josh Goebel][]
+- (enh) improve regular expression detect (less false-positives) (#2380) [Josh Goebel][]
+- (enh) make `noHighlightRe` and `languagePrefixRe` configurable (#2374) [Josh Goebel][]
 
 Language Improvements:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -89,21 +89,25 @@ Used instead of ``begin`` for modes starting with keywords to avoid needless rep
 ::
 
   {
-    begin: '\\b(extends|implements) ',
-    keywords: 'extends implements'
+    begin: '\\b(class|interface) ',
+    keywords: 'class interface'
   }
 
-… becomes:
+… can often be shortened to:
 
 ::
 
   {
-    beginKeywords: 'extends implements'
+    beginKeywords: 'class interface'
   }
 
 Unlike the :ref:`keywords <keywords>` attribute, this one allows only a simple list of space separated keywords.
 If you do need additional features of ``keywords`` or you just need more keywords for this mode you may include ``keywords`` along with ``beginKeywords``.
 
+Note: ``beginKeywords`` also checks for a ``.`` before or after the keywords and will fail to match if one is found.
+This is to avoid false positives for method calls or property accesses.
+
+Ex. ``class A { ... }`` would match while ``A.class == B.class`` would not.
 
 .. _endsWithParent:
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -89,7 +89,7 @@ Used instead of ``begin`` for modes starting with keywords to avoid needless rep
 ::
 
   {
-    begin: '\\b(class|interface) ',
+    begin: '\\b(class|interface)\\b',
     keywords: 'class interface'
   }
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -214,6 +214,12 @@ const HLJS = function(hljs) {
       var lexeme = match[0];
       var new_mode = match.rule;
 
+      // __abortIf is consider private API
+      if (new_mode.__abortIf && new_mode.__abortIf(match)) {
+        mode_buffer += lexeme;
+        return lexeme.length;
+      }
+
       if (new_mode && new_mode.endSameAsBegin) {
         new_mode.endRe = regex.escape( lexeme );
       }
@@ -358,6 +364,7 @@ const HLJS = function(hljs) {
       while (true) {
         top.terminators.lastIndex = index;
         match = top.terminators.exec(codeToHighlight);
+        // console.log("match", match[0], match.rule && match.rule.begin)
         if (!match)
           break;
         let beforeMatch = codeToHighlight.substring(index, match.index);

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -214,7 +214,6 @@ const HLJS = function(hljs) {
       var lexeme = match[0];
       var new_mode = match.rule;
 
-      // __abortIf is consider private API
       if (new_mode.__abortIf && new_mode.__abortIf(match)) {
         mode_buffer += lexeme;
         return lexeme.length;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -322,6 +322,7 @@ const HLJS = function(hljs) {
       // sometimes they can end up matching nothing at all
       // Ref: https://github.com/highlightjs/highlight.js/issues/2140
       if (lastMatch.type=="begin" && match.type=="end" && lastMatch.index == match.index && lexeme === "") {
+        top.terminators.startAt = 0;
         // spit the "skipped" character that our regex choked on back into the output sequence
         mode_buffer += codeToHighlight.slice(match.index, match.index + 1);
         if (!SAFE_MODE) {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -210,7 +210,7 @@ const HLJS = function(hljs) {
     }
 
     function doIgnore(lexeme) {
-      if (top.terminators.startAt === 0) {
+      if (top.matcher.regexIndex === 0) {
         // no more regexs to potentially match here, so we move the cursor forward one
         // space
         mode_buffer += lexeme[0];
@@ -218,7 +218,7 @@ const HLJS = function(hljs) {
       } else {
         // no need to move the cursor, we still have additional regexes to try and
         // match at this very spot
-        findNextRegexMatch = true;
+        continueScanAtSamePosition = true;
         return 0;
       }
     }
@@ -376,17 +376,19 @@ const HLJS = function(hljs) {
     var match, processedCount, index = 0;
 
     try {
-      var findNextRegexMatch = false;
-      top.terminators.startAt = 0;
+      var continueScanAtSamePosition = false;
+      top.matcher.considerAll();
 
       while (true) {
-        top.terminators.lastIndex = index;
-        if (findNextRegexMatch) {
-          findNextRegexMatch = false;
+        if (continueScanAtSamePosition) {
+          continueScanAtSamePosition = false;
+          // only regexes not matched previously will now be
+          // considered for a potential match
         } else {
-          top.terminators.startAt = 0;
+          top.matcher.lastIndex = index;
+          top.matcher.considerAll();
         }
-        match = top.terminators.exec(codeToHighlight);
+        match = top.matcher.exec(codeToHighlight);
         // console.log("match", match[0], match.rule && match.rule.begin)
         if (!match)
           break;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -227,13 +227,13 @@ const HLJS = function(hljs) {
       var lexeme = match[0];
       var new_mode = match.rule;
 
-      if (new_mode.__abortIf && new_mode.__abortIf(match)) {
-        return doIgnore(lexeme);
-        // mode_buffer += lexeme;
-        // return lexeme.length;
+      if (new_mode.__onBegin) {
+        let res = new_mode.__onBegin(match) || {};
+        if (res.ignoreMatch)
+          return doIgnore(lexeme);
       }
 
-      // we are not ignoring
+      // we are not ignoring, so next match should start with first regex in stack
       top.terminators.startAt = 0;
 
       if (new_mode && new_mode.endSameAsBegin) {

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -103,7 +103,7 @@ export function compileLanguage(language) {
       this.count = 0;
 
       this.lastIndex = 0;
-      this.startAt = 0;
+      this.regexIndex = 0;
     }
 
     getMatcher(index) {
@@ -116,22 +116,26 @@ export function compileLanguage(language) {
       return matcher;
     }
 
+    considerAll() {
+      this.regexIndex = 0;
+    }
+
     addRule(re, opts) {
       this.rules.push([re, opts]);
       if (opts.type==="begin") this.count++;
     }
 
     exec(s) {
-      let m = this.getMatcher(this.startAt);
+      let m = this.getMatcher(this.regexIndex);
       m.lastIndex = this.lastIndex;
       let result = m.exec(s);
       if (result) {
-        this.startAt += result.position + 1;
-        if (this.startAt === this.count) // wrap-around
-          this.startAt = 0;
+        this.regexIndex += result.position + 1;
+        if (this.regexIndex === this.count) // wrap-around
+          this.regexIndex = 0;
       }
 
-      // this.startAt = 0;
+      // this.regexIndex = 0;
       return result;
     }
   }
@@ -242,7 +246,7 @@ export function compileLanguage(language) {
       compileMode(mode.starts, parent);
     }
 
-    mode.terminators = buildModeRegex(mode);
+    mode.matcher = buildModeRegex(mode);
   }
 
   // self is not valid at the top-level

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -70,6 +70,14 @@ export function compileLanguage(language) {
     return matcher;
   }
 
+  function abortIf_preceedingOrTrailingDot(match) {
+    let before = match.input[match.index-1];
+    let after = match.input[match.index + match[0].length];
+    if (before === "." || after === ".") {
+      return true;
+    }
+  }
+
   function compileMode(mode, parent) {
     if (mode.compiled)
       return;
@@ -89,6 +97,7 @@ export function compileLanguage(language) {
         // doesn't allow spaces in keywords anyways and we still check for the boundary
         // first
         mode.begin = '\\b(' + mode.beginKeywords.split(' ').join('|') + ')(?=\\b|\\s)';
+        mode.__abortIf = abortIf_preceedingOrTrailingDot;
       }
       if (!mode.begin)
         mode.begin = /\B|\b/;

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -44,25 +44,22 @@ export function compileLanguage(language) {
     }
 
     compile() {
+      if (this.regexes.length === 0) {
+        // avoids the need to check length every time exec is called
+        this.exec = () => null;
+      }
       let terminators = this.regexes.map(el => el[1]);
       this.matcherRe = langRe(regex.join(terminators, '|'), true);
       this.lastIndex = 0;
     }
 
     exec(s) {
-      var matchData;
-      if (this.regexes.length === 0) return null;
-
       this.matcherRe.lastIndex = this.lastIndex;
       let match = this.matcherRe.exec(s);
       if (!match) { return null; }
 
-      for(var i = 0; i<match.length; i++) {
-        if (match[i] != undefined && this.matchIndexes[i]) {
-          matchData = this.matchIndexes[i];
-          break;
-        }
-      }
+      let i = match.findIndex((el, i) => i>0 && el!=undefined);
+      let matchData = this.matchIndexes[i];
 
       return Object.assign(match, matchData);
     }

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -154,11 +154,11 @@ export function compileLanguage(language) {
   }
 
   // TODO: We need negative look-behind support to do this properly
-  function hasPrecedingOrTrailingDot(match) {
+  function skipIfhasPrecedingOrTrailingDot(match) {
     let before = match.input[match.index-1];
     let after = match.input[match.index + match[0].length];
     if (before === "." || after === ".") {
-      return true;
+      return {ignoreMatch: true };
     }
   }
 
@@ -197,8 +197,8 @@ export function compileLanguage(language) {
       return;
     mode.compiled = true;
 
-    // __abortIf is considered private API, internal use only
-    mode.__abortIf = null;
+    // __onBegin is considered private API, internal use only
+    mode.__onBegin = null;
 
     mode.keywords = mode.keywords || mode.beginKeywords;
     if (mode.keywords)
@@ -214,7 +214,7 @@ export function compileLanguage(language) {
         // doesn't allow spaces in keywords anyways and we still check for the boundary
         // first
         mode.begin = '\\b(' + mode.beginKeywords.split(' ').join('|') + ')(?=\\b|\\s)';
-        mode.__abortIf = hasPrecedingOrTrailingDot;
+        mode.__onBegin = skipIfhasPrecedingOrTrailingDot;
       }
       if (!mode.begin)
         mode.begin = /\B|\b/;

--- a/test/api/beginKeywords.js
+++ b/test/api/beginKeywords.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const hljs   = require('../../build');
+
+let grammar = function() {
+  return {
+    contains: [
+      { beginKeywords: "class" }
+    ]
+  }
+}
+
+let grammarWithFollowupRule = function() {
+  return {
+    contains: [
+      { beginKeywords: "class" },
+      { begin: "class", className: "found" }
+    ]
+  }
+}
+
+describe('beginKeywords', () => {
+  before( () => {
+    hljs.registerLanguage("test", grammar);
+    hljs.registerLanguage("has-followup", grammarWithFollowupRule);
+  });
+
+  it("should allow subsequence matches to still succeed", () => {
+    let content = "A.class = self";
+    let res = hljs.highlight("has-followup", content);
+    res.value.should.equal('A.<span class="hljs-found">class</span> = self');
+  });
+
+  it("should ignore a preceeding .", () => {
+    let content = "A.class = self";
+    let res = hljs.highlight("test", content);
+    res.value.should.equal('A.class = self');
+  });
+
+  it("should ignore a trailing .", () => {
+    let content = "class.config = true";
+    let res = hljs.highlight("test", content);
+    res.value.should.equal('class.config = true');
+  });
+
+  it('should detect keywords', () => {
+    let content = "I have a class yes I do.";
+    let res = hljs.highlight("test", content);
+    res.value.should.equal('I have a <span class="hljs-keyword">class</span> yes I do.');
+  });
+});


### PR DESCRIPTION
Related: https://github.com/highlightjs/highlight.js/issues/2429 Resolves #2428 

Attempts to restore as little as possible of the previous `beginKeywords` magic behavior as necessary just to prevent `.keyword` or `keyword.` from matching.  This is done via an internal `onBegin` callback that essentially ignores the match if a `.` is found.

**What behavior does this NOT restore?**  A failed match will NOT consume any content from the input stream, ie it will not advance the cursor.

Previously:

```
       v Parse cursor is here after failure to match.
A.class
```

Now:

```
  v Parse cursor is here (or earlier) after failure to match.
A.class
```

Ex:

```js
    contains: [
      { beginKeywords: "class" },
      // this rule will still match class if the above rules fails to (because of a `.`)
      { begin: "class", className: "found" }
    ]
```

Also previously the match would actually start at the `.` (when one was present), which would prevent any other rules from matching if there was a failed keyword match - that is no longer the case.  The match now starts with the keyword itself and then looks backwards to see if there was a preceding `.` or not.

---

**What else might still be an issue...**

This new behavior means that when `beginKeywords` fails to match `keywords` now has a chance to.  I think this is new behavior, and correct behavior.  **No other place in the parser does a rule silently consume content for a non-match**, and I don't think `beginKeywords` should do so either.

---

- `MultiRegex` is just a re-factoring of the behavior that was there before into a class, allowing us to work with a large group of regexes as a single search unit.
- `ResumableMultiRegex` wraps multiple MultiRegex objects to allow resuming a multi-regex search at the same cursor position, allowing for the possibility of multiple regexes matching, instead of just the first.

See comments in source for more details