### PR TITLE
enh(dart) Add `late` and `required` keywords, and `Never` built-in type (Dart 2.9)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@ Language Improvements:
 - fix(typescript) `=>` function with nested `()` in params now works (#2502) [Josh Goebel][]
 - fix(yaml) Fix tags to include non-word characters (#2486) [Peter Plantinga][]
 - fix(swift) `@objcMembers` was being partially highlighted (#2543) [Nick Randall][]
-- fix(dart) Add `late` and `required` keywords, and `Never` built-in type (#2550) [Sam Rawlins][]
+- enh(dart) Add `late` and `required` keywords, and `Never` built-in type (#2550) [Sam Rawlins][]
 
 [Josh Goebel]: https://github.com/yyyc514
 [Peter Plantinga]: https://github.com/pplantinga

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Language Improvements:
 - fix(typescript) `=>` function with nested `()` in params now works (#2502) [Josh Goebel][]
 - fix(yaml) Fix tags to include non-word characters (#2486) [Peter Plantinga][]
 - fix(swift) `@objcMembers` was being partially highlighted (#2543) [Nick Randall][]
+- fix(dart) Add `late` and `required` keywords, and `Never` built-in type (#2550) [Sam Rawlins][]
 
 [Josh Goebel]: https://github.com/yyyc514
 [Peter Plantinga]: https://github.com/pplantinga
@@ -40,6 +41,7 @@ Language Improvements:
 [Vania Kucher]: https://github.com/qWici
 [Hankun Lin]: https://github.com/Linhk1606
 [Nick Randall]: https://github.com/nicked
+[Sam Rawlins]: https://github.com/srawlins
 
 
 ## Version 10.0.2

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -75,12 +75,12 @@ export default function(hljs) {
   var KEYWORDS = {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
       'dynamic else enum export extends extension external factory false final finally for Function get hide if ' +
-      'implements import in inferface is library mixin new null on operator part rethrow return set show static ' +
-      'super switch sync this throw true try typedef var void while with yield',
+      'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
+      'show static super switch sync this throw true try typedef var void while with yield',
     built_in:
       // dart:core
-      'Comparable DateTime Duration Function Iterable Iterator List Map Match Null Object Pattern RegExp Set ' +
-      'Stopwatch String StringBuffer StringSink Symbol Type Uri bool double dynamic int num print ' +
+      'Comparable DateTime Duration Function Iterable Iterator List Map Match Never Null Object Pattern RegExp ' +
+      'Set Stopwatch String StringBuffer StringSink Symbol Type Uri bool double dynamic int num print ' +
       // dart:html
       'Element ElementList document querySelector querySelectorAll window'
   };


### PR DESCRIPTION
Addresses some of #2550 

I think there are open questions about supporting `?` on every type, so that will be addressed later.