### PR TITLE
(dev) Developer tool should use un-minified library

### DIFF
--- a/test/browser/worker.js
+++ b/test/browser/worker.js
@@ -2,7 +2,7 @@
 
 const Worker   = require('tiny-worker');
 
-const {newTestCase, defaultCase, findLibrary } = require('./test_case')
+const { defaultCase, findLibrary } = require('./test_case')
 
 describe('web worker', function() {
   before(async function() {

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -68,7 +68,7 @@
     </div>
   </div>
 
-  <script src="../build/highlight.min.js"></script>
+  <script src="../build/highlight.js"></script>
   <script src="../demo/jquery-2.1.1.min.js"></script>
 
   <script>


### PR DESCRIPTION
- Following the docs, I've found that in *Basic Testing* section says: ["You need to build highlight.js with only the language you’re working on (**without compression**, to have readable code in browser error messages)"](https://highlightjs.readthedocs.io/en/latest/building-testing.html#basic-testing), but in `tools/developers.html` file the library is included minified. Documentation or file was wrong, I've supposed that the file.
- Removed a import in `test/browser/worker.js` that is not doing nothing.  