### PR TITLE
Remove console warnings

### DIFF
--- a/tools/build_config.js
+++ b/tools/build_config.js
@@ -43,7 +43,6 @@ module.exports = {
         },
         output: {
           format: "iife",
-          outro: "return module.exports.definer || module.exports;",
           interop: false,
         }
       }


### PR DESCRIPTION
The deleted outro adds to every language after the return statement, which generates the:
`Warning: unreachable code after return statement (Firefox)`
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return