### PR TITLE
Removed offending comma

### DIFF
--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -42,7 +42,7 @@ export default function(hljs) {
           regex.either(
             regex.concat(SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'), /\./, SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9')),
             regex.concat(SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'), /\.?/),
-            regex.concat(/\./, SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9')),
+            regex.concat(/\./, SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'))
           ),
           /([pP][+-]?(\d+))?/,
           /[fFdDlL]?/ // decimal & fp mixed for simplicity


### PR DESCRIPTION
This causes a syntax error on node 6 and earlier:

```
edwin@Lisbon:~/ht/loctool/test$ node -v
v6.17.1
edwin@Lisbon:~/ht/loctool/test$ node
> var hl = require("highlight.js");
/data/root/home/edwin/ht/loctool/node_modules/highlight.js/lib/languages/java.js:89
          ),
          ^

SyntaxError: Unexpected token )
```

Without the comma:

```
edwin@Lisbon:~/ht/loctool/test$ node -v
v6.17.1
edwin@Lisbon:~/ht/loctool/test$ node
> var hl = require("highlight.js");
>
```
Much better! That comma is a trailing comma after the last parameter to the function call. Node 6 and earlier do not like it. Node 7 and beyond just ignores it.