### PR TITLE
Update SUPPORTED_LANGUAGES.md to add arduino

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -12,6 +12,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | ABNF                    | abnf                   |         |
 | Access logs             | accesslog              |         |
 | Ada                     | ada                    |         |
+| Arduino (C++ w/Arduino libs) | arduino           |         |
 | ARM assembler           | armasm, arm            |         |
 | AVR assembler           | avrasm                 |         |
 | ActionScript            | actionscript, as       |         |


### PR DESCRIPTION
I just tested the `<pre><code class="arduino">` on a whim, and it works, so clearly it must be implemented.