### PR TITLE
fix(typescript) Add missing read-only keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,7 @@ Language Improvements:
 [Sam Rawlins]: https://github.com/srawlins
 [Sergey Prokhorov]: https://github.com/seriyps
 [Nils Knappmeier]: https://github.com/nknapp
-[Martin]: https://github.com/Lhoerion
+[Martin (Lhoerion)]: https://github.com/Lhoerion
 
 
 ## Version 10.0.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Deprecations:
 
 Language Improvements:
 
+- fix(typescript) add `readonly` keyword (#2562) [Martin (Lhoerion)][]
 - fix(javascript) fix regex inside parens after a non-regex (#2530) [Josh Goebel][]
 - enh(typescript) use identifier to match potential keywords, preventing false positivites (#2519) [Josh Goebel][]
 - enh(javascript) use identifier to match potential keywords, preventing false positivites (#2519) [Josh Goebel][]
@@ -49,6 +50,7 @@ Language Improvements:
 [Sam Rawlins]: https://github.com/srawlins
 [Sergey Prokhorov]: https://github.com/seriyps
 [Nils Knappmeier]: https://github.com/nknapp
+[Martin]: https://github.com/Lhoerion
 
 
 ## Version 10.0.2

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -31,7 +31,8 @@ export default function(hljs) {
     "protected",
     "implements",
     "declare",
-    "abstract"
+    "abstract",
+    "readonly"
   ];
   var KEYWORDS = {
     $pattern: ECMAScript.IDENT_RE,


### PR DESCRIPTION
I've fixed detection of keywords in property name, along with moving the basic types to keywords.