### PR TITLE
(package) Process 3rd party CSS during the build process

### DIFF
--- a/tools/build_cdn.js
+++ b/tools/build_cdn.js
@@ -98,8 +98,27 @@ async function buildDistributable(language) {
   let distDir = path.join(language.moduleDir,"dist")
   log(`Building ${distDir}/${filename}.`)
   await fs.mkdir(distDir, {recursive: true});
-  fs.writeFile(path.join(language.moduleDir,"dist",filename), language.minified);
+  fs.writeFile(path.join(distDir,filename), language.minified);
 
+
+  let styleSourceDir = path.join(language.moduleDir, "src/styles")
+  glob.sync("*", { cwd: styleSourceDir }).forEach((file) => {
+    let sourceFile = path.join(styleSourceDir, file)
+    let destFileName = file;
+    let destFilePath;
+    log(`Processing ${sourceFile}.`)
+    if (file.endsWith(".css")) {
+      destFileName = file.replace(".css", ".min.css")
+      destFilePath = `../${distDir}/${destFileName}`
+      install_cleancss(sourceFile, destFilePath);
+    }
+    else { // images, backgrounds, etc
+      destFilePath = `../${distDir}/${destFileName}`
+      install(sourceFile, destFilePath);
+    }
+
+    install(`${process.env.BUILD_DIR}/${destFilePath}`, `styles/${destFileName}`);
+  })
 }
 
  async function buildCDNLanguage (language) {


### PR DESCRIPTION
Process 3rd party CSS in a similar way as the JS files.

Tested by following instructions from https://github.com/highlightjs/highlight.js/blob/master/extra/3RD_PARTY_QUICK_START.md on https://github.com/highlightjs/highlightjs-tsql . 

The generated `ssms.min.css` was placed in both `.\extra\tsql\dist` and `.\build\styles`, and the resulted file can be inspected in https://github.com/highlightjs/highlightjs-tsql/pull/6 .

Disclaimer: I'm not happy about the code :( , but I'm afraid I wouldn't be able to do it properly for now. :( I'd really like to bring https://github.com/highlightjs/highlightjs-tsql to a usable state first...