### PR TITLE
enh(build) slimmer Docker image and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,6 @@ __pycache__
 *.swp
 node_modules
 .project
-yarn.lock
-extra/
 
 # editors
 .idea/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.DS_Store
+build
+docs/_build
+__pycache__
+*.swp
+node_modules
+.project
+yarn.lock
+extra/
+
+# editors
+.idea/
+.vscode/
+.Rproj.user
+
+# misc
+/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM node:12
-# docker build -t highlight-js .
-RUN apt-get update && apt-get install -y nginx
+# Dockerfile for highlight.js
+#
+# Build image:
+#   docker build -t highlight-js .
+#
+# Run container:
+#   docker run --rm -it --publish 8080:80 highlight-js
+#
+#   And open a browser to http://localhost:8080
+
+FROM node:12-slim
+RUN apt-get update -qq \
+    && apt-get install --yes --no-install-recommends \
+        nginx \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /var/www/html
-COPY ./package*.json /var/www/html/
+COPY package*.json /var/www/html/
 RUN npm install
-COPY . /var/www/html
+COPY . .
 RUN node tools/build.js :common
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This pull request proposes the following changes:

1. Use `node:12-slim` as the base image
2. Add some documentation to the Dockerfile
3. Add a `.dockerignore` file, which is similar to a `.gitignore` in that it tells Docker to not copy some files during the image build.

The result of number 1 is that the Docker image is 342 MB, down from 1.1 GB originally.