### PR TITLE
(build) browser build is CommonJS and IIFE (global)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,7 @@ script:
       npm run test
     else
       npm run test-browser
+      # our browser build should also work fine as a Node.js CommonJS module
+      node test/builds/browser_build_as_commonjs.js
     fi
 sudo: false  # Use container-based architecture

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ Brower build:
 
 Parser Engine Changes:
 
-- [Issue](https://github.com/highlightjs/highlight.js/issues/2504) (bug) Fix sublanguage with no relevance score (#2506) [Josh Goebel][]
+- ...
 
 
 [Josh Goebel]: https://github.com/yyyc514

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,16 @@
 ## Version 10.0.1
 
+Brower build:
+
+- [Issue](https://github.com/highlightjs/highlight.js/issues/2505) (bug) Fix: Version 10 fails to load as CommonJS module. (#2511) [Josh Goebel][]
+- [Issue](https://github.com/highlightjs/highlight.js/issues/2505) (removal) AMD module loading support has been removed. (#2511) [Josh Goebel][]
+
+
 Parser Engine Changes:
 
-- (bug) Fix sublanguage with no relevance score (#2506) [Josh Goebel][]
+- [Issue](https://github.com/highlightjs/highlight.js/issues/2504) (bug) Fix sublanguage with no relevance score (#2506) [Josh Goebel][]
+
+
 
 [Josh Goebel]: https://github.com/yyyc514
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Language Improvements:
 [Vania Kucher]: https://github.com/qWici
 
 
-## Version 10.0.1
+## Version 10.0.2 (pending)
 
 Brower build:
 
@@ -43,6 +43,14 @@ Parser Engine Changes:
 - [Issue](https://github.com/highlightjs/highlight.js/issues/2504) (bug) Fix sublanguage with no relevance score (#2506) [Josh Goebel][]
 
 
+[Josh Goebel]: https://github.com/yyyc514
+
+
+## Version 10.0.1
+
+Parser Engine Changes:
+
+- (bug) Fix sublanguage with no relevance score (#2506) [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/yyyc514
 

--- a/test/builds/browser_build_as_commonjs.js
+++ b/test/builds/browser_build_as_commonjs.js
@@ -1,0 +1,6 @@
+const hljs = require("../../build/highlight");
+
+let major = parseInt(majorVersion=hljs.versionString.split("."))
+if (major != 10) {
+  process.exit(1)
+}

--- a/tools/build_config.js
+++ b/tools/build_config.js
@@ -30,7 +30,7 @@ module.exports = {
         output: {
           name: "hljs",
           format: "iife",
-          footer: "if (typeof module !== 'undefined') { module.exports = hljs; }",
+          footer: "if (typeof exports === 'object' && typeof module !== 'undefined') { module.exports = hljs; }",
           interop: false,
         }
       },

--- a/tools/build_config.js
+++ b/tools/build_config.js
@@ -29,7 +29,8 @@ module.exports = {
         },
         output: {
           name: "hljs",
-          format: "umd",
+          format: "iife",
+          footer: "if (typeof module !== 'undefined') { module.exports = hljs; }",
           interop: false,
         }
       },


### PR DESCRIPTION
- dropping support for AMD, which we never truly supported
  in the first place

  Resolves #2505. Also think this will close #2291 