### PR TITLE
fix(parser) complete fix for resuming matches from same index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3283,9 +3283,9 @@
       }
     },
     "should-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
-      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
     "sigmund": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "mocha --globals document test",
     "test-markup": "mocha --globals document test/markup",
     "test-detect": "mocha --globals document test/detect",
-    "test-browser": "mocha --globals document test/browser"
+    "test-browser": "mocha --globals document test/browser",
+    "test-parser": "mocha --globals document test/parser"
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "mocha test",
     "test-markup": "mocha test/markup",
     "test-detect": "mocha test/detect",
-    "test-browser": "mocha test/browser"
+    "test-browser": "mocha test/browser",
     "test-parser": "mocha test/parser"
   },
   "engines": {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -498,20 +498,13 @@ const HLJS = function(hljs) {
           // considered for a potential match
           resumeScanAtSamePosition = false;
         } else {
-          top.matcher.lastIndex = index;
           top.matcher.considerAll();
         }
+        top.matcher.lastIndex = index;
 
         const match = top.matcher.exec(codeToHighlight);
         // console.log("match", match[0], match.rule && match.rule.begin)
 
-        // if our failure to match was the result of a "resumed scan" then we
-        // need to advance one position and revert to full scanning before we
-        // decide there are truly no more matches at all to be had
-        if (!match && top.matcher.resumingScanAtSamePosition()) {
-          advanceOne();
-          continue;
-        }
         if (!match) break;
 
         const beforeMatch = codeToHighlight.substring(index, match.index);

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -199,8 +199,10 @@ export function compileLanguage(language) {
         m2.lastIndex = this.lastIndex + 1;
         result2 = m2.exec(s);
 
-        if ((!result && result2)
-          || (result && result2 && result2.index < result.index)) {
+        // the only resumed match we care about is at position +0
+        if (result && result.index === this.lastIndex) {
+          // result wins
+        } else { // use the second matcher result
           result = result2;
         }
       }

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -199,14 +199,17 @@ export function compileLanguage(language) {
         m2.lastIndex = this.lastIndex + 1;
         result2 = m2.exec(s);
       }
-      if (result && result2 && result2.index < result.index) {
+      if ((!result && result2)
+        || (result && result2 && result2.index < result.index)) {
         result = result2;
+        this.considerAll();
       }
 
       if (result) {
         this.regexIndex += result.position + 1;
-        if (this.regexIndex === this.count) { // wrap-around
-          this.regexIndex = 0;
+        if (this.regexIndex === this.count) {
+          // wrap-around to considering all matches again
+          this.considerAll();
         }
       }
 

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -202,7 +202,6 @@ export function compileLanguage(language) {
         if ((!result && result2)
           || (result && result2 && result2.index < result.index)) {
           result = result2;
-          this.considerAll();
         }
       }
 

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -161,7 +161,6 @@ export function compileLanguage(language) {
       const m = this.getMatcher(this.regexIndex);
       m.lastIndex = this.lastIndex;
       let result = m.exec(s);
-      let result2 = null;
 
       // The following is because we have no easy way to say "resume scanning at the
       // existing position but also skip the current rule ONLY". What happens is
@@ -195,15 +194,13 @@ export function compileLanguage(language) {
       // 3. Match at index + 1 for [string, "booger", number]
       // 4. If #2 and #3 result in matches, which came first?
       if (this.resumingScanAtSamePosition()) {
-        const m2 = this.getMatcher(0);
-        m2.lastIndex = this.lastIndex + 1;
-        result2 = m2.exec(s);
-
-        // the only resumed match we care about is at position +0
         if (result && result.index === this.lastIndex) {
-          // result wins
+          // result is position +0 and therefore a valid
+          // "resume" match so result stays result
         } else { // use the second matcher result
-          result = result2;
+          const m2 = this.getMatcher(0);
+          m2.lastIndex = this.lastIndex + 1;
+          result = m2.exec(s);
         }
       }
 

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -143,7 +143,7 @@ export function compileLanguage(language) {
     }
 
     resumingScanAtSamePosition() {
-      return this.regexIndex != 0;
+      return this.regexIndex !== 0;
     }
 
     considerAll() {
@@ -198,11 +198,12 @@ export function compileLanguage(language) {
         const m2 = this.getMatcher(0);
         m2.lastIndex = this.lastIndex + 1;
         result2 = m2.exec(s);
-      }
-      if ((!result && result2)
-        || (result && result2 && result2.index < result.index)) {
-        result = result2;
-        this.considerAll();
+
+        if ((!result && result2)
+          || (result && result2 && result2.index < result.index)) {
+          result = result2;
+          this.considerAll();
+        }
       }
 
       if (result) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const hljs     = require('../build');
+const hljs = require('../build');
 hljs.debugMode(); // tests run in debug mode so errors are raised
 
 // Tests specific to the API exposed inside the hljs object.
@@ -8,7 +8,7 @@ hljs.debugMode(); // tests run in debug mode so errors are raised
 require('./api');
 
 // Test weird bugs we've fixed over time
-require("./parser")
+require("./parser");
 
 // Tests for auto detection of languages via `highlightAuto`.
 require('./detect');
@@ -26,4 +26,3 @@ require('./markup');
 // isn't actually used to test inside a browser but `jsdom` acts as a virtual
 // browser inside of node.js and runs together with all the other tests.
 require('./special');
-

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const should = require('should');
+
 describe('hljs', function() {
   require('./look-ahead-end-matchers');
   require('./resume-scan');

--- a/test/parser/resume-scan.js
+++ b/test/parser/resume-scan.js
@@ -1,13 +1,26 @@
+'use strict';
+
 const hljs = require('../../build');
+hljs.debugMode(); // tests run in debug mode so errors are raised
 
-describe("bugs", function () {
-
+describe("bugs", function() {
   describe("resume scan when a match is ignored", () => {
     it("should continue to highlight later matches", () => {
-      hljs.highlight('java', 'ImmutablePair.of(Stuff.class, "bar")').value
-        .should.equal(
-          'ImmutablePair.of(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>)'
-      )
-    })
-  })
-})
+      const result = hljs.highlight('java', 'ImmutablePair.of(Stuff.class, "bar")');
+      result.value.should.equal(
+        'ImmutablePair.of(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>)'
+      );
+    });
+    // previously the match rule was resumed but it would scan ahead too far and ignore
+    // later matches that matched the PRIOR rules... this is because when we "skip" (ignore) a
+    // rule we really only want to skip searching for THAT rule at that same location, we
+    // do not want to stop searching for ALL the prior rules at that location...
+    it("BUT should not skip ahead too far", () => {
+      const result = hljs.highlight('java', 'ImmutablePair.of(Stuff.class, "bar");\n23');
+      result.value.should.equal(
+        'ImmutablePair.of(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>);\n' +
+        '<span class="hljs-number">23</span>'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Resolves #2649.

Both our prior definitions of resuming were "off the mark"... resuming properly actually means you have to briefly must have _two parallel lines of regex search_.

1. You have to resume the prior multi-match at the SAME [index] position ("resume" meaning only matching expressions that haven't been tried yet). It's possible one of those remaining expressions could still match at `index`. 
2. You also have to begin a full multi-match at the next [index+1] position.  This is to allow ALL the potential regex expressions a chance to match starting at `index+1`... 
3. Then you "merge" the results... meaning whichever matched first (smaller index) is the next actual match.

The prior solution ignored the need for number 2 above... so we resumed matching but ONLY looking for the remaining expressions (however far in the future) so we would miss a lot of other quite valid expressions.

Or another way to think of this might be a "rotating match".

Normally our regex matching is looking for say [A,B or C]:

```
match [A,B,C] at offset 0
```

But after we match B and decide to ignore it we really want to rotate the matches:
 [C,A,B(but not the same B)]. So we do this:

```ts
// we don't need to worry about A or B at 0, we already ruled them out
resume match [C] at offset +0
full match [A,B,C] at offset +1
```

Technically that last C is doing a little extra work potentially (in some cases it might match the exact same thing the first matcher does), but it shouldn't be too bad, as this is already an edge case.

---

An actual Java real-life case:

```java
ImmutablePair.of(Stuff.class, "bar");
23
```

For simplicity our rules in Java are: `[string, "class" (begin keyword), number]`.  Class having the magic "not proceeded by "." internal rule (which means the "class" match here will be ignored)... At that point technically we still need to "complete" the existing matcher and see if it might still match `number`... but if we do alone (without considering the full ruleset) then we end up skipping the string `"bar"` and only highlighting 23 (the first number we find)...

