### PR TITLE
Clarify that one has to build before testing

### DIFF
--- a/docs/building-testing.rst
+++ b/docs/building-testing.rst
@@ -71,7 +71,7 @@ detection still works with your language definition included in the whole suite.
 
 Testing is done using `Mocha <http://mochajs.org/>`_ and the
 files are found in the ``test/`` directory. You can use the node build to
-run the tests in the command line with ``npm test`` after building_. (Using
+run the tests from the command line with ``npm test`` after building_. (Using
 ``npm run build_and_test`` you can build and then test with one command.)
 
 **Note**: for Debian-based machine, like Ubuntu, you might need to create an

--- a/docs/building-testing.rst
+++ b/docs/building-testing.rst
@@ -71,8 +71,8 @@ detection still works with your language definition included in the whole suite.
 
 Testing is done using `Mocha <http://mochajs.org/>`_ and the
 files are found in the ``test/`` directory. You can use the node build to
-run the tests in the command line with ``npm test`` after installing the
-dependencies with ``npm install``.
+run the tests in the command line with ``npm test`` after building_. (Using
+``npm run build_and_test`` you can build and then test with one command.)
 
 **Note**: for Debian-based machine, like Ubuntu, you might need to create an
 alias or symbolic link for nodejs to node. The reason for this is the


### PR DESCRIPTION
Since installing the dependencies is already mentioned in the section about building, a reference to that section should be sufficient.

I also included a reference to `build_and_test`.

Related issue: #2742