### PR TITLE
enh(javascript) highlight class methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Language Improvements:
 
+- enh(javascipt/typescript) Highlight class methods as functions (#2727) [Josh Goebel][]
+- fix(javascipt/typescript) `constructor` is now highlighted as a function title (not keyword) (#2727) [Josh Goebel][]
 - fix(fsharp) Prevent `(*)` from being detected as a multi-line comment [Josh Goebel][]
 - enh(r) major overhaul of the R language grammar (and fix a few bugs) (#2680) [Konrad Rudolph][]
 - enh(csharp) Add all C# 9 keywords, and other missing keywords (#2679) [David Pine][]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -247,11 +247,12 @@ export default function(hljs) {
             // we have to count the parens to make sure we actually have the
             // correct bounding ( ) before the =>.  There could be any number of
             // sub-expressions inside also surrounded by parens.
-            begin: '(\\([^(]*' +
-              '(\\([^(]*' +
-                '(\\([^(]*' +
-                '\\)\\s*)?' +
-              '\\)\\s*)?' +
+            begin: '(\\(' +
+            '[^()]*(\\(' +
+            '[^()]*(\\(' +
+            '[^()]*' +
+            '\\))*[^()]*' +
+            '\\))*[^()]*' +
             '\\)|' + hljs.UNDERSCORE_IDENT_RE + ')\\s*=>',
             returnBegin: true,
             end: '\\s*=>',
@@ -330,12 +331,14 @@ export default function(hljs) {
         // we have to count the parens to make sure we actually have the correct
         // bounding ( ).  There could be any number of sub-expressions inside
         // also surrounded by parens.
-        begin: hljs.UNDERSCORE_IDENT_RE + '(\\([^(]*' +
-              '(\\([^(]*' +
-                '(\\([^(]*' +
-                '\\)\\s*)?' +
-              '\\)\\s*)?' +
-            '\\))\\s*{',
+        begin: hljs.UNDERSCORE_IDENT_RE +
+          '\\(' + // first parens
+          '[^()]*(\\(' +
+            '[^()]*(\\(' +
+              '[^()]*' +
+            '\\))*[^()]*' +
+          '\\))*[^()]*' +
+          '\\)\\s*{', // end parens
         returnBegin:true,
         contains: [
           PARAMS,

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -325,6 +325,23 @@ export default function(hljs) {
         ],
         illegal: /%/
       },
+      {
+        className: 'function',
+        // we have to count the parens to make sure we actually have the
+        // correct bounding ( ) before the =>.  There could be any number of
+        // sub-expressions inside also surrounded by parens.
+        begin: hljs.UNDERSCORE_IDENT_RE + '(\\([^(]*' +
+              '(\\([^(]*' +
+                '(\\([^(]*' +
+                '\\))?' +
+              '\\))?' +
+            '\\))\\s*{',
+        returnBegin:true,
+        contains: [
+          PARAMS,
+          hljs.inherit(hljs.TITLE_MODE, { begin: IDENT_RE }),
+        ]
+      },
       // hack: prevents detection of keywords in some circumstances
       // .keyword()
       // $keyword = x
@@ -347,10 +364,11 @@ export default function(hljs) {
         ]
       },
       {
-        beginKeywords: 'constructor',
+        begin: /\b(?=constructor)/,
         end: /[\{;]/,
         excludeEnd: true,
         contains: [
+          hljs.inherit(hljs.TITLE_MODE, { begin: IDENT_RE }),
           'self',
           PARAMS
         ]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -250,8 +250,8 @@ export default function(hljs) {
             begin: '(\\([^(]*' +
               '(\\([^(]*' +
                 '(\\([^(]*' +
-                '\\))?' +
-              '\\))?' +
+                '\\)\\s*)?' +
+              '\\)\\s*)?' +
             '\\)|' + hljs.UNDERSCORE_IDENT_RE + ')\\s*=>',
             returnBegin: true,
             end: '\\s*=>',
@@ -327,14 +327,14 @@ export default function(hljs) {
       },
       {
         className: 'function',
-        // we have to count the parens to make sure we actually have the
-        // correct bounding ( ) before the =>.  There could be any number of
-        // sub-expressions inside also surrounded by parens.
+        // we have to count the parens to make sure we actually have the correct
+        // bounding ( ).  There could be any number of sub-expressions inside
+        // also surrounded by parens.
         begin: hljs.UNDERSCORE_IDENT_RE + '(\\([^(]*' +
               '(\\([^(]*' +
                 '(\\([^(]*' +
-                '\\))?' +
-              '\\))?' +
+                '\\)\\s*)?' +
+              '\\)\\s*)?' +
             '\\))\\s*{',
         returnBegin:true,
         contains: [

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Vehicle</span> </span>{
-  <span class="hljs-keyword">constructor</span>(<span class="hljs-params">speed, cost</span>) {
+  <span class="hljs-function"><span class="hljs-title">constructor</span>(<span class="hljs-params">speed, cost</span>)</span> {
     <span class="hljs-built_in">super</span>(speed);
 
     <span class="hljs-keyword">var</span> c = <span class="hljs-built_in">Symbol</span>(<span class="hljs-string">&#x27;cost&#x27;</span>);

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -14,4 +14,8 @@
   <span class="hljs-function"><span class="hljs-title">other</span>(<span class="hljs-params">a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ) </span>)</span> {
     <span class="hljs-built_in">console</span>.log(a)
   }
+  <span class="hljs-function"><span class="hljs-title">something</span>(<span class="hljs-params">a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ), b = <span class="hljs-number">1</span> </span>)</span> {
+    <span class="hljs-built_in">console</span>.log(a)
+  }
+  <span class="hljs-function"><span class="hljs-title">onemore</span>(<span class="hljs-params">a=(<span class="hljs-number">3</span>+<span class="hljs-number">2</span>, b=(<span class="hljs-number">5</span>*<span class="hljs-number">9</span>))</span>)</span> {}
 }

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -1,3 +1,4 @@
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Vehicle</span> </span>{}
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Vehicle</span> </span>{
   <span class="hljs-function"><span class="hljs-title">constructor</span>(<span class="hljs-params">speed, cost</span>)</span> {
     <span class="hljs-built_in">super</span>(speed);
@@ -7,5 +8,10 @@
 
     <span class="hljs-built_in">this</span>.intro = <span class="hljs-string">`This is a car runs at
       <span class="hljs-subst">${speed}</span>.`</span>;
+  }
+  <span class="hljs-function"><span class="hljs-title">join</span>(<span class="hljs-params"></span>)</span> {
+  }
+  <span class="hljs-function"><span class="hljs-title">other</span>(<span class="hljs-params">a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ) </span>)</span> {
+    <span class="hljs-built_in">console</span>.log(a)
   }
 }

--- a/test/markup/javascript/class.txt
+++ b/test/markup/javascript/class.txt
@@ -14,4 +14,8 @@ class Car extends Vehicle {
   other(a = ( ( 3 + 2 ) ) ) {
     console.log(a)
   }
+  something(a = ( ( 3 + 2 ) ), b = 1 ) {
+    console.log(a)
+  }
+  onemore(a=(3+2, b=(5*9))) {}
 }

--- a/test/markup/javascript/class.txt
+++ b/test/markup/javascript/class.txt
@@ -1,3 +1,4 @@
+class Vehicle {}
 class Car extends Vehicle {
   constructor(speed, cost) {
     super(speed);
@@ -7,5 +8,10 @@ class Car extends Vehicle {
 
     this.intro = `This is a car runs at
       ${speed}.`;
+  }
+  join() {
+  }
+  other(a = ( ( 3 + 2 ) ) ) {
+    console.log(a)
   }
 }

--- a/test/markup/javascript/jsx-fragment.expect.txt
+++ b/test/markup/javascript/jsx-fragment.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Columns</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">React</span>.<span class="hljs-title">Component</span> </span>{
-  render() {
+  <span class="hljs-function"><span class="hljs-title">render</span>(<span class="hljs-params"></span>)</span> {
     <span class="hljs-keyword">return</span> (
       <span class="xml"><span class="hljs-tag">&lt;&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-name">td</span>&gt;</span>Hello<span class="hljs-tag">&lt;/<span class="hljs-name">td</span>&gt;</span>

--- a/test/markup/javascript/jsx.expect.txt
+++ b/test/markup/javascript/jsx.expect.txt
@@ -12,7 +12,7 @@
 <span class="hljs-keyword">const</span> m = <span class="hljs-function">() =&gt;</span> <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">X</span> <span class="hljs-attr">x</span>=<span class="hljs-string">&quot;&quot;</span> /&gt;</span></span>
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">App</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Component</span> </span>{
-  render() {
+  <span class="hljs-function"><span class="hljs-title">render</span>(<span class="hljs-params"></span>)</span> {
     <span class="hljs-keyword">return</span> (
       <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">BrowserRouter</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>

--- a/test/markup/typescript/class.expect.txt
+++ b/test/markup/typescript/class.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Vehicle</span> </span>{
-  <span class="hljs-keyword">constructor</span>(<span class="hljs-params">speed, cost</span>) {
+  <span class="hljs-function"><span class="hljs-title">constructor</span>(<span class="hljs-params">speed, cost</span>)</span> {
     <span class="hljs-built_in">super</span>(speed);
 
     <span class="hljs-keyword">var</span> c = <span class="hljs-built_in">Symbol</span>(<span class="hljs-string">&#x27;cost&#x27;</span>);

--- a/test/markup/typescript/declares.expect.txt
+++ b/test/markup/typescript/declares.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-keyword">export</span> <span class="hljs-keyword">declare</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">CommandHandler</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">EventEmitter</span> </span>{
 
-    <span class="hljs-keyword">constructor</span>(<span class="hljs-params">config: CommandHandlerConfig</span>);
+    <span class="hljs-title">constructor</span>(<span class="hljs-params">config: CommandHandlerConfig</span>);
     <span class="hljs-comment">/**
      * Install the handler onto Discord.js
      * <span class="hljs-doctag">@param <span class="hljs-variable">client</span></span> - Client to handle

--- a/test/markup/typescript/decorator-factories.expect.txt
+++ b/test/markup/typescript/decorator-factories.expect.txt
@@ -3,7 +3,7 @@
     <span class="hljs-meta">@baz</span>(<span class="hljs-number">123</span>)
     <span class="hljs-keyword">private</span> myAttribute: <span class="hljs-built_in">string</span>;
 
-    <span class="hljs-keyword">constructor</span>(<span class="hljs-params"><span class="hljs-meta">@bar</span>(<span class="hljs-literal">true</span>) <span class="hljs-keyword">private</span> x,
+    <span class="hljs-title">constructor</span>(<span class="hljs-params"><span class="hljs-meta">@bar</span>(<span class="hljs-literal">true</span>) <span class="hljs-keyword">private</span> x,
                 <span class="hljs-meta">@bar</span>(qux(quux(<span class="hljs-literal">true</span>))) <span class="hljs-keyword">private</span> y</span>) { }
 
     <span class="hljs-meta">@bar</span>()

--- a/test/markup/typescript/decorator-factories.expect.txt
+++ b/test/markup/typescript/decorator-factories.expect.txt
@@ -7,7 +7,7 @@
                 <span class="hljs-meta">@bar</span>(qux(quux(<span class="hljs-literal">true</span>))) <span class="hljs-keyword">private</span> y</span>) { }
 
     <span class="hljs-meta">@bar</span>()
-    <span class="hljs-keyword">private</span> myMethod(<span class="hljs-meta">@bar</span>() z) {
+    <span class="hljs-keyword">private</span> <span class="hljs-function"><span class="hljs-title">myMethod</span>(<span class="hljs-params"><span class="hljs-meta">@bar</span>() z</span>)</span> {
         <span class="hljs-built_in">console</span>.log(<span class="hljs-string">&#x27;Hello world.&#x27;</span>);
     }
 }

--- a/test/markup/typescript/jsx.expect.txt
+++ b/test/markup/typescript/jsx.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyComponent</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Component</span>&lt;<span class="hljs-title">Props</span>&gt; </span>{
-    render() {
+    <span class="hljs-function"><span class="hljs-title">render</span>(<span class="hljs-params"></span>)</span> {
         <span class="hljs-keyword">let</span> a : <span class="hljs-built_in">Array</span>&lt;<span class="hljs-built_in">Array</span>&lt;<span class="hljs-built_in">number</span>&gt;&gt; = [[<span class="hljs-number">1</span>,<span class="hljs-number">2</span>]];
         <span class="hljs-keyword">let</span> b = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Map</span>&lt;<span class="hljs-built_in">string</span>,<span class="hljs-built_in">number</span>&gt;();
         <span class="hljs-keyword">return</span> (


### PR DESCRIPTION
Resolved #1987.  Never say never.

Doesn't deal with the edge case that TECHNICALLY `blah() {}` could be a function call FOLLOWED by a block as this is a very unusual coding style.

- Also changes "constructor" to be a function/title rather than a keyword