### PR TITLE
(kotlin) remove very old keywords and update example code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@ New themes:
 Language Improvements:
 
 - enh(matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619) [Andrew Janke][]
+- fix(kotlin) Remove very old keywords and update example code (#2623) [kageru][]
 
 [Andrew Janke]: https://github.com/apjanke
 [Samia Ali]: https://github.com/samiaab1990
+[kageru]: https://github.com/kageru
 
 
 ## Version 10.1.1

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -14,9 +14,7 @@ export default function(hljs) {
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
       'import package is in fun override companion reified inline lateinit init ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
-      'tailrec where const inner suspend typealias external expect actual ' +
-      // to be deleted soon
-      'trait volatile transient native default',
+      'tailrec where const inner suspend typealias external expect actual'
     built_in:
       'Byte Short Char Int Long Boolean Float Double Void Unit Nothing',
     literal:

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -14,7 +14,7 @@ export default function(hljs) {
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
       'import package is in fun override companion reified inline lateinit init ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
-      'tailrec where const inner suspend typealias external expect actual'
+      'tailrec where const inner suspend typealias external expect actual',
     built_in:
       'Byte Short Char Int Long Boolean Float Double Void Unit Nothing',
     literal:

--- a/test/detect/kotlin/default.txt
+++ b/test/detect/kotlin/default.txt
@@ -1,12 +1,12 @@
 import kotlin.lang.test
 
-trait A {
+interface A {
     fun x()
 }
 
-fun xxx() : Int {
-	return 888
+fun xxx(): Int {
+    return 888
 }
 
-public fun main(args : Array<String>) {
+public fun main(args: Array<String>) {
 }


### PR DESCRIPTION
These aren’t valid Kotlin keywords and just cause issues with autodetection
because Scala, which is syntactically quite similar to kotlin, actually has a `trait` keyword.
It even says `// to be deleted soon`, whenever soon is, so I decided to do it now.

Also replace `trait` in the example
(which would no longer be highlighted)
and format the code according to the Kotlin coding conventions.