### PR TITLE
(doc) add Lean language

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -93,6 +93,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Kotlin                  | kotlin, kt             |         |
 | LaTeX                   | tex                    |         |
 | Leaf                    | leaf                   |         |
+| Lean                    | lean                   | [highlightjs-lean](https://github.com/leanprover-community/highlightjs-lean) |
 | Lasso                   | lasso, ls, lassoscript |         |
 | Less                    | less                   |         |
 | LDIF                    | ldif                   |         |


### PR DESCRIPTION
This is a followup to #1689. We've created a new repository at https://github.com/leanprover-community/highlightjs-lean and linked to it in `SUPPORTED_LANGUAGES.md`. 

I'm not 100% sure we've made the new repo in the recommended way, so if a highlightjs maintainer would like to take a look and give some suggestions, I'd be very grateful!

cc: @PatrickMassot.