### PR TITLE
docs: Fix simple typo, higlighted -> highlighted

### DIFF
--- a/src/languages/autohotkey.js
+++ b/src/languages/autohotkey.js
@@ -40,7 +40,7 @@ export default function(hljs) {
         //I don't really know if this is totally relevant
       },
       {
-        className: 'title', //symbol would be most accurate however is higlighted just like built_in and that makes up a lot of AutoHotkey code
+        className: 'title', //symbol would be most accurate however is highlighted just like built_in and that makes up a lot of AutoHotkey code
 		                        //meaning that it would fail to highlight anything
         variants: [
           {begin: '^[^\\n";]+::(?!=)'},

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -205,7 +205,7 @@ export default function(hljs) {
           PARAMS
         ]
       },
-      { // prevent references like module.id from being higlighted as module definitions
+      { // prevent references like module.id from being highlighted as module definitions
         begin: /module\./,
         keywords: { built_in: 'module' },
         relevance: 0


### PR DESCRIPTION
There is a small typo in src/languages/autohotkey.js, src/languages/typescript.js.

Should read `highlighted` rather than `higlighted`.

