### PR TITLE
(python) don't include `(` `)` in functions `params` match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@ Developer Tools:
 [Josh Goebel]: https://github.com/yyyc514
 [Sean Williams]: https://github.com/hmmwhatsthisdo
 [Adnan Yaqoob]: https://github.com/adnanyaqoobvirk
+[Álvaro Mondéjar]: https://github.com/mondeja
 
 
 ## Version 9.18.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Parser Engine Changes:
 
 Language Improvements:
 
+- enh(python) Exclude parens from functions params (#2490) [Álvaro Mondéjar][]
 - enh(swift) Add `compactMap` to keywords as built_in (#2478) [Omid Golparvar][]
 - enh(nim) adds `func` keyword (#2468) [Adnan Yaqoob][]
 - enh(xml) deprecate ActionScript inside script tags (#2444) [Josh Goebel][]
@@ -2148,4 +2149,3 @@ your comments and question to [highlight.js forum][forum]. And don't be afraid
 if you find there some fancy Cyrillic letters -- it's for Russian users too :-)
 
 [forum]: http://softwaremaniacs.org/forum/viewforum.php?id=6
-

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -86,8 +86,14 @@ export default function(hljs) {
   };
   var PARAMS = {
     className: 'params',
-    begin: /\(/, end: /\)/, excludeBegin: true, excludeEnd: true,
-    contains: ['self', PROMPT, NUMBER, STRING, hljs.HASH_COMMENT_MODE]
+    variants: [
+      // Exclude params at functions without params
+      {begin: /\(\s*\)/, skip: true, className: null },
+      {
+        begin: /\(/, end: /\)/, excludeBegin: true, excludeEnd: true,
+        contains: ['self', PROMPT, NUMBER, STRING, hljs.HASH_COMMENT_MODE],
+      },
+    ],
   };
   SUBST.contains = [STRING, NUMBER, PROMPT];
   return {

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -86,7 +86,7 @@ export default function(hljs) {
   };
   var PARAMS = {
     className: 'params',
-    begin: /\(/, end: /\)/,
+    begin: /\(/, end: /\)/, excludeBegin: true, excludeEnd: true,
     contains: ['self', PROMPT, NUMBER, STRING, hljs.HASH_COMMENT_MODE]
   };
   SUBST.contains = [STRING, NUMBER, PROMPT];

--- a/test/markup/python-repl/sample.expect.txt
+++ b/test/markup/python-repl/sample.expect.txt
@@ -11,7 +11,7 @@ foo = 42"
 <span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-string">"""</span></span>
 <span class="hljs-meta">...</span> <span class="python"><span class="hljs-string">abc</span></span>
 <span class="hljs-meta">...</span> <span class="python"><span class="hljs-string">"""</span></span>
-<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">test</span><span class="hljs-params">()</span>:</span></span>
+<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">test</span>(<span class="hljs-params"></span>):</span></span>
 <span class="hljs-meta">...</span> <span class="python">    <span class="hljs-keyword">pass</span></span>
 <span class="hljs-meta">&gt;&gt;&gt;</span>
 <span class="hljs-meta">&gt;&gt;&gt;</span>

--- a/test/markup/python-repl/sample.expect.txt
+++ b/test/markup/python-repl/sample.expect.txt
@@ -11,7 +11,7 @@ foo = 42"
 <span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-string">"""</span></span>
 <span class="hljs-meta">...</span> <span class="python"><span class="hljs-string">abc</span></span>
 <span class="hljs-meta">...</span> <span class="python"><span class="hljs-string">"""</span></span>
-<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">test</span>(<span class="hljs-params"></span>):</span></span>
+<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">test</span>():</span></span>
 <span class="hljs-meta">...</span> <span class="python">    <span class="hljs-keyword">pass</span></span>
 <span class="hljs-meta">&gt;&gt;&gt;</span>
 <span class="hljs-meta">&gt;&gt;&gt;</span>

--- a/test/markup/python/function-header-comments.expect.txt
+++ b/test/markup/python/function-header-comments.expect.txt
@@ -1,10 +1,10 @@
-<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span><span class="hljs-params">(
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span>(<span class="hljs-params">
   bar, <span class="hljs-comment"># commment</span>
-)</span>:</span>
+</span>):</span>
     <span class="hljs-keyword">pass</span>
 
 
-<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span><span class="hljs-params">(collections.namedtuple<span class="hljs-params">(<span class="hljs-string">'Test'</span>)</span>, <span class="hljs-params">(
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span>(<span class="hljs-params">collections.namedtuple(<span class="hljs-params"><span class="hljs-string">'Test'</span></span>), (<span class="hljs-params">
     <span class="hljs-string">'name'</span>, <span class="hljs-comment"># comment</span>
-)</span>)</span>:</span>
+</span>)</span>):</span>
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/function-header.expect.txt
+++ b/test/markup/python/function-header.expect.txt
@@ -1,2 +1,2 @@
-<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span><span class="hljs-params">(x: int)</span> -&gt; <span class="hljs-keyword">None</span>:</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span>(<span class="hljs-params">x: int</span>) -&gt; <span class="hljs-keyword">None</span>:</span>
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/matrix-multiplication.expect.txt
+++ b/test/markup/python/matrix-multiplication.expect.txt
@@ -2,6 +2,6 @@
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>:</span>
 
 <span class="hljs-meta">    @decorator</span>
-    <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span><span class="hljs-params">(self, H, V, beta, r)</span>:</span>
+    <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span>(<span class="hljs-params">self, H, V, beta, r</span>):</span>
         S = (H @ beta - r).T @ inv(H @ V @ H.T) @ (H @ beta - r)
         <span class="hljs-keyword">return</span> S


### PR DESCRIPTION
Python functions parameters before this pull are including `(` and `)` characters. This not is the desired behaviour as commented in pull #2489.