### PR TITLE
(octave) Add Octave language

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -288,3 +288,4 @@ Contributors:
 - Alexandre Grison <a.grison@gmail.com>
 - Jim Mason <jmason@ibinx.com>
 - lioshi <lioshi@lioshi.com>
+- Andrew Janke <floss@apjanke.net>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ New themes:
 
 [Samia Ali]: https://github.com/samiaab1990
 
+New languages:
+
+- *Octave* as a variant of Matlab by [Andrew Janke]()
+
+[Andrew Janke]: https://github.com/apjanke
+
 ## Version 10.1.1
 
 Fixes:

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -125,6 +125,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Nix                     | nix                    |         |
 | Object Constraint Language | ocl                 | [highlightjs-ocl](https://github.com/nhomble/highlightjs-ocl)        |
 | OCaml                   | ocaml, ml              |         |
+| Octave                  | octave                 |         |
 | Objective C             | objectivec, mm, objc, obj-c |    |
 | OpenGL Shading Language | glsl                   |         |
 | OpenSCAD                | openscad, scad         |         |

--- a/src/languages/octave.js
+++ b/src/languages/octave.js
@@ -1,0 +1,110 @@
+/*
+Language: Octave
+Author: Andrew Janke <floss@apjanke.net>
+Origin: matlab.js
+Description: A FLOSS clone of Matlab
+Website: https://octave.org
+Category: scientific
+*/
+
+/*
+  Formal syntax is not incomplete, but published at:
+  https://octave.org/doc/v5.1.0/Grammar-and-Parser.html
+*/
+export default function(hljs) {
+
+  var TRANSPOSE_RE = '(\'|\\.\')+';
+  var TRANSPOSE = {
+    relevance: 0,
+    contains: [
+      { begin: TRANSPOSE_RE }
+    ]
+  };
+
+  return {
+    name: 'Octave',
+    keywords: {
+      keyword:
+        '__FILE__ __LINE__ arguments break case catch classdef continue do else elseif end ' +
+        'end_try_catch end_unwind_protect endclassdef endenumeration endevents endfor endfunction ' +
+        'endif endmethods endparfor endproperties endswitch endwhile ' +
+        'enumeration events for function global if methods otherwise parfor persistent properties ' +
+        'return switch try until unwind_protect unwind_protect_cleanup while',
+      built_in:
+        'sin sind sinh asin asind asinh cos cosd cosh acos acosd acosh tan tand tanh atan ' +
+        'atand atan2 atanh sec secd sech asec asecd asech csc cscd csch acsc acscd acsch cot ' +
+        'cotd coth acot acotd acoth hypot exp expm1 log log1p log10 log2 pow2 realpow reallog ' +
+        'realsqrt sqrt nthroot nextpow2 abs angle complex conj imag real unwrap isreal ' +
+        'cplxpair fix floor ceil round mod rem sign airy besselj bessely besselh besseli ' +
+        'besselk beta betainc betaln ellipj ellipke erf erfc erfcx erfinv expint gamma ' +
+        'gammainc gammaln psi legendre cross dot factor isprime primes gcd lcm rat rats perms ' +
+        'nchoosek factorial cart2sph cart2pol pol2cart sph2cart hsv2rgb rgb2hsv zeros ones ' +
+        'eye repmat rand randn linspace logspace freqspace meshgrid accumarray size length ' +
+        'ndims numel disp isempty isequal isequalwithequalnans cat reshape diag blkdiag tril ' +
+        'triu fliplr flipud flipdim rot90 find sub2ind ind2sub bsxfun ndgrid permute ipermute ' +
+        'shiftdim circshift squeeze isscalar isvector ans eps realmax realmin pi i inf nan ' +
+        'isnan isinf isfinite j why compan gallery hadamard hankel hilb invhilb magic pascal ' +
+        'rosser toeplitz vander wilkinson max min nanmax nanmin mean nanmean type table ' +
+        'readtable writetable sortrows sort figure plot plot3 scatter scatter3 cellfun ' +
+        'legend intersect ismember procrustes hold num2cell '
+    },
+    illegal: '(//|/\\*|\\s+/\\w+)',
+    contains: [
+      {
+        className: 'function',
+        beginKeywords: 'function', end: '$',
+        contains: [
+          hljs.UNDERSCORE_TITLE_MODE,
+          {
+            className: 'params',
+            variants: [
+              {begin: '\\(', end: '\\)'},
+              {begin: '\\[', end: '\\]'}
+            ]
+          }
+        ]
+      },
+      {
+        className: 'built_in',
+        begin: /true|false/,
+        relevance: 0,
+        starts: TRANSPOSE
+      },
+      {
+        begin: '[a-zA-Z][a-zA-Z_0-9]*' + TRANSPOSE_RE,
+        relevance: 0
+      },
+      {
+        className: 'number',
+        begin: hljs.C_NUMBER_RE,
+        relevance: 0,
+        starts: TRANSPOSE
+      },
+      {
+        className: 'string',
+        begin: '\'', end: '\'',
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          {begin: '\'\''}]
+      },
+      {
+        begin: /\]|}|\)/,
+        relevance: 0,
+        starts: TRANSPOSE
+      },
+      {
+        className: 'string',
+        begin: '"', end: '"',
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          {begin: '""'}
+        ],
+        starts: TRANSPOSE
+      },
+      hljs.COMMENT('^\\s*\\%\\{\\s*$', '^\\s*\\%\\}\\s*$'),
+      hljs.COMMENT('^\\s*\\#\\{\\s*$', '^\\s*\\#\\}\\s*$'),
+      hljs.COMMENT('\\%', '$'),
+      hljs.COMMENT('\\#', '$')
+    ]
+  };
+}

--- a/test/detect/octave/default.txt
+++ b/test/detect/octave/default.txt
@@ -1,0 +1,47 @@
+n = 20; % number of points
+points = [random('unid', 100, n, 1), random('unid', 100, n, 1)];
+len = zeros(1, n - 1); # length of array
+points = sortrows(points);
+a_string = 'foo';
+another_string = "foobar";
+%% Initial set of points
+plot(points(:,1),points(:,2));
+for i = 1: n-1
+    len(i) = points(i + 1, 1) - points(i, 1);
+endfor
+while(max(len) > 2 * min(len))
+    [d, i] = max(len);
+    k = on_margin(points, i, d, -1);
+    m = on_margin(points, i + 1, d, 1);
+    xm = 0; ym = 0;
+%% New point
+    if(i == 1 || i + 1 == n)
+        xm = mean(points([i,i+1],1))
+        ym = mean(points([i,i+1],2))
+    else
+        [xm, ym] = dlg1(points([k, i, i + 1, m], 1), ...
+            points([k, i, i + 1, m], 2))
+    endif
+
+    points = [ points(1:i, :); [xm, ym]; points(i + 1:end, :)];
+endwhile
+
+%{
+    This is a block comment. Please ignore me.
+%}
+
+function [net] = get_fit_network(inputs, targets)
+    % Create Network
+    numHiddenNeurons = 20;  % Adjust as desired
+    net = newfit(inputs,targets,numHiddenNeurons);
+    net.trainParam.goal = 0.01;
+    net.trainParam.epochs = 1000;
+    % Train and Apply Network
+    [net,tr] = train(net,inputs,targets);
+endfunction
+
+foo_matrix = [1, 2, 3; 4, 5, 6]''';
+foo_cell = {1, 2, 3; 4, 5, 6}''.'.';
+
+cell2flatten = {1,2,3,4,5};
+flattenedcell = cat(1, cell2flatten{:});


### PR DESCRIPTION
Would you accept a separate Octave language definition? Octave is a clone of Matlab, but is syntactically different enough that I think it deserves its own entry. In particular:

* Octave has several additional keywords not present in Matlab
* Its string literal semantics are somewhat different
* It allows "#" comments

Alternately, I could do this as a 3rd party definition – https://github.com/highlightjs/highlight.js/issues/2621 – in which case, just close this PR without merging.