### PR TITLE
(swift) @objcMembers not completely highlighted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,12 +32,14 @@ Language Improvements:
 - fix(javascript) `=>` function with nested `()` in params now works (#2502) [Josh Goebel][]
 - fix(typescript) `=>` function with nested `()` in params now works (#2502) [Josh Goebel][]
 - fix(yaml) Fix tags to include non-word characters (#2486) [Peter Plantinga][]
+- fix(swift) `@objcMembers` was being partially highlighted (#2543) [Nick Randall][]
 
 [Josh Goebel]: https://github.com/yyyc514
 [Peter Plantinga]: https://github.com/pplantinga
 [David Benjamin]: https://github.com/davidben
 [Vania Kucher]: https://github.com/qWici
 [Hankun Lin]: https://github.com/Linhk1606
+[Nick Randall]: https://github.com/nicked
 
 
 ## Version 10.0.2

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -125,11 +125,11 @@ export default function(hljs) {
       {
         className: 'meta', // @attributes
         begin: '(@discardableResult|@warn_unused_result|@exported|@lazy|@noescape|' +
-                  '@NSCopying|@NSManaged|@objcMembers|@objc|@convention|@required|' +
+                  '@NSCopying|@NSManaged|@objc|@objcMembers|@convention|@required|' +
                   '@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|' +
                   '@infix|@prefix|@postfix|@autoclosure|@testable|@available|' +
                   '@nonobjc|@NSApplicationMain|@UIApplicationMain|@dynamicMemberLookup|' +
-                  '@propertyWrapper)'
+                  '@propertyWrapper)\\b'
 
       },
       {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -125,7 +125,7 @@ export default function(hljs) {
       {
         className: 'meta', // @attributes
         begin: '(@discardableResult|@warn_unused_result|@exported|@lazy|@noescape|' +
-                  '@NSCopying|@NSManaged|@objc|@objcMembers|@convention|@required|' +
+                  '@NSCopying|@NSManaged|@objcMembers|@objc|@convention|@required|' +
                   '@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|' +
                   '@infix|@prefix|@postfix|@autoclosure|@testable|@available|' +
                   '@nonobjc|@NSApplicationMain|@UIApplicationMain|@dynamicMemberLookup|' +


### PR DESCRIPTION
Would match `@objc` first, and the `Members` part would be unhighlighted