### PR TITLE
enh(javascript) allow leading `#` for private class fields (stop treating as illegal)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Language Improvements:
 
+- enh(javascript) allow `#` for private class fields (#2701) [Chris Krycho][]
 - fix(bash) enh(bash) allow nested params (#2731) [Josh Goebel][]
 - fix(python) Fix highlighting of keywords and strings (#2713, #2715) [Konrad Rudolph][]
 - fix(fsharp) Prevent `(*)` from being detected as a multi-line comment [Josh Goebel][]
@@ -25,6 +26,7 @@ Deprecations:
 
 - `useBR` option deprecated and will be removed in v11.0. (#2559) [Josh Goebel][]
 
+[Chris Krycho]: https://github.com/chriskrycho
 [David Pine]: https://github.com/IEvangelist
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Jonasson]: https://github.com/ryanjonasson

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -63,7 +63,7 @@ export default function(hljs) {
     literal: ECMAScript.LITERALS.join(" "),
     built_in: ECMAScript.BUILT_INS.join(" ")
   };
-  const nonDecimalLiterals = (prefixLetters, validChars) => 
+  const nonDecimalLiterals = (prefixLetters, validChars) =>
     `\\b0[${prefixLetters}][${validChars}]([${validChars}_]*[${validChars}])?n?`;
   const noLeadingZeroDecimalDigits = /[1-9]([0-9_]*\d)?/;
   const decimalDigits = /\d([0-9_]*\d)?/;
@@ -204,7 +204,7 @@ export default function(hljs) {
     keywords: KEYWORDS,
     // this will be extended by TypeScript
     exports: { PARAMS_CONTAINS },
-    illegal: /#(?!!)/,
+    illegal: /#(?![$_A-z])/,
     contains: [
       hljs.SHEBANG({
         label: "shebang",


### PR DESCRIPTION
As of an upcoming release of ECMAScript (almost certainly 2021), private class fields may be defined with this syntax:

```js
class Demo {
  #neato;
}
```

Accordingly, treating *all* non-shebang `#` as illegal markers for JavaScript is no longer viable. Instead, support `$`, `_`, and `[A-z]` as well as `!` as legal identifiers here.

Note that this will still fail in cases where Unicode characters are used as the first character of a private class field name.

Fixes #2700