### PR TITLE
class definitions could start with keyword enum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,13 @@ Language Improvements:
 - enh(matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619) [Andrew Janke][]
 - fix(kotlin) Remove very old keywords and update example code (#2623) [kageru][]
 - fix(night) Prevent object prototypes method values from being returned in `getLanguage` (#2636) [night][]
+- enh(java) Add support for `enum`, which will identify as a `class` now (#2643) [ezksd][]
 
 [Andrew Janke]: https://github.com/apjanke
 [Samia Ali]: https://github.com/samiaab1990
 [kageru]: https://github.com/kageru
 [night]: https://github.com/night
+[ezksd]: https://github.com/ezksd
 
 
 ## Version 10.1.1

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -98,8 +98,8 @@ export default function(hljs) {
       hljs.QUOTE_STRING_MODE,
       {
         className: 'class',
-        beginKeywords: 'class interface', end: /[{;=]/, excludeEnd: true,
-        keywords: 'class interface',
+        beginKeywords: 'class interface enum', end: /[{;=]/, excludeEnd: true,
+        keywords: 'class interface enum',
         illegal: /[:"\[\]]/,
         contains: [
           { beginKeywords: 'extends implements' },


### PR DESCRIPTION
Enum is a special type in java, which doesn't like enum in other programming languages. It's not a primitive type, enum has the same construct of class.  We also consider it a syntax sugar to define a special class. And enum definition located at subchapter of classes in [java language specification](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.9) too. 
```java
enum Coin {
    PENNY(1), NICKEL(5), DIME(10), QUARTER(25);
    Coin(int value) { this.value = value; }

    private final int value;
    public int value() { return value; }
}
```


