### PR TITLE
Fix Typescript markup for comment after enclosed lambda.

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -159,7 +159,6 @@ export default function(hljs) {
                     excludeBegin: true, excludeEnd: true,
                     keywords: KEYWORDS,
                     contains: [
-                      'self',
                       hljs.C_LINE_COMMENT_MODE,
                       hljs.C_BLOCK_COMMENT_MODE
                     ]

--- a/test/markup/typescript/comment-after-enclosed-lambda.expect.txt
+++ b/test/markup/typescript/comment-after-enclosed-lambda.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-keyword">const</span> bad = <span class="hljs-function">(<span class="hljs-params">(a, b</span>) =&gt;</span> [...a, b]);
+<span class="hljs-comment">// https://github.com/highlightjs/highlight.js/issues/2189</span>

--- a/test/markup/typescript/comment-after-enclosed-lambda.txt
+++ b/test/markup/typescript/comment-after-enclosed-lambda.txt
@@ -1,0 +1,2 @@
+const bad = ((a, b) => [...a, b]);
+// https://github.com/highlightjs/highlight.js/issues/2189


### PR DESCRIPTION
This resolves #2189. Function params can't contains `self`.