### PR TITLE
enh(cpp) Improve C++ class template headers

### DIFF
--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -202,7 +202,7 @@ export default function(hljs) {
   };
 
   var TEMPLATE_USE = {
-    begin: /</, end: />/,
+    begin: /</, end: /[>{;]/,
     keywords: CPP_KEYWORDS,
     contains: EXPRESSION_CONTAINS.concat([
       // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
@@ -222,35 +222,27 @@ export default function(hljs) {
   };
 
   var TEMPLATE_DECLARATION = {
-    beginKeywords: 'template',
+    begin: /template\s*</,
     // Add additional stops to stop runaway template declaration, e.g.
     // `template <bool b = 1 < 2> void f();`
     end: /[>;{]/,
-    contains: [
+    keywords: CPP_KEYWORDS,
+    contains: EXPRESSION_CONTAINS.concat([
+      // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
+      { begin: /<</ },
+      TEMPLATE_USE,
       {
-        begin: /</, end: />/,
-        endsWithParent: true,
-        endsParent: true,
+        begin: /\(/, end: /[);{]/,
         keywords: CPP_KEYWORDS,
-        contains: EXPRESSION_CONTAINS.concat([
+        contains: [
           // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
           { begin: /<</ },
-          TEMPLATE_USE,
-          {
-            begin: /\(/, end: /\)/,
-            keywords: CPP_KEYWORDS,
-            contains: [
-              // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
-              { begin: /<</ },
-              TEMPLATE_USE
-            ]
-          },
-        ]),
-        relevance: 10
+          TEMPLATE_USE
+        ]
       },
-      // FIXME: Set relevance of class declarations at this point to 10!
-      CLASS_DECLARATION,
-    ]
+      'self'
+    ]),
+    relevance: 10
   };
 
   return {

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -232,11 +232,15 @@ export default function(hljs) {
       { begin: /<</ },
       TEMPLATE_USE,
       {
-        begin: /\(/, end: /[);{]/,
+        begin: /\(/, end: /\)/,
+        endsWithParent: true,
         keywords: CPP_KEYWORDS,
         contains: [
           // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
           { begin: /<</ },
+          // Match greater-than to prevent this from terminating the mode (via
+          // the parent).
+          { begin: />/ },
           TEMPLATE_USE
         ]
       },

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -207,6 +207,19 @@ export default function(hljs) {
     contains: EXPRESSION_CONTAINS.concat([
       // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
       { begin: /<</ },
+      {
+        begin: /\(/, end: /\)/,
+        endsWithParent: true,
+        keywords: CPP_KEYWORDS,
+        contains: [
+          // Match left-shift to prevent it from creating a nested `TEMPLATE_USE`.
+          { begin: /<</ },
+          // Match greater-than to prevent this from terminating the mode (via
+          // the parent).
+          { begin: />/ }
+          // TEMPLATE_USE
+        ]
+      },
       'self'
     ])
   };

--- a/test/markup/cpp/templates.expect.txt
+++ b/test/markup/cpp/templates.expect.txt
@@ -1,0 +1,104 @@
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">typename</span> X&gt; <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span></span>;
+
+<span class="hljs-keyword">template</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">A::B</span>&lt;<span class="hljs-number">1</span>, <span class="hljs-number">2</span>&gt; {</span>};
+
+<span class="hljs-function"><span class="hljs-keyword">template</span> <span class="hljs-keyword">void</span> <span class="hljs-title">A::f</span><span class="hljs-params">(<span class="hljs-keyword">int</span>)</span></span>;
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">class</span> T, <span class="hljs-built_in">std</span>::<span class="hljs-keyword">size_t</span> N = <span class="hljs-keyword">sizeof</span>(T), <span class="hljs-keyword">class</span> K = T&gt;
+ostream&amp; <span class="hljs-keyword">operator</span>&lt;&lt; (ostream&amp; os, <span class="hljs-keyword">const</span> skg::Triplet&lt;T&gt; pt) ;
+<span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">other_stuff_that_isnt_colored</span><span class="hljs-params">()</span></span>;
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> T&gt;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">My_vector</span> {</span> <span class="hljs-comment">/* ... */</span> };
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> T = <span class="hljs-keyword">void</span>&gt;
+<span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">My_op_functor</span> {</span> <span class="hljs-comment">/* ... */</span> };
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span>... Ts&gt;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">My_tuple</span> {</span> <span class="hljs-comment">/* ... */</span> };
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span>&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">My_vector</span>;</span>
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> = <span class="hljs-keyword">void</span>&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">My_op_functor</span>;</span>
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span>...&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">My_tuple</span>;</span>
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt; <span class="hljs-keyword">concept</span> C1 = <span class="hljs-literal">true</span>;
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span>... Ts&gt; <span class="hljs-keyword">concept</span> C2 = <span class="hljs-literal">true</span>; <span class="hljs-comment">// variadic concept</span>
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T, <span class="hljs-keyword">typename</span> U&gt; <span class="hljs-keyword">concept</span> C3 = <span class="hljs-literal">true</span>;
+ 
+<span class="hljs-keyword">template</span>&lt;C1 T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">s1</span>;</span>         <span class="hljs-comment">// constraint-expression is C1&lt;T&gt;</span>
+<span class="hljs-keyword">template</span>&lt;C1... T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">s2</span>;</span>      <span class="hljs-comment">// constraint-expression is (C1&lt;T&gt; &amp;&amp; ...)</span>
+<span class="hljs-keyword">template</span>&lt;C2... T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">s3</span>;</span>      <span class="hljs-comment">// constraint-expression is (C2&lt;T&gt; &amp;&amp; ...)</span>
+<span class="hljs-keyword">template</span>&lt;C3&lt;<span class="hljs-keyword">int</span>&gt; T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">s4</span>;</span>    <span class="hljs-comment">// constraint-expression is C3&lt;T, int&gt;</span>
+<span class="hljs-keyword">template</span>&lt;C3&lt;<span class="hljs-keyword">int</span>&gt;... T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">s5</span>;</span> <span class="hljs-comment">// constraint-expression is (C3&lt;T, int&gt; &amp;&amp; ...)</span>
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> K, <span class="hljs-keyword">typename</span> V, <span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span>&gt; <span class="hljs-keyword">typename</span> C = my_array&gt;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Map</span> {</span>};
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> B&gt;
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> C&gt;
+<span class="hljs-keyword">void</span> A&lt;B&gt;::g(C) {}
+
+
+<span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g</span><span class="hljs-params">()</span> </span>{
+    f&lt;<span class="hljs-keyword">int</span>()&gt;();
+}
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">int</span> (&amp;pa)[<span class="hljs-number">5</span>]&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">W</span> {</span>};
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">void</span> (*pf)(<span class="hljs-keyword">int</span>)&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">A</span> {</span>};
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> T, <span class="hljs-keyword">const</span> <span class="hljs-keyword">char</span>* p&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">X</span> {</span>};
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">A</span> {</span> <span class="hljs-keyword">int</span> x; }; <span class="hljs-comment">// primary template</span>
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">A</span>&lt;T*&gt; {</span> <span class="hljs-keyword">long</span> x; }; <span class="hljs-comment">// partial specialization</span>
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">eval</span>;</span> <span class="hljs-comment">// primary template </span>
+ 
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span>, <span class="hljs-keyword">typename</span>...&gt; <span class="hljs-keyword">class</span> TT, <span class="hljs-keyword">typename</span> T1, <span class="hljs-keyword">typename</span>... Rest&gt;
+<span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">eval</span>&lt;TT&lt;T1, Rest...&gt;&gt; {</span>}; <span class="hljs-comment">// partial specialization of eval</span>
+
+
+eval&lt;A&lt;<span class="hljs-keyword">int</span>&gt;&gt; eA;
+eval&lt;B&lt;<span class="hljs-keyword">int</span>, <span class="hljs-keyword">float</span>&gt;&gt; eB;
+eval&lt;C&lt;<span class="hljs-number">17</span>&gt;&gt; eC;
+eval&lt;D&lt;<span class="hljs-keyword">int</span>, <span class="hljs-number">17</span>&gt;&gt; eD;
+eval&lt;E&lt;<span class="hljs-keyword">int</span>, <span class="hljs-keyword">float</span>&gt;&gt; eE;
+
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">auto</span>&gt; <span class="hljs-keyword">class</span>&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">FA</span><span class="hljs-params">()</span></span>;  <span class="hljs-comment">// note: C++17</span>
+
+
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> TT = <span class="hljs-keyword">char</span>&gt; <span class="hljs-keyword">class</span> T&gt;
+<span class="hljs-keyword">void</span> A&lt;T&gt;::g()
+{
+    T&lt;&gt; t; <span class="hljs-comment">// ok: t is T&lt;char&gt;</span>
+}
+
+s.<span class="hljs-keyword">template</span> foo&lt;T&gt;();
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>;</span>
+
+
+<span class="hljs-comment">// Hard mode</span>
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = (a &gt; b), <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">f1</span><span class="hljs-params">()</span></span>;
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = (a &gt;&gt; b), <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">f2</span><span class="hljs-params">()</span></span>;
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = (a &lt; b), <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g1</span><span class="hljs-params">()</span></span>;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>;</span>
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = a &lt; b, <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g1</span><span class="hljs-params">()</span></span>;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">D</span>;</span>
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = (a &lt;&lt; b), <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g2</span><span class="hljs-params">()</span></span>;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">E</span>;</span>
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = a &lt;&lt; b, <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g2</span><span class="hljs-params">()</span></span>;
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">F</span>;</span>

--- a/test/markup/cpp/templates.expect.txt
+++ b/test/markup/cpp/templates.expect.txt
@@ -102,3 +102,7 @@ s.<span class="hljs-keyword">template</span> foo&lt;T&gt;();
 
 <span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> a, <span class="hljs-keyword">int</span> b, <span class="hljs-keyword">bool</span> c = a &lt;&lt; b, <span class="hljs-keyword">class</span> T&gt; <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">g2</span><span class="hljs-params">()</span></span>;
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">F</span>;</span>
+
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> A = (B&lt;C&gt;), <span class="hljs-keyword">class</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>;</span>
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> A = B&lt;(c &gt; D&lt;E&gt;)&gt;, <span class="hljs-keyword">class</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>;</span>
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">int</span> A = B&lt;(c &gt; D&lt;(e &gt; f)&gt;)&gt;, <span class="hljs-keyword">class</span> T&gt; <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">C</span>;</span>

--- a/test/markup/cpp/templates.txt
+++ b/test/markup/cpp/templates.txt
@@ -102,3 +102,7 @@ class E;
 
 template <int a, int b, bool c = a << b, class T> void g2();
 class F;
+
+template <int A = (B<C>), class T> class C;
+template <int A = B<(c > D<E>)>, class T> class C;
+template <int A = B<(c > D<(e > f)>)>, class T> class C;

--- a/test/markup/cpp/templates.txt
+++ b/test/markup/cpp/templates.txt
@@ -1,0 +1,104 @@
+template <template <typename X> class T> void f();
+
+template class A::B<1, 2> {};
+
+template void A::f(int);
+
+template <class T, std::size_t N = sizeof(T), class K = T>
+ostream& operator<< (ostream& os, const skg::Triplet<T> pt) ;
+void other_stuff_that_isnt_colored();
+
+
+template<class T>
+class My_vector { /* ... */ };
+
+template<class T = void>
+struct My_op_functor { /* ... */ };
+
+template<typename... Ts>
+class My_tuple { /* ... */ };
+
+
+template<class> class My_vector;
+template<class = void> struct My_op_functor;
+template<typename...> class My_tuple;
+
+
+template<typename T> concept C1 = true;
+template<typename... Ts> concept C2 = true; // variadic concept
+template<typename T, typename U> concept C3 = true;
+ 
+template<C1 T> struct s1;         // constraint-expression is C1<T>
+template<C1... T> struct s2;      // constraint-expression is (C1<T> && ...)
+template<C2... T> struct s3;      // constraint-expression is (C2<T> && ...)
+template<C3<int> T> struct s4;    // constraint-expression is C3<T, int>
+template<C3<int>... T> struct s5; // constraint-expression is (C3<T, int> && ...)
+
+
+template<typename K, typename V, template<typename> typename C = my_array>
+class Map {};
+
+
+template<class B>
+template<class C>
+void A<B>::g(C) {}
+
+
+void g() {
+    f<int()>();
+}
+
+
+template<int (&pa)[5]> struct W {};
+template<void (*pf)(int)> struct A {};
+
+
+template<class T, const char* p> class X {};
+
+
+template<typename T> class A { int x; }; // primary template
+template<typename T> class A<T*> { long x; }; // partial specialization
+
+
+template<typename T> struct eval; // primary template 
+ 
+template<template<typename, typename...> class TT, typename T1, typename... Rest>
+struct eval<TT<T1, Rest...>> {}; // partial specialization of eval
+
+
+eval<A<int>> eA;
+eval<B<int, float>> eB;
+eval<C<17>> eC;
+eval<D<int, 17>> eD;
+eval<E<int, float>> eE;
+
+
+template <template <auto> class> void FA();  // note: C++17
+
+
+template<template<typename TT = char> class T>
+void A<T>::g()
+{
+    T<> t; // ok: t is T<char>
+}
+
+s.template foo<T>();
+class C;
+
+
+// Hard mode
+
+template <int a, int b, bool c = (a > b), class T> void f1();
+template <int a, int b, bool c = (a >> b), class T> void f2();
+
+template <int a, int b, bool c = (a < b), class T> void g1();
+class C;
+
+template <int a, int b, bool c = a < b, class T> void g1();
+class D;
+
+template <int a, int b, bool c = (a << b), class T> void g2();
+class E;
+
+template <int a, int b, bool c = a << b, class T> void g2();
+class F;


### PR DESCRIPTION
This fixes #2716 and it fixes #2102<sup>1</sup>. In order to parse class and function headers correctly, it is insufficient to just skip greedily (or, worse, non-greedily) over `/<.*>/`, since C++ template declarations as well as template instantiations can contain nested template parameter lists. As a further complication, they can even contain the operators `<`, `>`, `<<` and `>>` (as part of non-type template parameters or their defaults (in declarations)).

This PR attempts to be a minimal change — a much more comprehensive refactor of the C and C++ language definitions is somewhat overdue (see #2173 and #2146). But this will take time, and in the meantime the improvement from this PR is probably “good enough”.

This PR is a WIP: there are some open issues that I’ve commented inside the changes.

---

<sup>1</sup> The failing code from the second issue isn’t added as a test case because hljs still fails to highlight it as a function declaration, but that’s unrelated to templates and rather because hljs currently doesn’t recognise operator overload definitions at all.