### PR TITLE
fix(bash) Less false positives for keywords in arguments ie, `--keyword-flag`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Big picture:
 
 Language Improvements:
 
+- fix(bash) Fewer false positives for keywords in arguments (#2669) [sirosen][]
 - fix(js) Prevent long series of /////// from causing freezes (#2656) [Josh Goebel][]
 - enh(csharp) Add `init` and `record` keywords for C# 9.0 (#2660) [Youssef Victor][]
 - enh(matlab) Add new R2019b `arguments` keyword and fix `enumeration` keyword (#2619) [Andrew Janke][]
@@ -36,6 +37,7 @@ Language Improvements:
 [ezksd]: https://github.com/ezksd
 [idleberg]: https://github.com/idleberg
 [eytienne]: https://github.com/eytienne
+[sirosen]: https://github.com/sirosen
 
 
 ## Version 10.1.1

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -83,7 +83,7 @@ export default function(hljs) {
     name: 'Bash',
     aliases: ['sh', 'zsh'],
     keywords: {
-      $pattern: /\b-?[a-z\._]+\b/,
+      $pattern: /\b-?[a-z\._-]+\b/,
       keyword:
         'if then else elif fi for while in do done case esac function',
       literal:

--- a/test/markup/bash/token-containing-keyword.expect.txt
+++ b/test/markup/bash/token-containing-keyword.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-comment"># a keyword as part of an option</span>
+mycmd --disable-foo
+
+<span class="hljs-comment"># a keyword as part of a parameter</span>
+some-cmd set-some-setting
+some-cmd set_some_setting
+
+<span class="hljs-comment"># a keyword as part of command</span>
+check-case foo
+check_case foo

--- a/test/markup/bash/token-containing-keyword.txt
+++ b/test/markup/bash/token-containing-keyword.txt
@@ -1,0 +1,10 @@
+# a keyword as part of an option
+mycmd --disable-foo
+
+# a keyword as part of a parameter
+some-cmd set-some-setting
+some-cmd set_some_setting
+
+# a keyword as part of command
+check-case foo
+check_case foo


### PR DESCRIPTION
In bash, option, param, and command names may contain builtins as hyphen-delimited components. As in `foo --set-bar`.

In order to handle this, just add `-` to the pattern's set of word characters. Includes a new test for bash tokens containing keywords, which checks hyphens and underscores for a few common cases.

Against current `master`, the new test fails, which helps to confirm the fix.

resolves #2668

----

Aside: I really have to compliment you guys on the structure of the testsuite. Even with my very limited knowledge in this domain, adding a new failing test case and verifying it was a breeze. Thanks to everyone who works on this project!