### PR TITLE
fix(tooling) developer.html does not render highlighted language properly

### DIFF
--- a/tools/developer.html
+++ b/tools/developer.html
@@ -70,7 +70,7 @@
     </div>
     <div>
       <h3>Rendered in <span class="rendering_time">...</span> ms [<span class="rendering_stats">...</span>]</h3>
-      <highlightjs auto :code="code" />
+      <highlightjs :language="language" :code="code" />
     </div>
     <div>
       <h3>Markup</h3>
@@ -99,6 +99,7 @@
         var result = hljs.getLanguage(language) ? hljs.highlight(language, source, true) : hljs.highlightAuto(source);
         var rendering_time = +new Date() - start_time;
         vue.code = source;
+        vue.language = hljs.getLanguage(language) ? language : '';
 
         var rendering_stats = result.language + ': relevance ' + (result.relevance );
         if (result.second_best) {
@@ -144,15 +145,25 @@
     Vue.use(hljs.vuePlugin);
     let vue = new Vue({
       el: '#app',
-      data: { code: "" },
-      watch: { code: function(){
-        // update data-klass post-render for cool class previews
-        this.$nextTick(() => {
-          $(".hljs span").each((_,el) => {
-            $(el).attr("data-klass", el.className.replace("hljs-",""))
+      data: { code: "", language: "" },
+      watch: {
+        code: function(){
+          // update data-klass post-render for cool class previews
+          this.$nextTick(() => {
+            $(".hljs span").each((_,el) => {
+              $(el).attr("data-klass", el.className.replace("hljs-",""))
+            })
           })
-        })
-      }}
+        },
+        language: function(){
+          // update data-klass post-render for cool class previews
+          this.$nextTick(() => {
+            $(".hljs span").each((_,el) => {
+              $(el).attr("data-klass", el.className.replace("hljs-",""))
+            })
+          })
+        }
+      }
     })
   </script>
 </body>

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -146,22 +146,22 @@
     let vue = new Vue({
       el: '#app',
       data: { code: "", language: "" },
+      methods: {
+        refreshKlass: function() {
+          // update data-klass post-render for cool class previews
+          this.$nextTick(() => {
+            $(".hljs span").each((_,el) => {
+              $(el).attr("data-klass", el.className.replace("hljs-",""))
+            })
+          })
+        }
+      },
       watch: {
         code: function(){
-          // update data-klass post-render for cool class previews
-          this.$nextTick(() => {
-            $(".hljs span").each((_,el) => {
-              $(el).attr("data-klass", el.className.replace("hljs-",""))
-            })
-          })
+          this.refreshKlass();
         },
         language: function(){
-          // update data-klass post-render for cool class previews
-          this.$nextTick(() => {
-            $(".hljs span").each((_,el) => {
-              $(el).attr("data-klass", el.className.replace("hljs-",""))
-            })
-          })
+          this.refreshKlass();
         }
       }
     })


### PR DESCRIPTION
Our `developer.html` tool correctly shows markup using specified language, but always displays rendering in autodetection mode.
To reproduce, enter e. g.
```
for i in *.sh; do echo $i; done
```
and choose Language: bash. The code is (erroneously) rendered for `nginx`, while markup is (correctly) for `bash`.

I'm not familiar with vue and somehow managed to fix the issue although in a disgusting way. There should be a better solution for sure.