### PR TITLE
(docs) Mention `c` is a possible class for C

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -31,7 +31,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | BNF                     | bnf                    |         |
 | Brainfuck               | brainfuck, bf          |         |
 | C#                      | csharp, cs             |         |
-| C                       | h                      |         |
+| C                       | c, h                   |         |
 | C++                     | cpp, hpp, cc, hh, c++, h++, cxx, hxx |   |
 | C/AL                    | cal                    |         |
 | Cache Object Script     | cos, cls               |         |


### PR DESCRIPTION
This PR is simply a correction to the documentation. Not only is `c` already one of the classes available for C, but it also wouldn't really make sense for `h` to be the only available class for this language.