### PR TITLE
enh(csharp) Add all v9 keywords, and other missing keywords

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -288,3 +288,4 @@ Contributors:
 - Alexandre Grison <a.grison@gmail.com>
 - Jim Mason <jmason@ibinx.com>
 - lioshi <lioshi@lioshi.com>
+- David Pine <david.pine.7@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Version 10.2.1
+## Version 10.2.1 (next up)
 
 Language Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Version 10.2.1 (next up)
+## Version 10.3.0 (next up)
 
 Language Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 10.2.1
+
+Language Improvements:
+
+- Add all C# 9 keywords, and other missing keywords (#2679) [David Pine][]
+
+[David Pine]: https://github.com/IEvangelist
+
 ## Version 10.2.0
 
 Parser Engine:
@@ -1397,7 +1405,7 @@ New languages:
 - *Protocol Buffers* by [Dan Tao][]
 - *Nix* by [Domen Kožar][]
 - *x86asm* by [innocenat][]
-- *Cap’n Proto* and *Thrift* by [Oleg Efimov][]
+- *Cap'n Proto* and *Thrift* by [Oleg Efimov][]
 - *Monkey* by [Arthur Bikmullin][]
 - *TypeScript* by [Panu Horsmalahti][]
 - *Nimrod* by [Flaviu Tamas][]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highlight.js",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "syntax"
   ],
   "homepage": "https://highlightjs.org/",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "author": {
     "name": "Ivan Sagalaev",
     "email": "maniac@softwaremaniacs.org"

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -1,27 +1,139 @@
 /*
 Language: C#
 Author: Jason Diamond <jason@diamond.name>
-Contributor: Nicolas LLOBERA <nllobera@gmail.com>, Pieter Vantorre <pietervantorre@gmail.com>
+Contributor: Nicolas LLOBERA <nllobera@gmail.com>, Pieter Vantorre <pietervantorre@gmail.com>, David Pine <david.pine@microsoft.com>
 Website: https://docs.microsoft.com/en-us/dotnet/csharp/
 Category: common
 */
 
 /** @type LanguageFn */
 export default function(hljs) {
+  var BUILT_IN_KEYWORDS = [
+      'bool',
+      'byte',
+      'char',
+      'decimal',
+      'delegate',
+      'double',
+      'dynamic',
+      'enum',
+      'float',
+      'int',
+      'long',
+      'nint',
+      'nuint',
+      'object',
+      'sbyte',
+      'short',
+      'string',
+      'ulong',
+      'unit',
+      'ushort'
+  ];
+  var LITERAL_KEYWORDS = [
+      'default',
+      'false',
+      'null',
+      'true'
+  ];
+  var NORMAL_KEYWORDS = [
+    'abstract',
+    'as',
+    'base',
+    'break',
+    'case',
+    'class',
+    'const',
+    'continue',
+    'do',
+    'else',
+    'event',
+    'explicit',
+    'extern',
+    'finally',
+    'fixed',
+    'for',
+    'foreach',
+    'goto',
+    'if',
+    'implicit',
+    'in',
+    'interface',
+    'internal',
+    'is',
+    'lock',
+    'namespace',
+    'new',
+    'operator',
+    'out',
+    'override',
+    'params',
+    'private',
+    'protected',
+    'public',
+    'readonly',
+    'record',
+    'ref',
+    'return',
+    'sealed',
+    'sizeof',
+    'stackalloc',
+    'static',
+    'struct',
+    'switch',
+    'this',
+    'throw',
+    'try',
+    'typeof',
+    'unchecked',
+    'unsafe',
+    'using',
+    'virtual',
+    'void',
+    'volatile',
+    'while'
+  ];
+  var CONTEXTUAL_KEYWORDS = [
+    'add',
+    'alias',
+    'and',
+    'ascending',
+    'async',
+    'await',
+    'by',
+    'descending',
+    'equals',
+    'from',
+    'get',
+    'global',
+    'group',
+    'init',
+    'into',
+    'join',
+    'let',
+    'nameof',
+    'not',
+    'notnull',
+    'on',
+    'or',
+    'orderby',
+    'partial',
+    'remove',
+    'select',
+    'set',
+    'unmanaged',
+    'value',
+    'var',
+    'when',
+    'where',
+    'with',
+    'yield'
+  ];
+
   var KEYWORDS = {
-    keyword:
-      // Normal keywords.
-      'abstract as base bool break byte case catch char checked const continue decimal ' +
-      'default delegate do double enum event explicit extern finally fixed float ' +
-      'for foreach goto if implicit in init int interface internal is lock long ' +
-      'object operator out override params private protected public readonly ref sbyte ' +
-      'sealed short sizeof stackalloc static string struct switch this try typeof ' +
-      'uint ulong unchecked unsafe ushort using virtual void volatile while ' +
-      // Contextual keywords.
-      'add alias ascending async await by descending dynamic equals from get global group into join ' +
-      'let nameof on orderby partial remove select set value var when where yield',
-    literal:
-      'null false true'
+    keyword: NORMAL_KEYWORDS.concat(CONTEXTUAL_KEYWORDS).join(' '),
+    built_in: BUILT_IN_KEYWORDS.join(' '),
+    literal: LITERAL_KEYWORDS.join(' ')
   };
   var TITLE_MODE = hljs.inherit(hljs.TITLE_MODE, {begin: '[a-zA-Z](\\.?\\w)*'});
   var NUMBERS = {

--- a/test/markup/csharp/floats.expect.txt
+++ b/test/markup/csharp/floats.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-keyword">float</span> test = <span class="hljs-number">1.0f</span>;
-<span class="hljs-keyword">float</span> test2 = <span class="hljs-number">1.f</span>;
-<span class="hljs-keyword">float</span> test3 = <span class="hljs-number">1.0</span>;
-<span class="hljs-keyword">float</span> test4 = <span class="hljs-number">1</span>;
+<span class="hljs-built_in">float</span> test = <span class="hljs-number">1.0f</span>;
+<span class="hljs-built_in">float</span> test2 = <span class="hljs-number">1.f</span>;
+<span class="hljs-built_in">float</span> test3 = <span class="hljs-number">1.0</span>;
+<span class="hljs-built_in">float</span> test4 = <span class="hljs-number">1</span>;

--- a/test/markup/csharp/functions.expect.txt
+++ b/test/markup/csharp/functions.expect.txt
@@ -10,7 +10,7 @@
 <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">ExampleFunctionDeclaration2</span>(<span class="hljs-params"></span>)</span>
 ;
 
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction1</span>(<span class="hljs-params"></span>)</span> =&gt; <span class="hljs-string">&quot;dummy&quot;</span>;
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-built_in">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction1</span>(<span class="hljs-params"></span>)</span> =&gt; <span class="hljs-string">&quot;dummy&quot;</span>;
 
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction2</span>(<span class="hljs-params"></span>)</span>
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-built_in">string</span> <span class="hljs-title">ExampleExpressionBodiedFunction2</span>(<span class="hljs-params"></span>)</span>
     =&gt; <span class="hljs-string">&quot;dummy&quot;</span>;

--- a/test/markup/csharp/generic_modifiers.expect.txt
+++ b/test/markup/csharp/generic_modifiers.expect.txt
@@ -4,9 +4,9 @@
 <span class="hljs-keyword">interface</span> <span class="hljs-title">IObservable</span>&lt;<span class="hljs-keyword">out</span> <span class="hljs-title">T</span>&gt;;
 {}
 
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">delegate</span> <span class="hljs-keyword">void</span> <span class="hljs-title">DContravariant</span>&lt;<span class="hljs-keyword">in</span> <span class="hljs-title">A</span>&gt;(<span class="hljs-params">A argument</span>)</span>;
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-built_in">delegate</span> <span class="hljs-keyword">void</span> <span class="hljs-title">DContravariant</span>&lt;<span class="hljs-keyword">in</span> <span class="hljs-title">A</span>&gt;(<span class="hljs-params">A argument</span>)</span>;
 
-<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">delegate</span> A <span class="hljs-title">DCovariant</span>&lt;<span class="hljs-keyword">out</span> <span class="hljs-title">A</span>&gt;(<span class="hljs-params"></span>)</span>;
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-built_in">delegate</span> A <span class="hljs-title">DCovariant</span>&lt;<span class="hljs-keyword">out</span> <span class="hljs-title">A</span>&gt;(<span class="hljs-params"></span>)</span>;
 
 <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">MethodWithGenericParameter</span>&lt;<span class="hljs-title">T</span>&gt;(<span class="hljs-params"></span>)
 </span>

--- a/test/markup/csharp/records.expect.txt
+++ b/test/markup/csharp/records.expect.txt
@@ -1,4 +1,6 @@
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">record</span> <span class="hljs-title">MyRecord</span>
 {
-    <span class="hljs-keyword">public</span> <span class="hljs-keyword">string</span> SomeMember { <span class="hljs-keyword">get</span>; <span class="hljs-keyword">set</span>; }
+    <span class="hljs-keyword">public</span> <span class="hljs-built_in">string</span> SomeMember { <span class="hljs-keyword">get</span>; <span class="hljs-keyword">init</span>; }
 }
+
+<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-keyword">record</span> <span class="hljs-title">Person</span>(<span class="hljs-params"><span class="hljs-built_in">string</span> FirstName, <span class="hljs-built_in">string</span>? MiddleName, <span class="hljs-built_in">string</span> LastName</span>)</span>;

--- a/test/markup/csharp/records.txt
+++ b/test/markup/csharp/records.txt
@@ -1,4 +1,6 @@
 public record MyRecord
 {
-    public string SomeMember { get; set; }
+    public string SomeMember { get; init; }
 }
+
+public record Person(string FirstName, string? MiddleName, string LastName);

--- a/test/markup/csharp/titles.expect.txt
+++ b/test/markup/csharp/titles.expect.txt
@@ -2,12 +2,12 @@
 {
     <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : <span class="hljs-title">Base</span>, <span class="hljs-title">Other</span>, <span class="hljs-title">IInterface.test.path</span> <span class="hljs-comment">// class</span>
     {
-        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> who</span>) <span class="hljs-comment">// function</span></span>
+        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span>(<span class="hljs-params"><span class="hljs-built_in">string</span> who</span>) <span class="hljs-comment">// function</span></span>
         {
             Who = who;
         }
 
-        <span class="hljs-function"><span class="hljs-keyword">int</span>[] <span class="hljs-title">f</span>(<span class="hljs-params"><span class="hljs-keyword">int</span> val = <span class="hljs-number">0</span></span>)</span>
+        <span class="hljs-function"><span class="hljs-built_in">int</span>[] <span class="hljs-title">f</span>(<span class="hljs-params"><span class="hljs-built_in">int</span> val = <span class="hljs-number">0</span></span>)</span>
         {
             <span class="hljs-keyword">new</span> Type();
             <span class="hljs-keyword">return</span> getType();


### PR DESCRIPTION
Hi 👋🏼 highlight.js friends!

I'd like to introduce several new C# keywords. These are being added as part of C# 9.

- Added C# 9 keywords
  - `init`
  - `record`
  - `and`
  - `not`
  - `or`
  - `nint`
  - `nunit`
  - `with`
- Added other missing keywords (i.e.; `default` as literal, etc.)
- Improved organization
- Added `built_in` keywords

See our official docs: https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-9