### PR TITLE
(themes) add `nnfx-dark` theme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 New themes:
 
-- *NNFX* by [Jim Mason][]
+- *NNFX* and *NNFX-dark* by [Jim Mason][]
 - *lioshi* by [lioshi][]
 
 Parser Engine:

--- a/src/styles/nnfx-dark.css
+++ b/src/styles/nnfx-dark.css
@@ -1,0 +1,106 @@
+/**
+ * nnfx dark - a theme inspired by Netscape Navigator/Firefox
+ *
+ * @version 1.0.0
+ * @author (c) 2020 Jim Mason <jmason@ibinx.com>
+ * @license https://creativecommons.org/licenses/by-sa/4.0  CC BY-SA 4.0
+ */
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #333;
+  color: #fff;
+}
+
+.xml .hljs-meta {
+  font-weight: bold;
+  font-style: italic;
+  color: #69f;
+}
+
+.hljs-comment,
+.hljs-quote {
+  font-style: italic;
+  color: #9c6;
+}
+
+.hljs-name,
+.hljs-keyword {
+  color: #a7a;
+}
+
+.hljs-name,
+.hljs-attr {
+  font-weight: bold;
+}
+
+.hljs-string {
+  font-weight: normal;
+}
+
+.hljs-variable,
+.hljs-template-variable {
+  color: #588;
+}
+
+.hljs-code,
+.hljs-string,
+.hljs-meta-string,
+.hljs-number,
+.hljs-regexp,
+.hljs-link {
+  color: #bce;
+}
+
+.hljs-title,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #d40;
+}
+
+.hljs-section,
+.hljs-meta {
+  color: #a85;
+}
+
+.hljs-class .hljs-title,
+.hljs-type {
+  color: #96c;
+}
+
+.hljs-function .hljs-title,
+.hljs-attr,
+.hljs-subst {
+  color: #fff;
+}
+
+.hljs-formula {
+  background-color: #eee;
+  font-style: italic;
+}
+
+.hljs-addition {
+  background-color: #797;
+}
+
+.hljs-deletion {
+  background-color: #c99;
+}
+
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #964;
+}
+
+.hljs-doctag,
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}


### PR DESCRIPTION
nnfx-dark is the dark theme complement to nnfx #2571.

Full style preview is available here:  https://stage.ibinx.com/nnfx_build/demo/

GNOME Web view source styled with nnfx-dark under Adwaita dark:
![Screenshot from 2020-06-01 13-31-17](https://user-images.githubusercontent.com/6860356/83409644-b5824e00-a40c-11ea-9b97-2443ca149a8b.png)

GNOME Web view source styled with nnfx:
![Screenshot from 2020-06-01 14-19-35](https://user-images.githubusercontent.com/6860356/83413134-3cd2c000-a413-11ea-9619-ecbca3c11e04.png)



