### PR TITLE
enh(angelscript) Improve heredocs, numbers, metadata blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,14 @@ Language Improvements:
 - fix(javascript) Comments inside params should be highlighted (#2702) [Josh Goebel][]
 - fix(scala) Comments inside class header should be highlighted (#1559) [Josh Goebel][]
 - fix(c-like) Correctly highlight modifiers (`final`) in class declaration (#2696) [Josh Goebel][]
+- enh(angelscript) Improve heredocs, numbers, metadata blocks (#2724) [Melissa Geels][]
 
 [David Pine]: https://github.com/IEvangelist
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Jonasson]: https://github.com/ryanjonasson
 [Philipp Engel]: https://github.com/interkosmos
 [Konrad Rudolph]: https://github.com/klmr
+[Melissa Geels]: https://github.com/codecat
 
 
 ## Version 10.2.1

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -108,7 +108,7 @@ export default function(hljs) {
 
       { // numbers
         className: 'number',
-        begin: '(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?f?|\\.\\d+f?)([eE][-+]?\\d+f?)?)'
+        begin: '(-?)(\\b0[xXbBoOdD][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?f?|\\.\\d+f?)([eE][-+]?\\d+f?)?)'
       }
     ]
   };

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -65,6 +65,11 @@ export default function(hljs) {
       hljs.C_LINE_COMMENT_MODE, // single-line comments
       hljs.C_BLOCK_COMMENT_MODE, // comment blocks
 
+      { // metadata
+        className: 'string',
+        begin: '^\\s*\\[', end: '\\]',
+      },
+
       { // interface or namespace declaration
         beginKeywords: 'interface namespace', end: '{',
         illegal: '[;.\\-]',

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -48,18 +48,18 @@ export default function(hljs) {
         relevance: 0
       },
 
+      // """heredoc strings"""
+      {
+        className: 'string',
+        begin: '"""', end: '"""'
+      },
+
       { // "strings"
         className: 'string',
         begin: '"', end: '"',
         illegal: '\\n',
         contains: [ hljs.BACKSLASH_ESCAPE ],
         relevance: 0
-      },
-
-      // """heredoc strings"""
-      {
-        className: 'string',
-        begin: '"""', end: '"""'
       },
 
       hljs.C_LINE_COMMENT_MODE, // single-line comments

--- a/test/detect/angelscript/default.txt
+++ b/test/detect/angelscript/default.txt
@@ -23,7 +23,7 @@ namespace MyApplication
             m_arr.insertLast(1.0f);
             m_arr.insertLast(1.75f);
             m_arr.insertLast(3.14159f);
-            uint x = 0x7fff0000 + 2;
+            uint x = 0x7fff0000;
             int y = 9001;
             uint z = 0b10101010;
         }

--- a/test/detect/angelscript/default.txt
+++ b/test/detect/angelscript/default.txt
@@ -23,13 +23,15 @@ namespace MyApplication
             m_arr.insertLast(1.0f);
             m_arr.insertLast(1.75f);
             m_arr.insertLast(3.14159f);
-            uint x = 0x7fff0000;
+            uint x = 0x7fff0000 + 2;
             int y = 9001;
+            uint z = 0b10101010;
         }
 
         int get_Thing() property { return m_thing; }
         void set_Thing(int x) property { m_thing = x; }
 
+        [Hook x=1 y=2]
         void DoSomething()
         {
             print("Something! " + 'stuff.');
@@ -53,4 +55,9 @@ void Main()
 {
     SomeClass@ c = SomeClass();
     c.DoSomething();
+    @c = null;
 }
+
+string multilineString = """
+Hello world, "this is a test"!
+""";

--- a/test/detect/angelscript/default.txt
+++ b/test/detect/angelscript/default.txt
@@ -55,7 +55,6 @@ void Main()
 {
     SomeClass@ c = SomeClass();
     c.DoSomething();
-    @c = null;
 }
 
 string multilineString = """


### PR DESCRIPTION
* Fixed a bug where heredoc strings were not being handled properly:
  ![image](https://user-images.githubusercontent.com/136534/94812927-ac73ae80-03f7-11eb-8a4c-90d2bb678afc.png)
* Fixed some missing number formatting syntaxes, for example binary numbers:
  ![image](https://user-images.githubusercontent.com/136534/94813276-14c29000-03f8-11eb-90b5-b3a5ececc404.png)
* Added missing metadata syntax as a string class: (Angelscript lets implementations treat these as strings)
  ![image](https://user-images.githubusercontent.com/136534/94813130-e775e200-03f7-11eb-898f-b935334c37b7.png)
