### PR TITLE
use null prototype objects for languages/aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,12 @@ Language Improvements:
 
 - enh(matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619) [Andrew Janke][]
 - fix(kotlin) Remove very old keywords and update example code (#2623) [kageru][]
+- fix(night) Prevent object prototypes method values from being returned in `getLanguage` (#2636) [night][]
 
 [Andrew Janke]: https://github.com/apjanke
 [Samia Ali]: https://github.com/samiaab1990
 [kageru]: https://github.com/kageru
+[night]: https://github.com/night
 
 
 ## Version 10.1.1

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -29,9 +29,9 @@ const HLJS = function(hljs) {
 
   // Global internal variables used within the highlight.js library.
   /** @type {Record<string, Language>} */
-  var languages = {};
+  var languages = Object.create(null);
   /** @type {Record<string, string>} */
-  var aliases = {};
+  var aliases = Object.create(null);
   /** @type {HLJSPlugin[]} */
   var plugins = [];
 

--- a/test/api/getLanguage.js
+++ b/test/api/getLanguage.js
@@ -41,4 +41,34 @@ describe('.getLanguage()', () => {
     result.should.have.property('aliases').with.containEql('cs');
     should.strictEqual(result, hljs.getLanguage('csharp'))
   });
+
+  it('should not succeed for hasOwnProperty', () => {
+    const result = hljs.getLanguage('hasOwnProperty');
+
+    should.strictEqual(result, undefined);
+  });
+
+  it('should not succeed for toString', () => {
+    const result = hljs.getLanguage('toString');
+
+    should.strictEqual(result, undefined);
+  });
+
+  it('should not succeed for valueOf', () => {
+    const result = hljs.getLanguage('valueOf');
+
+    should.strictEqual(result, undefined);
+  });
+
+  it('should not succeed for constructor', () => {
+    const result = hljs.getLanguage('constructor');
+
+    should.strictEqual(result, undefined);
+  });
+
+  it('should not succeed for __proto__', () => {
+    const result = hljs.getLanguage('__proto__');
+
+    should.strictEqual(result, undefined);
+  });
 });

--- a/test/api/getLanguage.js
+++ b/test/api/getLanguage.js
@@ -42,24 +42,6 @@ describe('.getLanguage()', () => {
     should.strictEqual(result, hljs.getLanguage('csharp'))
   });
 
-  it('should not succeed for hasOwnProperty', () => {
-    const result = hljs.getLanguage('hasOwnProperty');
-
-    should.strictEqual(result, undefined);
-  });
-
-  it('should not succeed for toString', () => {
-    const result = hljs.getLanguage('toString');
-
-    should.strictEqual(result, undefined);
-  });
-
-  it('should not succeed for valueOf', () => {
-    const result = hljs.getLanguage('valueOf');
-
-    should.strictEqual(result, undefined);
-  });
-
   it('should not succeed for constructor', () => {
     const result = hljs.getLanguage('constructor');
 


### PR DESCRIPTION
`getLanguage` currently returns values for object prototype method names. By swapping to objects with a null prototype, we can fix this weird behavior.