### PR TITLE
fix(c-like) preprocessor directives not detected after else

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Language Improvements:
 
+- fix(c-like) preprocessor directives not detected after else (#2738) [Josh Goebel][]
 - fix(bash) enh(bash) allow nested params (#2731) [Josh Goebel][]
 - fix(python) Fix highlighting of keywords and strings (#2713, #2715) [Konrad Rudolph][]
 - fix(fsharp) Prevent `(*)` from being detected as a multi-line comment [Josh Goebel][]

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -119,6 +119,7 @@ export default function(hljs) {
   };
 
   var EXPRESSION_CONTAINS = [
+    PREPROCESSOR,
     CPP_PRIMITIVE_TYPES,
     hljs.C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -20,10 +20,10 @@
 
 <span class="hljs-keyword">if</span> (p) {
 <span class="hljs-meta">#<span class="hljs-meta-keyword">ifdef</span> DEBUG</span>
-    <span class="hljs-built_in">fprintf</span> (<span class="hljs-built_in">stderr</span>, <span class="hljs-string">&quot;error: no digits converted in &#x27;%s&#x27;.\n&quot;</span>, p);
+    onething();
 <span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span></span>
 } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (errno) {
 <span class="hljs-meta">#<span class="hljs-meta-keyword">ifdef</span> DEBUG</span>
-    <span class="hljs-built_in">fprintf</span> (<span class="hljs-built_in">stderr</span>, <span class="hljs-string">&quot;error: over/under-flow in conversion or &#x27;%s&#x27;.\n&quot;</span>, p);
+    anotherthing();
 <span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span></span>
 }

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -17,3 +17,13 @@
     EXPRESSION</span>
 <span class="hljs-keyword">int</span> bar;
 <span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span>  <span class="hljs-comment">// comment</span></span>
+
+<span class="hljs-keyword">if</span> (p) {
+<span class="hljs-meta">#<span class="hljs-meta-keyword">ifdef</span> DEBUG</span>
+    <span class="hljs-built_in">fprintf</span> (<span class="hljs-built_in">stderr</span>, <span class="hljs-string">&quot;error: no digits converted in &#x27;%s&#x27;.\n&quot;</span>, p);
+<span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span></span>
+} <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (errno) {
+<span class="hljs-meta">#<span class="hljs-meta-keyword">ifdef</span> DEBUG</span>
+    <span class="hljs-built_in">fprintf</span> (<span class="hljs-built_in">stderr</span>, <span class="hljs-string">&quot;error: over/under-flow in conversion or &#x27;%s&#x27;.\n&quot;</span>, p);
+<span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span></span>
+}

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -17,3 +17,13 @@ int foo(void)
     EXPRESSION
 int bar;
 #endif  // comment
+
+if (p) {
+#ifdef DEBUG
+    fprintf (stderr, "error: no digits converted in '%s'.\n", p);
+#endif
+} else if (errno) {
+#ifdef DEBUG
+    fprintf (stderr, "error: over/under-flow in conversion or '%s'.\n", p);
+#endif
+}

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -20,10 +20,10 @@ int bar;
 
 if (p) {
 #ifdef DEBUG
-    fprintf (stderr, "error: no digits converted in '%s'.\n", p);
+    onething();
 #endif
 } else if (errno) {
 #ifdef DEBUG
-    fprintf (stderr, "error: over/under-flow in conversion or '%s'.\n", p);
+    anotherthing();
 #endif
 }


### PR DESCRIPTION
Resolves #2737.