### PR TITLE
(docs) add Jolie to Supported Languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -92,6 +92,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | JSON                    | json                   |         |
 | Java                    | java, jsp              |         |
 | JavaScript              | javascript, js, jsx    |         |
+| Jolie                   | jolie, iol, ol         | [highlightjs-jolie](https://github.com/xiroV/highlightjs-jolie) |
 | Kotlin                  | kotlin, kt             |         |
 | LaTeX                   | tex                    |         |
 | Leaf                    | leaf                   |         |


### PR DESCRIPTION
Adds syntax highlighting support for the [Jolie language](https://www.jolie-lang.org/).