### PR TITLE
fix(fsharp) Prevent `(*)` from being detected as a multi-line comment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Language Improvements:
 
+- fix(fsharp) Prevent `(*)` from being detected as a multi-line comment [Josh Goebel][]
 - enh(r) major overhaul of the R language grammar (and fix a few bugs) (#2680) [Konrad Rudolph][]
 - enh(csharp) Add all C# 9 keywords, and other missing keywords (#2679) [David Pine][]
 - enh(objectivec) Add `objective-c++` and `obj-c++` aliases for Objective-C [Josh Goebel][]

--- a/src/languages/fsharp.js
+++ b/src/languages/fsharp.js
@@ -39,7 +39,9 @@ export default function(hljs) {
         className: 'string',
         begin: '"""', end: '"""'
       },
-      hljs.COMMENT('\\(\\*(\\s)', '\\*\\)'),
+      hljs.COMMENT('\\(\\*(\\s)', '\\*\\)',{
+        contains: [ "self" ]
+      }),
       {
         className: 'class',
         beginKeywords: 'type', end: '\\(|=|$', excludeEnd: true,

--- a/src/languages/fsharp.js
+++ b/src/languages/fsharp.js
@@ -39,7 +39,7 @@ export default function(hljs) {
         className: 'string',
         begin: '"""', end: '"""'
       },
-      hljs.COMMENT('\\(\\*', '\\*\\)'),
+      hljs.COMMENT('\\(\\*(\\s)', '\\*\\)'),
       {
         className: 'class',
         beginKeywords: 'type', end: '\\(|=|$', excludeEnd: true,

--- a/test/markup/fsharp/comments.expect.txt
+++ b/test/markup/fsharp/comments.expect.txt
@@ -1,0 +1,14 @@
+<span class="hljs-comment">(* here is a multi-line comment on one line *)</span>
+
+<span class="hljs-comment">(*
+    here is a multi-line comment on
+    multiple lines
+*)</span>
+
+<span class="hljs-keyword">let</span> index =
+    len
+    |&gt; float
+    |&gt; Operators.(*) <span class="hljs-number">0.1</span>      <span class="hljs-comment">// (*) here is not comment</span>
+    |&gt; Operators.(+) <span class="hljs-number">1</span>        <span class="hljs-comment">// (+) here is not comment</span>
+    |&gt; Operators.(-) len      <span class="hljs-comment">// (-) here is not comment</span>
+;;

--- a/test/markup/fsharp/comments.txt
+++ b/test/markup/fsharp/comments.txt
@@ -1,0 +1,14 @@
+(* here is a multi-line comment on one line *)
+
+(*
+    here is a multi-line comment on
+    multiple lines
+*)
+
+let index =
+    len
+    |> float
+    |> Operators.(*) 0.1      // (*) here is not comment
+    |> Operators.(+) 1        // (+) here is not comment
+    |> Operators.(-) len      // (-) here is not comment
+;;


### PR DESCRIPTION
Resolves #2697