### PR TITLE
Add Srcery style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ New languages:
 
 New themes:
 
-- none.
+- *Srcery* by [Chen Bin][]
 
 Parser Engine Changes:
 
@@ -63,6 +63,7 @@ Developer Tools:
 [Omid Golparvar]: https://github.com/omidgolparvar
 [Alexandre Grison]: https://github.com/agrison
 [Josh Goebel]: https://github.com/yyyc514
+[Chen Bin]: https://github.com/redguardtoo
 [Sam Miller]: https://github.com/smillerc
 [Robert Riebisch]: https://github.com/bttrx
 [Taufik Nurrohman]: https://github.com/taufik-nurrohman

--- a/src/styles/srcery.css
+++ b/src/styles/srcery.css
@@ -1,0 +1,78 @@
+/*
+Description: Srcery dark color scheme for highlight.js
+Author: Chen Bin <chen.bin@gmail.com>
+Website: https://srcery-colors.github.io/
+Date: 2020-04-06
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #1C1B19;
+  color: #FCE8C3;
+}
+
+.hljs-strong,
+.hljs-emphasis {
+  color: #918175;
+}
+
+.hljs-bullet,
+.hljs-quote,
+.hljs-link,
+.hljs-number,
+.hljs-regexp,
+.hljs-literal {
+  color: #FF5C8F;
+}
+
+.hljs-code,
+.hljs-selector-class {
+  color: #68A8E4
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-section,
+.hljs-attribute,
+.hljs-variable {
+  color: #EF2F27;
+}
+
+.hljs-name,
+.hljs-title {
+  color: #FBB829;
+}
+
+.hljs-type,
+.hljs-params {
+  color: #0AAEB3;
+}
+
+.hljs-string {
+  color: #98BC37;
+}
+
+.hljs-subst,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-symbol,
+.hljs-selector-id,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-addition {
+  color: #C07ABE;
+}
+
+.hljs-comment,
+.hljs-deletion,
+.hljs-meta {
+  color: #918175;
+}


### PR DESCRIPTION
Migrate Srcery (https://srcery-colors.github.io/) to highlight.js.

Screenshot,
![image](https://user-images.githubusercontent.com/184553/78524738-298ee400-7818-11ea-961b-dd645f21ee04.png)
