### PR TITLE
[PHP] PHP 8 updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Language Improvements:
 - enh(angelscript) Improve heredocs, numbers, metadata blocks (#2724) [Melissa Geels][]
 - enh(javascript) Implement Numeric Separators (#2617) [Antoine du Hamel][]
 - enh(typescript) TypeScript also gains support for numeric separators (#2617) [Antoine du Hamel][]
+- enh(php) Add support for PHP 8 `match` keyword and add `php8` as an alias (#2733) [Ayesh Karunaratne][]
 
 [David Pine]: https://github.com/IEvangelist
 [Josh Goebel]: https://github.com/joshgoebel
@@ -25,6 +26,7 @@ Language Improvements:
 [Konrad Rudolph]: https://github.com/klmr
 [Melissa Geels]: https://github.com/codecat
 [Antoine du Hamel]: https://github.com/aduh95
+[Ayesh Karunaratne]: https://github.com/Ayesh
 
 
 ## Version 10.2.1

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -85,7 +85,7 @@ export default function(hljs) {
     'Directory __PHP_Incomplete_Class parent php_user_filter self static stdClass'
   };
   return {
-    aliases: ['php', 'php3', 'php4', 'php5', 'php6', 'php7'],
+    aliases: ['php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8'],
     case_insensitive: true,
     keywords: KEYWORDS,
     contains: [

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -70,7 +70,7 @@ export default function(hljs) {
     // Other keywords:
     // <https://www.php.net/manual/en/reserved.php>
     // <https://www.php.net/manual/en/language.types.type-juggling.php>
-    'array abstract and as binary bool boolean break callable case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends final finally float for foreach from global goto if implements instanceof insteadof int integer interface isset iterable list new object or private protected public real return string switch throw trait try unset use var void while xor yield',
+    'array abstract and as binary bool boolean break callable case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends final finally float for foreach from global goto if implements instanceof insteadof int integer interface isset iterable list match new object or private protected public real return string switch throw trait try unset use var void while xor yield',
     literal: 'false null true',
     built_in:
     // Standard PHP library:


### PR DESCRIPTION
 - PHP introduces a new [`match` keyword in PHP 8.0](https://php.watch/versions/8.0/match-expression). This PR adds the `match` keyword to the list of keywords for PHP.
 -  Add 'php8' as an alias for PHP

Thank you.