### PR TITLE
fix(js) Implement Numeric Separator proposal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Language Improvements:
 - fix(scala) Comments inside class header should be highlighted (#1559) [Josh Goebel][]
 - fix(c-like) Correctly highlight modifiers (`final`) in class declaration (#2696) [Josh Goebel][]
 - enh(angelscript) Improve heredocs, numbers, metadata blocks (#2724) [Melissa Geels][]
+- enh(js) Implement Numeric Separator proposal (#2617) [Antoine du Hamel][]
 
 [David Pine]: https://github.com/IEvangelist
 [Josh Goebel]: https://github.com/joshgoebel
@@ -21,6 +22,7 @@ Language Improvements:
 [Philipp Engel]: https://github.com/interkosmos
 [Konrad Rudolph]: https://github.com/klmr
 [Melissa Geels]: https://github.com/codecat
+[Antoine du Hamel]: https://github.com/aduh95
 
 
 ## Version 10.2.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,8 @@ Language Improvements:
 - fix(scala) Comments inside class header should be highlighted (#1559) [Josh Goebel][]
 - fix(c-like) Correctly highlight modifiers (`final`) in class declaration (#2696) [Josh Goebel][]
 - enh(angelscript) Improve heredocs, numbers, metadata blocks (#2724) [Melissa Geels][]
-- enh(js) Implement Numeric Separator proposal (#2617) [Antoine du Hamel][]
+- enh(javascript) Implement Numeric Separators (#2617) [Antoine du Hamel][]
+- enh(typescript) TypeScript also gains support for numeric separators (#2617) [Antoine du Hamel][]
 
 [David Pine]: https://github.com/IEvangelist
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -75,7 +75,7 @@ export default function(hljs) {
       { begin: nonDecimalLiterals('oO', '0-7') }, // Octal literals
       { begin: nonDecimalLiterals('xX', '0-9a-fA-F') }, // Hexadecimal literals
       { begin: regex.concat(/\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
-      { begin: regex.concat(/\b0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
+      { begin: regex.concat(/(\b0)?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
       { begin: regex.concat(
         /\b/,
         noLeadingZeroDecimalDigits,

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -64,7 +64,7 @@ export default function(hljs) {
     built_in: ECMAScript.BUILT_INS.join(" ")
   };
   const nonDecimalLiterals = (prefixLetters, validChars) => 
-    `(-?)\\b0[${prefixLetters}][${validChars}]([${validChars}_]*[${validChars}])?n?`;
+    `\\b0[${prefixLetters}][${validChars}]([${validChars}_]*[${validChars}])?n?`;
   const noLeadingZeroDecimalDigits = /[1-9]([0-9_]*\d)?/;
   const decimalDigits = /\d([0-9_]*\d)?/;
   const exponentPart = regex.concat(/[eE][+-]?/, decimalDigits);
@@ -74,15 +74,15 @@ export default function(hljs) {
       { begin: nonDecimalLiterals('bB', '01') }, // Binary literals
       { begin: nonDecimalLiterals('oO', '0-7') }, // Octal literals
       { begin: nonDecimalLiterals('xX', '0-9a-fA-F') }, // Hexadecimal literals
-      { begin: regex.concat(/(-?)\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
-      { begin: regex.concat(/(-?)0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
+      { begin: regex.concat(/\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
+      { begin: regex.concat(/0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
       { begin: regex.concat(
-        /(-?)\b/,
+        /\b/,
         noLeadingZeroDecimalDigits,
         regex.optional(regex.concat(/\./, regex.optional(decimalDigits))), // fractional part
         regex.optional(exponentPart)
         ) }, // Decimal literals >= 1
-      { begin: /(-?)\b0[\.n]?/ }, // Zero literals (`0`, `0.`, `0n`, `-0`, ...)
+      { begin: /\b0[\.n]?/ }, // Zero literals (`0`, `0.`, `0n`)
     ],
     relevance: 0
   };

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -63,12 +63,26 @@ export default function(hljs) {
     literal: ECMAScript.LITERALS.join(" "),
     built_in: ECMAScript.BUILT_INS.join(" ")
   };
+  const nonDecimalLiterals = (prefixLetters, validChars) => 
+    `(-?)\\b0[${prefixLetters}][${validChars}]([${validChars}_]*[${validChars}])?n?`;
+  const noLeadingZeroDecimalDigits = /[1-9]([0-9_]*\d)?/;
+  const decimalDigits = /\d([0-9_]*\d)?/;
+  const exponentPart = regex.concat(/[eE][+-]?/, decimalDigits);
   const NUMBER = {
     className: 'number',
     variants: [
-      { begin: '\\b(0[bB][01]+)n?' },
-      { begin: '\\b(0[oO][0-7]+)n?' },
-      { begin: hljs.C_NUMBER_RE + 'n?' }
+      { begin: nonDecimalLiterals('bB', '01') }, // Binary literals
+      { begin: nonDecimalLiterals('oO', '0-7') }, // Octal literals
+      { begin: nonDecimalLiterals('xX', '0-9a-fA-F') }, // Hexadecimal literals
+      { begin: regex.concat(/(-?)\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
+      { begin: regex.concat(/(-?)0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
+      { begin: regex.concat(
+        /(-?)\b/,
+        noLeadingZeroDecimalDigits,
+        regex.optional(regex.concat(/\./, regex.optional(decimalDigits))), // fractional part
+        regex.optional(exponentPart)
+        ) }, // Decimal literals >= 1
+      { begin: /(-?)\b0[\.n]?/ }, // Zero literals (`0`, `0.`, `0n`, `-0`, ...)
     ],
     relevance: 0
   };

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -75,7 +75,7 @@ export default function(hljs) {
       { begin: nonDecimalLiterals('oO', '0-7') }, // Octal literals
       { begin: nonDecimalLiterals('xX', '0-9a-fA-F') }, // Hexadecimal literals
       { begin: regex.concat(/\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
-      { begin: regex.concat(/0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
+      { begin: regex.concat(/\b0?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
       { begin: regex.concat(
         /\b/,
         noLeadingZeroDecimalDigits,

--- a/test/markup/javascript/keywords.expect.txt
+++ b/test/markup/javascript/keywords.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">$initHighlight</span>(<span class="hljs-params">block, cls</span>) </span>{
   <span class="hljs-keyword">try</span> {
-    <span class="hljs-keyword">if</span> (cls.search(<span class="hljs-regexp">/\bno\-highlight\b/</span>) != <span class="hljs-number">-1</span>)
+    <span class="hljs-keyword">if</span> (cls.search(<span class="hljs-regexp">/\bno\-highlight\b/</span>) != -<span class="hljs-number">1</span>)
       <span class="hljs-keyword">return</span> process(block, <span class="hljs-literal">true</span>, <span class="hljs-number">0x0F</span>) +
              <span class="hljs-string">&#x27; class=&quot;&quot;&#x27;</span>;
   } <span class="hljs-keyword">catch</span> (e) {

--- a/test/markup/javascript/numbers.expect.txt
+++ b/test/markup/javascript/numbers.expect.txt
@@ -19,7 +19,7 @@
 <span class="hljs-number">0.000001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">0.000_001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
-<span class="hljs-number">-.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+-<span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">1e10_000</span>  <span class="hljs-comment">// 10^10000 -- granted, far less useful / in-range...</span>
 
 <span class="hljs-keyword">let</span> nibbles = <span class="hljs-number">0b1010_0001_1000_0101</span>;
@@ -47,4 +47,4 @@
 <span class="hljs-number">2_00n</span>
 <span class="hljs-number">2_0_0n</span>
 <span class="hljs-number">20_0n</span>
-<span class="hljs-number">-20_0n</span>
+-<span class="hljs-number">20_0n</span>

--- a/test/markup/javascript/numbers.expect.txt
+++ b/test/markup/javascript/numbers.expect.txt
@@ -1,0 +1,50 @@
+<span class="hljs-number">1000000000</span>   <span class="hljs-comment">// Is this a billion? a hundred millions? Ten millions?</span>
+<span class="hljs-number">101475938.38</span> <span class="hljs-comment">// what scale is this? what power of 10?</span>
+
+<span class="hljs-keyword">const</span> FEE = <span class="hljs-number">12300</span>;
+<span class="hljs-comment">// is this 12,300? Or 123, because it&#x27;s in cents?</span>
+
+<span class="hljs-keyword">const</span> AMOUNT = <span class="hljs-number">1234500</span>;
+<span class="hljs-comment">// is this 1,234,500? Or cents, hence 12,345? Or financial, 4-fixed 123.45?</span>
+
+<span class="hljs-number">1_000_000_000</span>           <span class="hljs-comment">// Ah, so a billion</span>
+<span class="hljs-number">101_475_938.38</span>          <span class="hljs-comment">// And this is hundreds of millions</span>
+
+<span class="hljs-keyword">let</span> fee = <span class="hljs-number">123_00</span>;       <span class="hljs-comment">// $123 (12300 cents, apparently)</span>
+<span class="hljs-keyword">let</span> fee = <span class="hljs-number">12_300</span>;       <span class="hljs-comment">// $12,300 (woah, that fee!)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">12345_00</span>;  <span class="hljs-comment">// 12,345 (1234500 cents, apparently)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">123_4500</span>;  <span class="hljs-comment">// 123.45 (4-fixed financial)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">1_234_500</span>; <span class="hljs-comment">// 1,234,500</span>
+
+<span class="hljs-number">0.000001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">0.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">-.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">1e10_000</span>  <span class="hljs-comment">// 10^10000 -- granted, far less useful / in-range...</span>
+
+<span class="hljs-keyword">let</span> nibbles = <span class="hljs-number">0b1010_0001_1000_0101</span>;
+<span class="hljs-keyword">let</span> message = <span class="hljs-number">0xA0_B0_C0</span>;
+
+<span class="hljs-keyword">let</span> x1 = _52;              <span class="hljs-comment">// This is an identifier, not a numeric literal</span>
+<span class="hljs-keyword">let</span> x2 = <span class="hljs-number">5_2</span>;              <span class="hljs-comment">// OK (decimal literal)</span>
+
+<span class="hljs-keyword">let</span> x7 = <span class="hljs-number">0x5_2</span>;            <span class="hljs-comment">// OK (hexadecimal literal)</span>
+<span class="hljs-number">0xff</span>
+<span class="hljs-number">0xdead_beef</span>
+
+<span class="hljs-number">0o52</span>
+<span class="hljs-number">0O52</span>
+
+<span class="hljs-number">0xa</span>
+<span class="hljs-number">0Xa</span>
+<span class="hljs-number">0XA</span>
+<span class="hljs-number">0xA</span>
+
+<span class="hljs-number">0n</span>
+<span class="hljs-number">2n</span>
+<span class="hljs-number">20n</span>
+<span class="hljs-number">2_0n</span>
+<span class="hljs-number">2_00n</span>
+<span class="hljs-number">2_0_0n</span>
+<span class="hljs-number">20_0n</span>
+<span class="hljs-number">-20_0n</span>

--- a/test/markup/javascript/numbers.txt
+++ b/test/markup/javascript/numbers.txt
@@ -1,0 +1,50 @@
+1000000000   // Is this a billion? a hundred millions? Ten millions?
+101475938.38 // what scale is this? what power of 10?
+
+const FEE = 12300;
+// is this 12,300? Or 123, because it's in cents?
+
+const AMOUNT = 1234500;
+// is this 1,234,500? Or cents, hence 12,345? Or financial, 4-fixed 123.45?
+
+1_000_000_000           // Ah, so a billion
+101_475_938.38          // And this is hundreds of millions
+
+let fee = 123_00;       // $123 (12300 cents, apparently)
+let fee = 12_300;       // $12,300 (woah, that fee!)
+let amount = 12345_00;  // 12,345 (1234500 cents, apparently)
+let amount = 123_4500;  // 123.45 (4-fixed financial)
+let amount = 1_234_500; // 1,234,500
+
+0.000001 // 1 millionth
+0.000_001 // 1 millionth
+.000_001 // 1 millionth
+-.000_001 // 1 millionth
+1e10_000  // 10^10000 -- granted, far less useful / in-range...
+
+let nibbles = 0b1010_0001_1000_0101;
+let message = 0xA0_B0_C0;
+
+let x1 = _52;              // This is an identifier, not a numeric literal
+let x2 = 5_2;              // OK (decimal literal)
+
+let x7 = 0x5_2;            // OK (hexadecimal literal)
+0xff
+0xdead_beef
+
+0o52
+0O52
+
+0xa
+0Xa
+0XA
+0xA
+
+0n
+2n
+20n
+2_0n
+2_00n
+2_0_0n
+20_0n
+-20_0n

--- a/test/markup/typescript/numbers-and-dashes.expect.txt
+++ b/test/markup/typescript/numbers-and-dashes.expect.txt
@@ -1,8 +1,9 @@
-<span class="hljs-keyword">let</span> num = <span class="hljs-number">-3</span>
-<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> - <span class="hljs-number">3</span>
-<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>-<span class="hljs-number">3</span>
+<span class="hljs-keyword">let</span> num = -<span class="hljs-number">3</span>;
+
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> - <span class="hljs-number">3</span>;
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>-<span class="hljs-number">3</span>;
 
 <span class="hljs-comment">// Who writes JS like that??</span>
-<span class="hljs-keyword">let</span> num = - <span class="hljs-number">3</span>
-<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>- <span class="hljs-number">3</span>
-<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> -<span class="hljs-number">3</span>
+<span class="hljs-keyword">let</span> num = - <span class="hljs-number">3</span>;
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> -<span class="hljs-number">3</span>;
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>- <span class="hljs-number">3</span>;

--- a/test/markup/typescript/numbers-and-dashes.expect.txt
+++ b/test/markup/typescript/numbers-and-dashes.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-keyword">let</span> num = <span class="hljs-number">-3</span>
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> - <span class="hljs-number">3</span>
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>-<span class="hljs-number">3</span>
+
+<span class="hljs-comment">// Who writes JS like that??</span>
+<span class="hljs-keyword">let</span> num = - <span class="hljs-number">3</span>
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span>- <span class="hljs-number">3</span>
+<span class="hljs-keyword">let</span> diff = <span class="hljs-number">5</span> -<span class="hljs-number">3</span>

--- a/test/markup/typescript/numbers-and-dashes.txt
+++ b/test/markup/typescript/numbers-and-dashes.txt
@@ -1,0 +1,9 @@
+let num = -3;
+
+let diff = 5 - 3;
+let diff = 5-3;
+
+// Who writes JS like that??
+let num = - 3;
+let diff = 5 -3;
+let diff = 5- 3;

--- a/test/markup/typescript/numbers.expect.txt
+++ b/test/markup/typescript/numbers.expect.txt
@@ -19,7 +19,7 @@
 <span class="hljs-number">0.000001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">0.000_001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
-<span class="hljs-number">-.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+-<span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">1e10_000</span>  <span class="hljs-comment">// 10^10000 -- granted, far less useful / in-range...</span>
 
 <span class="hljs-keyword">let</span> nibbles = <span class="hljs-number">0b1010_0001_1000_0101</span>;
@@ -47,4 +47,4 @@
 <span class="hljs-number">2_00n</span>
 <span class="hljs-number">2_0_0n</span>
 <span class="hljs-number">20_0n</span>
-<span class="hljs-number">-20_0n</span>
+-<span class="hljs-number">20_0n</span>

--- a/test/markup/typescript/numbers.expect.txt
+++ b/test/markup/typescript/numbers.expect.txt
@@ -1,0 +1,50 @@
+<span class="hljs-number">1000000000</span>   <span class="hljs-comment">// Is this a billion? a hundred millions? Ten millions?</span>
+<span class="hljs-number">101475938.38</span> <span class="hljs-comment">// what scale is this? what power of 10?</span>
+
+<span class="hljs-keyword">const</span> FEE = <span class="hljs-number">12300</span>;
+<span class="hljs-comment">// is this 12,300? Or 123, because it&#x27;s in cents?</span>
+
+<span class="hljs-keyword">const</span> AMOUNT = <span class="hljs-number">1234500</span>;
+<span class="hljs-comment">// is this 1,234,500? Or cents, hence 12,345? Or financial, 4-fixed 123.45?</span>
+
+<span class="hljs-number">1_000_000_000</span>           <span class="hljs-comment">// Ah, so a billion</span>
+<span class="hljs-number">101_475_938.38</span>          <span class="hljs-comment">// And this is hundreds of millions</span>
+
+<span class="hljs-keyword">let</span> fee = <span class="hljs-number">123_00</span>;       <span class="hljs-comment">// $123 (12300 cents, apparently)</span>
+<span class="hljs-keyword">let</span> fee = <span class="hljs-number">12_300</span>;       <span class="hljs-comment">// $12,300 (woah, that fee!)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">12345_00</span>;  <span class="hljs-comment">// 12,345 (1234500 cents, apparently)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">123_4500</span>;  <span class="hljs-comment">// 123.45 (4-fixed financial)</span>
+<span class="hljs-keyword">let</span> amount = <span class="hljs-number">1_234_500</span>; <span class="hljs-comment">// 1,234,500</span>
+
+<span class="hljs-number">0.000001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">0.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">-.000_001</span> <span class="hljs-comment">// 1 millionth</span>
+<span class="hljs-number">1e10_000</span>  <span class="hljs-comment">// 10^10000 -- granted, far less useful / in-range...</span>
+
+<span class="hljs-keyword">let</span> nibbles = <span class="hljs-number">0b1010_0001_1000_0101</span>;
+<span class="hljs-keyword">let</span> message = <span class="hljs-number">0xA0_B0_C0</span>;
+
+<span class="hljs-keyword">let</span> x1 = _52;              <span class="hljs-comment">// This is an identifier, not a numeric literal</span>
+<span class="hljs-keyword">let</span> x2 = <span class="hljs-number">5_2</span>;              <span class="hljs-comment">// OK (decimal literal)</span>
+
+<span class="hljs-keyword">let</span> x7 = <span class="hljs-number">0x5_2</span>;            <span class="hljs-comment">// OK (hexadecimal literal)</span>
+<span class="hljs-number">0xff</span>
+<span class="hljs-number">0xdead_beef</span>
+
+<span class="hljs-number">0o52</span>
+<span class="hljs-number">0O52</span>
+
+<span class="hljs-number">0xa</span>
+<span class="hljs-number">0Xa</span>
+<span class="hljs-number">0XA</span>
+<span class="hljs-number">0xA</span>
+
+<span class="hljs-number">0n</span>
+<span class="hljs-number">2n</span>
+<span class="hljs-number">20n</span>
+<span class="hljs-number">2_0n</span>
+<span class="hljs-number">2_00n</span>
+<span class="hljs-number">2_0_0n</span>
+<span class="hljs-number">20_0n</span>
+<span class="hljs-number">-20_0n</span>

--- a/test/markup/typescript/numbers.txt
+++ b/test/markup/typescript/numbers.txt
@@ -1,0 +1,50 @@
+1000000000   // Is this a billion? a hundred millions? Ten millions?
+101475938.38 // what scale is this? what power of 10?
+
+const FEE = 12300;
+// is this 12,300? Or 123, because it's in cents?
+
+const AMOUNT = 1234500;
+// is this 1,234,500? Or cents, hence 12,345? Or financial, 4-fixed 123.45?
+
+1_000_000_000           // Ah, so a billion
+101_475_938.38          // And this is hundreds of millions
+
+let fee = 123_00;       // $123 (12300 cents, apparently)
+let fee = 12_300;       // $12,300 (woah, that fee!)
+let amount = 12345_00;  // 12,345 (1234500 cents, apparently)
+let amount = 123_4500;  // 123.45 (4-fixed financial)
+let amount = 1_234_500; // 1,234,500
+
+0.000001 // 1 millionth
+0.000_001 // 1 millionth
+.000_001 // 1 millionth
+-.000_001 // 1 millionth
+1e10_000  // 10^10000 -- granted, far less useful / in-range...
+
+let nibbles = 0b1010_0001_1000_0101;
+let message = 0xA0_B0_C0;
+
+let x1 = _52;              // This is an identifier, not a numeric literal
+let x2 = 5_2;              // OK (decimal literal)
+
+let x7 = 0x5_2;            // OK (hexadecimal literal)
+0xff
+0xdead_beef
+
+0o52
+0O52
+
+0xa
+0Xa
+0XA
+0xA
+
+0n
+2n
+20n
+2_0n
+2_00n
+2_0_0n
+20_0n
+-20_0n


### PR DESCRIPTION
This PR implements the Numeric Separator proposal, currently stage 3 of TC39 process, and supported by all major browsers.

Limitations:
- the proposal doesn't allow multiple adjacent separator. Because it makes the regex overcomplicated, I've ignored it.
- Number literals with leading zero (which represents either decimal or octal literal) are not supported by this PR. Worth noting they are illegal in strict mode (incl. ES modules), so I believe it makes sense to not highlight them.

Refs: https://github.com/tc39/proposal-numeric-separator
Refs: https://tc39.es/ecma262/#sec-literals-numeric-literals