### PR TITLE
enh(matlab) add "arguments" keyword and fix "enumeration"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ New themes:
 
 [Samia Ali]: https://github.com/samiaab1990
 
+Fixes:
+
+- (matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619)[Andrew Janke][]
+
+[Andrew Janke]: https://github.com/apjanke
+
 ## Version 10.1.1
 
 Fixes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@ New themes:
 
 - *Gradient Light* by [Samia Ali]()
 
-Fixes:
+Language Improvements:
 
-- (matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619)[Andrew Janke][]
+- enh(matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619) [Andrew Janke][]
 
 [Andrew Janke]: https://github.com/apjanke
 [Samia Ali]: https://github.com/samiaab1990

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,13 @@ New themes:
 
 - *Gradient Light* by [Samia Ali]()
 
-[Samia Ali]: https://github.com/samiaab1990
-
 Fixes:
 
 - (matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619)[Andrew Janke][]
 
 [Andrew Janke]: https://github.com/apjanke
+[Samia Ali]: https://github.com/samiaab1990
+
 
 ## Version 10.1.1
 

--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -24,7 +24,7 @@ export default function(hljs) {
     name: 'Matlab',
     keywords: {
       keyword:
-        'break case catch classdef continue else elseif end enumerated events for function ' +
+        'arguments break case catch classdef continue else elseif end enumeration events for function ' +
         'global if methods otherwise parfor persistent properties return spmd switch try while',
       built_in:
         'sin sind sinh asin asind asinh cos cosd cosh acos acosd acosh tan tand tanh atan ' +


### PR DESCRIPTION
In R2019b, Matlab introduced a new "arguments" block syntax. This adds a keyword for it.

Also, the correct keyword is "enumeration", not "enumerated". This commit fixes it.