### PR TITLE
adds func keyword for nim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Parser Engine Changes:
 
 Language Improvements:
 
+- enh(nim) adds `func` keyword (#2468) [Adnan Yaqoob][]
 - enh(xml) deprecate ActionScript inside script tags (#2444) [Josh Goebel][]
 - fix(javascript) prevent get/set variables conflicting with keywords (#2440) [Josh Goebel][]
 - bug(clojure) Now highlights `defn-` properly (#2438) [Josh Goebel][]
@@ -64,6 +65,7 @@ Developer Tools:
 [Taufik Nurrohman]: https://github.com/taufik-nurrohman
 [Josh Goebel]: https://github.com/yyyc514
 [Sean Williams]: https://github.com/hmmwhatsthisdo
+[Adnan Yaqoob]: https://github.com/adnanyaqoobvirk
 
 
 ## Version 9.18.1

--- a/src/languages/nim.js
+++ b/src/languages/nim.js
@@ -13,7 +13,7 @@ export default function(hljs) {
       keyword:
         'addr and as asm bind block break case cast const continue converter ' +
         'discard distinct div do elif else end enum except export finally ' +
-        'for from generic if import in include interface is isnot iterator ' +
+        'for from func generic if import in include interface is isnot iterator ' +
         'let macro method mixin mod nil not notin object of or out proc ptr ' +
         'raise ref return shl shr static template try tuple type using var ' +
         'when while with without xor yield',


### PR DESCRIPTION
The func keyword introduces a shortcut for a noSideEffect proc.

`func binarySearch[T](a: openArray[T]; elem: T): int`

Is short for:

`proc binarySearch[T](a: openArray[T]; elem: T): int {.noSideEffect.}`

[Nim Manual Reference](https://nim-lang.org/docs/manual.html#procedures-func)