### PR TITLE
Fix windows absolute paths.

### DIFF
--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -63,7 +63,7 @@ class Language {
   }
 
   static fromFile(filename) {
-    if (filename.startsWith("/") || filename.startsWith("."))
+    if ( path.isAbsolute(filename) || filename.startsWith(".") )
     {
       var file = filename
     } else {

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -63,7 +63,7 @@ class Language {
   }
 
   static fromFile(filename) {
-    if ( path.isAbsolute(filename) || filename.startsWith(".") )
+    if (path.isAbsolute(filename) || filename.startsWith("."))
     {
       var file = filename
     } else {


### PR DESCRIPTION
Fix windows absolute paths (building of extra languages breaks on Windows 10).