### PR TITLE
(chore) add `.js` extension to import statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,9 +38,6 @@ module.exports = {
       "no-undefined": "error",
       // ensure import specifier contains file extension
       "import/extensions": ["error", "always"],
-      // make sure there is no Node.js specific API slipping into the source files
-      "import/no-nodejs-modules": "error",
-      "import/no-commonjs": "error",
 
       // TODO maybe
       "camelcase": "off", // TODO: turn on later
@@ -50,6 +47,10 @@ module.exports = {
       {
         "files": ["src/languages/*.js"],
         "rules": {
+          // make sure there is no Node.js specific API slipping into the source files
+          "import/no-nodejs-modules": "error",
+          "import/no-commonjs": "error",
+
           "no-unused-expressions": "off",
           // languages are all over the map and we don't want to
           // do a mass edit so turn off the most egregious rule violations

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,12 +45,16 @@ module.exports = {
     },
     "overrides": [
       {
-        "files": ["src/languages/*.js"],
+        "files": ["src/**/*.js"],
         "rules": {
           // make sure there is no Node.js specific API slipping into the source files
           "import/no-nodejs-modules": "error",
           "import/no-commonjs": "error",
-
+        }
+      },
+      {
+        "files": ["src/languages/*.js"],
+        "rules": {
           "no-unused-expressions": "off",
           // languages are all over the map and we don't want to
           // do a mass edit so turn off the most egregious rule violations

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,11 @@ module.exports = {
       "indent": ["error", 2, {"VariableDeclarator":2}],
       // seems like a good idea not to use explicit undefined
       "no-undefined": "error",
+      // ensure import specifier contains file extension
+      "import/extensions": ["error", "always"],
+      // make sure there is no Node.js specific API slipping into the source files
+      "import/no-nodejs-modules": "error",
+      "import/no-commonjs": "error",
 
       // TODO maybe
       "camelcase": "off", // TODO: turn on later

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -3,13 +3,13 @@ Syntax highlighting with language autodetection.
 https://highlightjs.org/
 */
 
-import deepFreeze from './vendor/deep_freeze';
-import Response from './lib/response';
-import TokenTreeEmitter from './lib/token_tree';
-import * as regex from './lib/regex';
-import * as utils from './lib/utils';
-import * as MODES from './lib/modes';
-import { compileLanguage } from './lib/mode_compiler';
+import deepFreeze from './vendor/deep_freeze.js';
+import Response from './lib/response.js';
+import TokenTreeEmitter from './lib/token_tree.js';
+import * as regex from './lib/regex.js';
+import * as utils from './lib/utils.js';
+import * as MODES from './lib/modes.js';
+import { compileLanguage } from './lib/mode_compiler.js';
 import * as packageJSON from '../package.json';
 
 const escape = utils.escapeHTML;

--- a/src/languages/coffeescript.js
+++ b/src/languages/coffeescript.js
@@ -7,7 +7,7 @@ Category: common, scripting
 Website: https://coffeescript.org
 */
 
-import * as ECMAScript from "./lib/ecmascript";
+import * as ECMAScript from './lib/ecmascript.js';
 
 /** @type LanguageFn */
 export default function(hljs) {

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -5,7 +5,7 @@
  Website: https://groovy-lang.org
  */
 
-import * as regex from "../lib/regex";
+import * as regex from '../lib/regex.js';
 
 function variants(variants, obj = {}) {
   obj.variants = variants;

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -7,7 +7,7 @@ Website: https://handlebarsjs.com
 Category: template
 */
 
-import * as regex from '../lib/regex'
+import * as regex from '../lib/regex.js'
 
 export default function(hljs) {
   const BUILT_INS = {

--- a/src/languages/htmlbars.js
+++ b/src/languages/htmlbars.js
@@ -19,7 +19,7 @@ TODO: Remove in version 11.0.
 */
 
 // compile time dependency on handlebars
-import handlebars from "./handlebars"
+import handlebars from "./handlebars.js"
 
 export default function(hljs) {
   const definition = handlebars(hljs)

--- a/src/languages/ini.js
+++ b/src/languages/ini.js
@@ -1,4 +1,4 @@
-import * as regex from '../lib/regex';
+import * as regex from '../lib/regex.js';
 
 /*
 Language: TOML, also INI

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -5,7 +5,7 @@ Category: common, enterprise
 Website: https://www.java.com/
 */
 
-import * as regex from "../lib/regex";
+import * as regex from '../lib/regex.js';
 
 export default function(hljs) {
   var JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -5,8 +5,8 @@ Category: common, scripting
 Website: https://developer.mozilla.org/en-US/docs/Web/JavaScript
 */
 
-import * as ECMAScript from "./lib/ecmascript";
-import * as regex from "../lib/regex";
+import * as ECMAScript from './lib/ecmascript.js';
+import * as regex from '../lib/regex.js';
 
 export default function(hljs) {
   var IDENT_RE = ECMAScript.IDENT_RE;

--- a/src/languages/livescript.js
+++ b/src/languages/livescript.js
@@ -8,7 +8,7 @@ Website: https://livescript.net
 Category: scripting
 */
 
-import * as ECMAScript from "./lib/ecmascript";
+import * as ECMAScript from './lib/ecmascript.js';
 
 export default function(hljs) {
   var LIVESCRIPT_BUILT_INS = [

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -7,7 +7,7 @@ Website: https://www.typescriptlang.org
 Category: common, scripting
 */
 
-import * as ECMAScript from "./lib/ecmascript";
+import * as ECMAScript from './lib/ecmascript.js';
 
 export default function(hljs) {
   var IDENT_RE = ECMAScript.IDENT_RE;

--- a/src/lib/html_renderer.js
+++ b/src/lib/html_renderer.js
@@ -1,4 +1,4 @@
-import { escapeHTML } from './utils';
+import { escapeHTML } from './utils.js';
 
 /**
  * @typedef {object} Renderer

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -1,5 +1,5 @@
-import * as regex from './regex';
-import { inherit } from './utils';
+import * as regex from './regex.js';
+import { inherit } from './utils.js';
 
 // keywords that should have no default relevance value
 var COMMON_KEYWORDS = 'of and for in not or if then'.split(' ');

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -1,5 +1,5 @@
-import { inherit } from './utils';
-import * as regex from './regex';
+import { inherit } from './utils.js';
+import * as regex from './regex.js';
 
 // Common regexps
 export const IDENT_RE = '[a-zA-Z]\\w*';

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -1,4 +1,4 @@
-import HTMLRenderer from './html_renderer';
+import HTMLRenderer from './html_renderer.js';
 
 /** @typedef {{kind?: string, sublanguage?: boolean, children: Node[]} | string} Node */
 /** @typedef {{kind?: string, sublanguage?: boolean, children: Node[]} } DataNode */


### PR DESCRIPTION
Add file extension to all `import` specifiers in `./src/` files.
This is useful to run the files straight from source with a web browser, Node.js ESM or Deno.

Refs: https://github.com/highlightjs/highlight.js/issues/2600#issuecomment-642282239