### PR TITLE
Rust unsafe keyword also gets `emphasis strong`.

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -12,7 +12,7 @@ export default function(hljs) {
     'abstract as async await become box break const continue crate do dyn ' +
     'else enum extern false final fn for if impl in let loop macro match mod ' +
     'move mut override priv pub ref return self Self static struct super ' +
-    'trait true try type typeof unsafe unsized use virtual where while yield';
+    'trait true try type typeof unsized use virtual where while yield';
   var BUILTINS =
     // functions
     'drop ' +
@@ -38,6 +38,7 @@ export default function(hljs) {
     aliases: ['rs'],
     keywords: {
       $pattern: hljs.IDENT_RE + '!?',
+      "keyword emphasis strong": "unsafe",
       keyword:
         KEYWORDS,
       literal:

--- a/test/markup/rust/unsafe.expect.txt
+++ b/test/markup/rust/unsafe.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-keyword emphasis strong">unsafe</span> <span class="hljs-function"><span class="hljs-keyword">fn</span> <span class="hljs-title">sqr</span></span>(i: <span class="hljs-built_in">i32</span>) { <span class="hljs-keyword emphasis strong">unsafe</span> { i * i } }
+<span class="hljs-keyword emphasis strong">unsafe</span> <span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">Minimum</span></span> : <span class="hljs-built_in">Copy</span> {}

--- a/test/markup/rust/unsafe.txt
+++ b/test/markup/rust/unsafe.txt
@@ -1,0 +1,2 @@
+unsafe fn sqr(i: i32) { unsafe { i * i } }
+unsafe trait Minimum : Copy {}


### PR DESCRIPTION
This differentiates the `unsafe` keyword from others with additional styling.

Closes #2585.