### PR TITLE
(dart) highlight built-in nullable types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@ Language Improvements:
 - fix(typescript) `=>` function with nested `()` in params now works (#2502) [Josh Goebel][]
 - fix(yaml) Fix tags to include non-word characters (#2486) [Peter Plantinga][]
 - fix(swift) `@objcMembers` was being partially highlighted (#2543) [Nick Randall][]
-- enh(dart) Add `late` and `required` keywords, and `Never` built-in type (#2550) [Sam Rawlins][]
+- enh(dart) Add `late` and `required` keywords, the `Never` built-in type, and nullable built-in types (#2550) [Sam Rawlins][]
 - enh(erlang) Add underscore separators to numeric literals (#2554) [Sergey Prokhorov][]
 - enh(handlebars) Support for sub-expressions, path-expressions, hashes, block-parameters and literals (#2344) [Nils Knappmeier][]
 - enh(protobuf) Support multiline comments (#2597) [Pavel Evstigneev][]

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -8,23 +8,23 @@ Category: scripting
 */
 
 export default function(hljs) {
-  var SUBST = {
+  const SUBST = {
     className: 'subst',
     variants: [{
       begin: '\\$[A-Za-z0-9_]+'
     }],
   };
 
-  var BRACED_SUBST = {
+  const BRACED_SUBST = {
     className: 'subst',
     variants: [{
       begin: '\\${',
       end: '}'
-    }, ],
+    }],
     keywords: 'true false null this is new super',
   };
 
-  var STRING = {
+  const STRING = {
     className: 'string',
     variants: [{
         begin: 'r\'\'\'',
@@ -72,7 +72,7 @@ export default function(hljs) {
     hljs.C_NUMBER_MODE, STRING
   ];
 
-  var BUILT_IN_TYPES = [
+  const BUILT_IN_TYPES = [
     // dart:core
     'Comparable',
     'DateTime',
@@ -102,13 +102,13 @@ export default function(hljs) {
     'Element',
     'ElementList',
   ];
-  var NULLABLE_BUILT_IN_TYPES = BUILT_IN_TYPES.map((e) => `${e}?`);
+  const NULLABLE_BUILT_IN_TYPES = BUILT_IN_TYPES.map((e) => `${e}?`);
 
-  var KEYWORDS = {
+  const KEYWORDS = {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
       'dynamic else enum export extends extension external factory false final finally for Function get hide if ' +
       'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
-      'show static super switch sync this throw true try typedef var void while with yield',
+      'show static super switch sync this throw true try typedef const void while with yield',
     built_in:
       BUILT_IN_TYPES
         .concat(NULLABLE_BUILT_IN_TYPES)

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -72,12 +72,36 @@ export default function(hljs) {
     hljs.C_NUMBER_MODE, STRING
   ];
 
-  var BUILT_IN_TYPES =
+  var BUILT_IN_TYPES = [
     // dart:core
-    'Comparable DateTime Duration Function Iterable Iterator List Map Match Object Pattern RegExp Set Stopwatch ' +
-    'String StringBuffer StringSink Symbol Type Uri bool double int num ' +
+    'Comparable',
+    'DateTime',
+    'Duration',
+    'Function',
+    'Iterable',
+    'Iterator',
+    'List',
+    'Map',
+    'Match',
+    'Object',
+    'Pattern',
+    'RegExp',
+    'Set',
+    'Stopwatch',
+    'String',
+    'StringBuffer',
+    'StringSink',
+    'Symbol',
+    'Type',
+    'Uri',
+    'bool',
+    'double',
+    'int',
+    'num',
     // dart:html
-    'Element ElementList';
+    'Element',
+    'ElementList',
+  ];
 
   var KEYWORDS = {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
@@ -85,15 +109,22 @@ export default function(hljs) {
       'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
       'show static super switch sync this throw true try typedef var void while with yield',
     built_in:
-      // non-nullable built-in types
-      BUILT_IN_TYPES + ' ' +
-      // nullable built-in types
-      BUILT_IN_TYPES.split(' ').map((e) => { e + '?' }).join(' ') + ' ' +
-      // dart:core
-      'Never Null dynamic print ' +
-      // dart:html
-      'document querySelector querySelectorAll window',
-    $pattern: /[A-Za-z][A-Za-z0-9_]+\??/
+        // non-nullable built-in types
+        BUILT_IN_TYPES.concat(
+          // nullable built-in types
+          BUILT_IN_TYPES.map((e) => `${e}?`)).concat([
+            // dart:core
+            'Never',
+            'Null',
+            'dynamic',
+            'print',
+            // dart:html
+            'document',
+            'querySelector',
+            'querySelectorAll',
+            'window',
+        ]).join(' '),
+    $pattern: /[A-Za-z][A-Za-z0-9_]*\??/
   };
 
   return {

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -72,17 +72,28 @@ export default function(hljs) {
     hljs.C_NUMBER_MODE, STRING
   ];
 
+  var BUILT_IN_TYPES =
+    // dart:core
+    'Comparable DateTime Duration Function Iterable Iterator List Map Match Object Pattern RegExp Set Stopwatch ' +
+    'String StringBuffer StringSink Symbol Type Uri bool double int num ' +
+    // dart:html
+    'Element ElementList';
+
   var KEYWORDS = {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
       'dynamic else enum export extends extension external factory false final finally for Function get hide if ' +
       'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
       'show static super switch sync this throw true try typedef var void while with yield',
     built_in:
+      // non-nullable built-in types
+      BUILT_IN_TYPES + ' ' +
+      // nullable built-in types
+      BUILT_IN_TYPES.split(' ').map((e) => { e + '?' }).join(' ') + ' ' +
       // dart:core
-      'Comparable DateTime Duration Function Iterable Iterator List Map Match Never Null Object Pattern RegExp ' +
-      'Set Stopwatch String StringBuffer StringSink Symbol Type Uri bool double dynamic int num print ' +
+      'Never Null dynamic print ' +
       // dart:html
-      'Element ElementList document querySelector querySelectorAll window'
+      'document querySelector querySelectorAll window',
+    $pattern: /[A-Za-z][A-Za-z0-9_]+\??/
   };
 
   return {

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -102,6 +102,7 @@ export default function(hljs) {
     'Element',
     'ElementList',
   ];
+  var NULLABLE_BUILT_IN_TYPES = BUILT_IN_TYPES.map((e) => `${e}?`);
 
   var KEYWORDS = {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
@@ -109,21 +110,20 @@ export default function(hljs) {
       'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
       'show static super switch sync this throw true try typedef var void while with yield',
     built_in:
-        // non-nullable built-in types
-        BUILT_IN_TYPES.concat(
-          // nullable built-in types
-          BUILT_IN_TYPES.map((e) => `${e}?`)).concat([
-            // dart:core
-            'Never',
-            'Null',
-            'dynamic',
-            'print',
-            // dart:html
-            'document',
-            'querySelector',
-            'querySelectorAll',
-            'window',
-        ]).join(' '),
+      BUILT_IN_TYPES
+        .concat(NULLABLE_BUILT_IN_TYPES)
+        .concat([
+          // dart:core
+          'Never',
+          'Null',
+          'dynamic',
+          'print',
+          // dart:html
+          'document',
+          'querySelector',
+          'querySelectorAll',
+          'window',
+      ]).join(' '),
     $pattern: /[A-Za-z][A-Za-z0-9_]*\??/
   };
 
@@ -172,5 +172,5 @@ export default function(hljs) {
         begin: '=>' // No markup, just a relevance booster
       }
     ]
-  }
+  };
 }

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -108,7 +108,7 @@ export default function(hljs) {
     keyword: 'abstract as assert async await break case catch class const continue covariant default deferred do ' +
       'dynamic else enum export extends extension external factory false final finally for Function get hide if ' +
       'implements import in inferface is late library mixin new null on operator part required rethrow return set ' +
-      'show static super switch sync this throw true try typedef const void while with yield',
+      'show static super switch sync this throw true try typedef var void while with yield',
     built_in:
       BUILT_IN_TYPES
         .concat(NULLABLE_BUILT_IN_TYPES)


### PR DESCRIPTION
Fixes #2550 

This change separates the "built-ins" into those which can be marked nullable (like `int` and `String`) and those which cannot (like `dynamic` and `window`). Nullable built-in types like `int?` are highlighted as such.