### PR TITLE
chore(css) Fix background color of the Lightfair theme

### DIFF
--- a/src/styles/lightfair.css
+++ b/src/styles/lightfair.css
@@ -8,7 +8,7 @@ Lightfair style (c) Tristian Kelly <tristian.kelly560@gmail.com>
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  /* TODO: background? */
+  background: #fff;
 }
 
 .hljs-name {


### PR DESCRIPTION
Added background colour `#fff` to the Lightfair theme to make it visible on dark backgrounds. As of now when this theme is used, some text is not visible on certain darker backgrounds.