### PR TITLE
Add Chaos to the list of supported languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -40,6 +40,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | CSP                     | csp                    |         |
 | CSS                     | css                    |         |
 | Cap’n Proto             | capnproto, capnp       |         |
+| Chaos                   | chaos, kaos            | [highlightjs-chaos](https://github.com/chaos-lang/highlightjs-chaos) |
 | Clojure                 | clojure, clj           |         |
 | CoffeeScript            | coffeescript, coffee, cson, iced | |
 | CpcdosC+                | cpc                    | [highlightjs-cpcdos](https://github.com/SPinti-Software/highlightjs-cpcdos) |


### PR DESCRIPTION
I'm not sure whether you're accepting new languages to this repository or not, but while I was following the [3RD_PARTY_QUICK_START.md](https://github.com/highlightjs/highlight.js/blob/master/extra/3RD_PARTY_QUICK_START.md) guide with the purpose of adding the syntax highlighting support to [chaos-lang.org](https://chaos-lang.org/), I ended up adding the language to the official repository first. :sweat_smile: 

[Here](https://chaos-lang.org/docs/19_everything) is a live example for the syntax highlighting of Chaos using `hljs`.

It's `disableAutodetect: false` and auto-detection works perfectly well.

The npm package: https://www.npmjs.com/package/highlightjs-chaos