### PR TITLE
enh(autodetect) multiple autodetect fixes

### DIFF
--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -113,6 +113,7 @@ export default function(hljs) {
 
       { // numbers
         className: 'number',
+        relevance: 0,
         begin: '(-?)(\\b0[xXbBoOdD][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?f?|\\.\\d+f?)([eE][-+]?\\d+f?)?)'
       }
     ]

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -25,7 +25,10 @@ export default function(hljs) {
   Object.assign(VAR,{
     className: 'variable',
     variants: [
-      {begin: regex.concat(/\$[\w\d#@][\w\d_]*/, `(?![\\w\\d])(?![$])`) },
+      {begin: regex.concat(/\$[\w\d#@][\w\d_]*/,
+        // negative look-ahead tries to avoid matching patterns that are not
+        // Perl at all like $ident$, @ident@, etc.
+        `(?![\\w\\d])(?![$])`) },
       BRACED_VAR
     ]
   });

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -6,6 +6,8 @@ Website: https://www.gnu.org/software/bash/
 Category: common
 */
 
+import * as regex from '../lib/regex.js';
+
 /** @type LanguageFn */
 export default function(hljs) {
   const VAR = {};
@@ -23,7 +25,7 @@ export default function(hljs) {
   Object.assign(VAR,{
     className: 'variable',
     variants: [
-      {begin: /\$[\w\d#@][\w\d_]*/},
+      {begin: regex.concat(/\$[\w\d#@][\w\d_]*/, `(?![\\w\\d])(?![$])`) },
       BRACED_VAR
     ]
   });

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -16,7 +16,7 @@ export default function(hljs) {
     'builtin-name':
       // Clojure keywords
       globals + ' ' +
-      'cond apply if-not if-let if not not= = < > <= >= == + / * - rem ' +
+      'cond apply if-not if-let if not not= =|0 <|0 >|0 <=|0 >=|0 ==|0 +|0 /|0 *|0 -|0 rem ' +
       'quot neg? pos? delay? symbol? keyword? true? false? integer? empty? coll? list? ' +
       'set? ifn? fn? associative? sequential? sorted? counted? reversible? number? decimal? ' +
       'class? distinct? isa? float? rational? reduced? ratio? odd? even? char? seq? vector? ' +
@@ -88,7 +88,9 @@ export default function(hljs) {
   };
   var NAME = {
     keywords: keywords,
-    className: 'name', begin: SYMBOL_RE,
+    className: 'name',
+    begin: SYMBOL_RE,
+    relevance: 0,
     starts: BODY
   };
   var DEFAULT_CONTAINS = [LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL, SYMBOL];

--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -158,7 +158,7 @@ export default function(hljs) {
           endsParent: true
         })
       ],
-      relevance: 5
+      relevance: 2
     },
     {
       className: 'symbol',

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -139,7 +139,7 @@ export default function(hljs) {
     'select',
     'set',
     'unmanaged',
-    'value',
+    'value|0',
     'var',
     'when',
     'where',
@@ -274,7 +274,9 @@ export default function(hljs) {
       STRING,
       NUMBERS,
       {
-        beginKeywords: 'class interface', end: /[{;=]/,
+        beginKeywords: 'class interface',
+        relevance: 0,
+        end: /[{;=]/,
         illegal: /[^\s:,]/,
         contains: [
           { beginKeywords: "where class" },
@@ -285,7 +287,9 @@ export default function(hljs) {
         ]
       },
       {
-        beginKeywords: 'namespace', end: /[{;=]/,
+        beginKeywords: 'namespace',
+        relevance: 0,
+        end: /[{;=]/,
         illegal: /[^\s:]/,
         contains: [
           TITLE_MODE,
@@ -294,7 +298,9 @@ export default function(hljs) {
         ]
       },
       {
-        beginKeywords: 'record', end: /[{;=]/,
+        beginKeywords: 'record',
+        relevance: 0,
+        end: /[{;=]/,
         illegal: /[^\s:]/,
         contains: [
           TITLE_MODE,
@@ -324,7 +330,10 @@ export default function(hljs) {
         keywords: KEYWORDS,
         contains: [
           // prevents these from being highlighted `title`
-          { beginKeywords: FUNCTION_MODIFIERS.join(" ")},
+          {
+            beginKeywords: FUNCTION_MODIFIERS.join(" "),
+            relevance: 0
+          },
           {
             begin: hljs.IDENT_RE + '\\s*(<.+>)?\\s*\\(', returnBegin: true,
             contains: [

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -49,7 +49,7 @@ export default function(hljs) {
   var AT_PROPERTY_RE = /@-?\w[\w]*(-\w+)*/ // @-webkit-keyframes
   var IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
   var RULE = {
-    begin: /(?:[A-Z_.-]+|--[a-zA-Z0-9_-]+)\s*:/, returnBegin: true, end: ';', endsWithParent: true,
+    begin: /([*]\s?)?(?:[A-Z_.\-\\]+|--[a-zA-Z0-9_-]+)\s*(\/\*\*\/)?:/, returnBegin: true, end: ';', endsWithParent: true,
     contains: [
       ATTRIBUTE
     ]

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -125,6 +125,7 @@ export default function(hljs) {
         illegal: /\S/,
         contains: [
           hljs.C_BLOCK_COMMENT_MODE,
+          { begin: /;/ }, // empty ; rule
           RULE,
         ]
       }

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -58,7 +58,7 @@ export default function(hljs) {
   return {
     name: 'CSS',
     case_insensitive: true,
-    illegal: /[=\/|'\$]/,
+    illegal: /[=|'\$]/,
     contains: [
       hljs.C_BLOCK_COMMENT_MODE,
       {

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -65,7 +65,7 @@ export default function(hljs) {
         className: 'selector-id', begin: /#[A-Za-z0-9_-]+/
       },
       {
-        className: 'selector-class', begin: /\.[A-Za-z0-9_-]+/
+        className: 'selector-class', begin: '\\.' + IDENT_RE
       },
       {
         className: 'selector-attr',

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -78,7 +78,10 @@ export default function(hljs) {
             'throw throws try catch finally implements extends new import package return instanceof'
         },
         contains: [
-            hljs.SHEBANG(),
+            hljs.SHEBANG({
+              binary: "groovy",
+              relevance: 10
+            }),
             COMMENT,
             STRING,
             REGEXP,
@@ -104,6 +107,7 @@ export default function(hljs) {
               // to avoid highlight it as a label, named parameter, or map key
               begin: /\?/,
               end: /:/,
+              relevance: 0,
               contains: [
                 COMMENT,
                 STRING,

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -96,7 +96,9 @@ export default function(hljs) {
                 ]
             },
             {
-                className: 'meta', begin: '@[A-Za-z]+'
+                className: 'meta',
+                begin: '@[A-Za-z]+',
+                relevance: 0
             },
             {
               // highlight map keys and named parameters as attrs

--- a/src/languages/hy.js
+++ b/src/languages/hy.js
@@ -86,8 +86,10 @@ export default function(hljs) {
     relevance: 0
   };
   var NAME = {
+    className: 'name',
+    relevance: 0,
     keywords: keywords,
-    className: 'name', begin: SYMBOL_RE,
+    begin: SYMBOL_RE,
     starts: BODY
   };
   var DEFAULT_CONTAINS = [LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL, SYMBOL];

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -84,6 +84,12 @@ export default function(hljs) {
           ]
         }
       ),
+      // relevance boost
+      {
+        begin: /import java\.[a-z]+\./,
+        keywords: "import",
+        relevance: 2
+      },
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       hljs.APOS_STRING_MODE,

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -292,7 +292,8 @@ export default function(hljs) {
                 className: 'params',
                 variants: [
                   {
-                    begin: hljs.UNDERSCORE_IDENT_RE
+                    begin: hljs.UNDERSCORE_IDENT_RE,
+                    relevance: 0
                   },
                   {
                     className: null,

--- a/src/languages/lisp.js
+++ b/src/languages/lisp.js
@@ -80,7 +80,10 @@ export default function(hljs) {
     {
       className: 'name',
       variants: [
-        {begin: LISP_IDENT_RE},
+        {
+          begin: LISP_IDENT_RE,
+          relevance: 0,
+        },
         {begin: MEC_RE}
       ]
     },

--- a/src/languages/lsl.js
+++ b/src/languages/lsl.js
@@ -24,6 +24,7 @@ export default function(hljs) {
 
     var LSL_NUMBERS = {
         className: 'number',
+        relevance:0,
         begin: hljs.C_NUMBER_RE
     };
 

--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -38,8 +38,8 @@ export default function(hljs) {
         'eye repmat rand randn linspace logspace freqspace meshgrid accumarray size length ' +
         'ndims numel disp isempty isequal isequalwithequalnans cat reshape diag blkdiag tril ' +
         'triu fliplr flipud flipdim rot90 find sub2ind ind2sub bsxfun ndgrid permute ipermute ' +
-        'shiftdim circshift squeeze isscalar isvector ans eps realmax realmin pi i inf nan ' +
-        'isnan isinf isfinite j why compan gallery hadamard hankel hilb invhilb magic pascal ' +
+        'shiftdim circshift squeeze isscalar isvector ans eps realmax realmin pi i|0 inf nan ' +
+        'isnan isinf isfinite j|0 why compan gallery hadamard hankel hilb invhilb magic pascal ' +
         'rosser toeplitz vander wilkinson max min nanmax nanmin mean nanmean type table ' +
         'readtable writetable sortrows sort figure plot plot3 scatter scatter3 cellfun ' +
         'legend intersect ismember procrustes hold num2cell '

--- a/src/languages/n1ql.js
+++ b/src/languages/n1ql.js
@@ -52,14 +52,12 @@ export default function(hljs) {
           {
             className: 'string',
             begin: '\'', end: '\'',
-            contains: [hljs.BACKSLASH_ESCAPE],
-            relevance: 0
+            contains: [hljs.BACKSLASH_ESCAPE]
           },
           {
             className: 'string',
             begin: '"', end: '"',
-            contains: [hljs.BACKSLASH_ESCAPE],
-            relevance: 0
+            contains: [hljs.BACKSLASH_ESCAPE]
           },
           {
             className: 'symbol',

--- a/src/languages/ocaml.js
+++ b/src/languages/ocaml.js
@@ -73,7 +73,7 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        begin: /[-=]>/ // relevance booster
+        begin: /->/ // relevance booster
       }
     ]
   }

--- a/src/languages/perl.js
+++ b/src/languages/perl.js
@@ -5,6 +5,9 @@ Website: https://www.perl.org
 Category: common
 */
 
+import * as regex from '../lib/regex.js';
+
+/** @type LanguageFn */
 export default function(hljs) {
   var PERL_KEYWORDS = {
     $pattern: /[\w.]+/,
@@ -40,7 +43,12 @@ export default function(hljs) {
   var VAR = {
     variants: [
       {begin: /\$\d/},
-      {begin: /[$%@](\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/},
+      {begin: regex.concat(
+        /[$%@](\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,
+        // negative look-ahead tries to avoid matching patterns that are not
+        // Perl at all like $ident$, @ident@, etc.
+        `(?![A-Za-z])(?![@$%])`
+        )},
       {begin: /[$%@][^\s\w{]/, relevance: 0}
     ]
   };

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -13,7 +13,10 @@ Category: common
 export default function(hljs) {
   const VARIABLE = {
     className: 'variable',
-    begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' + `(?![A-Za-z0-9])(?![$])`
+    begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
+      // negative look-ahead tries to avoid matching patterns that are not
+      // Perl at all like $ident$, @ident@, etc.
+      `(?![A-Za-z0-9])(?![$])`
   };
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -71,7 +71,11 @@ export default function(hljs) {
     // Other keywords:
     // <https://www.php.net/manual/en/reserved.php>
     // <https://www.php.net/manual/en/language.types.type-juggling.php>
-    'array abstract and as binary bool boolean break callable case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends final finally float for foreach from global goto if implements instanceof insteadof int integer interface isset iterable list match new object or private protected public real return string switch throw trait try unset use var void while xor yield',
+    'array abstract and as binary bool boolean break callable case catch class clone const continue declare ' +
+    'default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends ' +
+    'final finally float for foreach from global goto if implements instanceof insteadof int integer interface ' +
+    'isset iterable list match|0 new object or private protected public real return string switch throw trait ' +
+    'try unset use var void while xor yield',
     literal: 'false null true',
     built_in:
     // Standard PHP library:
@@ -123,10 +127,14 @@ export default function(hljs) {
       },
       {
         className: 'function',
+        relevance: 0,
         beginKeywords: 'fn function', end: /[;{]/, excludeEnd: true,
         illegal: '[$%\\[]',
         contains: [
           hljs.UNDERSCORE_TITLE_MODE,
+          {
+            begin: '=>' // No markup, just a relevance booster
+          },
           {
             className: 'params',
             begin: '\\(', end: '\\)',
@@ -145,7 +153,10 @@ export default function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'class interface', end: /\{/, excludeEnd: true,
+        beginKeywords: 'class interface',
+        relevance: 0,
+        end: /\{/,
+        excludeEnd: true,
         illegal: /[:($"]/,
         contains: [
           {beginKeywords: 'extends implements'},
@@ -153,16 +164,17 @@ export default function(hljs) {
         ]
       },
       {
-        beginKeywords: 'namespace', end: ';',
+        beginKeywords: 'namespace',
+        relevance: 0,
+        end: ';',
         illegal: /[.']/,
         contains: [hljs.UNDERSCORE_TITLE_MODE]
       },
       {
-        beginKeywords: 'use', end: ';',
+        beginKeywords: 'use',
+        relevance: 0,
+        end: ';',
         contains: [hljs.UNDERSCORE_TITLE_MODE]
-      },
-      {
-        begin: '=>' // No markup, just a relevance booster
       },
       STRING,
       NUMBER

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -13,7 +13,7 @@ Category: common
 export default function(hljs) {
   const VARIABLE = {
     className: 'variable',
-    begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
+    begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' + `(?![A-Za-z0-9])(?![$])`
   };
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/properties.js
+++ b/src/languages/properties.js
@@ -11,7 +11,9 @@ export default function(hljs) {
   var WS0 = '[ \\t\\f]*';
   var WS1 = '[ \\t\\f]+';
   // delimiter
-  var DELIM = '(' + WS0+'[:=]'+WS0+ '|' + WS1 + ')';
+  var EQUAL_DELIM = WS0+'[:=]'+WS0;
+  var WS_DELIM = WS1;
+  var DELIM = '(' + EQUAL_DELIM + '|' + WS_DELIM + ')';
   var KEY_ALPHANUM = '([^\\\\\\W:= \\t\\f\\n]|\\\\.)+';
   var KEY_OTHER = '([^\\\\:= \\t\\f\\n]|\\\\.)+';
 
@@ -39,8 +41,11 @@ export default function(hljs) {
       // key: everything until whitespace or = or : (taking into account backslashes)
       // case of a "normal" key
       {
-        begin: KEY_ALPHANUM + DELIM,
         returnBegin: true,
+        variants: [
+          { begin: KEY_ALPHANUM + EQUAL_DELIM, relevance: 1 },
+          { begin: KEY_ALPHANUM + WS_DELIM, relevance: 0 }
+        ],
         contains: [
           {
             className: 'attr',

--- a/src/languages/protobuf.js
+++ b/src/languages/protobuf.js
@@ -36,9 +36,9 @@ export default function(hljs) {
         end: /[{;]/, excludeEnd: true,
         keywords: 'rpc returns'
       },
-      {
-        begin: /^\s*[A-Z_]+/,
-        end: /\s*=/, excludeEnd: true
+      { // match enum items (relevance)
+        // BLAH = ...;
+        begin: /^\s*[A-Z_]+(?=\s*=[^\n]+;$)/
       }
     ]
   };

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -254,6 +254,7 @@ export default function(hljs) {
       NUMBER,
       // eat "if" prior to string so that it won't accidentally be
       // labeled as an f-string as in:
+      { begin: /\bself\b/, }, // very common convention
       { beginKeywords: "if", relevance: 0 },
       STRING,
       hljs.HASH_COMMENT_MODE,

--- a/src/languages/r.js
+++ b/src/languages/r.js
@@ -7,6 +7,8 @@ Website: https://www.r-project.org
 Category: scientific
 */
 
+import * as regex from '../lib/regex.js';
+
 export default function(hljs) {
   // Identifiers in R cannot start with `_`, but they can start with `.` if it
   // is not immediately followed by a digit.
@@ -15,10 +17,13 @@ export default function(hljs) {
   // handled in a separate mode. See `test/markup/r/names.txt` for examples.
   // FIXME: Support Unicode identifiers.
   const IDENT_RE = /(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/;
+  const SIMPLE_IDENT = /[a-zA-Z][a-zA-Z_0-9]*/;
 
   return {
     name: 'R',
 
+    // only in Haskell, not R
+    illegal: /->/,
     keywords: {
       $pattern: IDENT_RE,
       keyword:
@@ -168,7 +173,10 @@ export default function(hljs) {
         begin: '%',
         end: '%'
       },
-
+      // relevance boost for assignment
+      {
+        begin: regex.concat(SIMPLE_IDENT, "\\s+<-\\s+")
+      },
       {
         // escaped identifier
         begin: '`',

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -160,8 +160,10 @@ export default function(hljs) {
     },
     NUMBER,
     {
+      // negative-look forward attemps to prevent false matches like:
+      // @ident@ or $ident$ that might indicate this is not ruby at all
       className: "variable",
-      begin: '(\\$\\W)|((\\$|@@?)(\\w+))' // variables
+      begin: '(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])' + `(?![A-Za-z])(?![@$?'])`
     },
     {
       className: 'params',

--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -116,6 +116,7 @@ export default function(hljs) {
 
   var NAME = {
     className: 'name',
+    relevance: 0,
     begin: SCHEME_IDENT_RE,
     keywords: KEYWORDS
   };

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -156,7 +156,8 @@ export default function(hljs) {
       },
       {
         beginKeywords: 'import', end: /$/,
-        contains: [hljs.C_LINE_COMMENT_MODE, BLOCK_COMMENT]
+        contains: [hljs.C_LINE_COMMENT_MODE, BLOCK_COMMENT],
+        relevance: 0
       }
     ]
   };

--- a/src/languages/vbscript.js
+++ b/src/languages/vbscript.js
@@ -7,7 +7,40 @@ Website: https://en.wikipedia.org/wiki/VBScript
 Category: scripting
 */
 
+import * as regex from '../lib/regex.js';
+
+/** @type LanguageFn */
 export default function(hljs) {
+  const BUILT_IN_FUNCTIONS = ('lcase month vartype instrrev ubound setlocale getobject rgb getref string ' +
+  'weekdayname rnd dateadd monthname now day minute isarray cbool round formatcurrency ' +
+  'conversions csng timevalue second year space abs clng timeserial fixs len asc ' +
+  'isempty maths dateserial atn timer isobject filter weekday datevalue ccur isdate ' +
+  'instr datediff formatdatetime replace isnull right sgn array snumeric log cdbl hex ' +
+  'chr lbound msgbox ucase getlocale cos cdate cbyte rtrim join hour oct typename trim ' +
+  'strcomp int createobject loadpicture tan formatnumber mid ' +
+  'split  cint sin datepart ltrim sqr ' +
+  'time derived eval date formatpercent exp inputbox left ascw ' +
+  'chrw regexp cstr err').split(" ");
+  const BUILT_IN_OBJECTS = [
+    "server",
+    "response",
+    "request",
+    // take no arguments so can be caleld without ()
+    "scriptengine",
+    "scriptenginebuildversion",
+    "scriptengineminorversion",
+    "scriptenginemajorversion"
+  ];
+
+  const BUILT_IN_CALL = {
+    begin: regex.concat(regex.either(...BUILT_IN_FUNCTIONS), "\\s*\\("),
+    // relevance 0 because this is acting as a beginKeywords really
+    relevance:0,
+    keywords: {
+      built_in: BUILT_IN_FUNCTIONS.join(" ")
+    }
+  };
+
   return {
     name: 'VBScript',
     aliases: ['vbs'],
@@ -18,22 +51,13 @@ export default function(hljs) {
         'if then else on error option explicit new private property let get public randomize ' +
         'redim rem select case set stop sub while wend with end to elseif is or xor and not ' +
         'class_initialize class_terminate default preserve in me byval byref step resume goto',
-      built_in:
-        'lcase month vartype instrrev ubound setlocale getobject rgb getref string ' +
-        'weekdayname rnd dateadd monthname now day minute isarray cbool round formatcurrency ' +
-        'conversions csng timevalue second year space abs clng timeserial fixs len asc ' +
-        'isempty maths dateserial atn timer isobject filter weekday datevalue ccur isdate ' +
-        'instr datediff formatdatetime replace isnull right sgn array snumeric log cdbl hex ' +
-        'chr lbound msgbox ucase getlocale cos cdate cbyte rtrim join hour oct typename trim ' +
-        'strcomp int createobject loadpicture tan formatnumber mid scriptenginebuildversion ' +
-        'scriptengine split scriptengineminorversion cint sin datepart ltrim sqr ' +
-        'scriptenginemajorversion time derived eval date formatpercent exp inputbox left ascw ' +
-        'chrw regexp server response request cstr err',
+      built_in: BUILT_IN_OBJECTS.join(" "),
       literal:
         'true false null nothing empty'
     },
     illegal: '//',
     contains: [
+      BUILT_IN_CALL,
       hljs.inherit(hljs.QUOTE_STRING_MODE, {contains: [{begin: '""'}]}),
       hljs.COMMENT(
         /'/,

--- a/src/languages/vbscript.js
+++ b/src/languages/vbscript.js
@@ -25,7 +25,7 @@ export default function(hljs) {
     "server",
     "response",
     "request",
-    // take no arguments so can be caleld without ()
+    // take no arguments so can be called without ()
     "scriptengine",
     "scriptenginebuildversion",
     "scriptengineminorversion",

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -153,7 +153,8 @@ export default function(hljs) {
     // sit isolated from other words
     {
       className: 'number',
-      begin: hljs.C_NUMBER_RE + '\\b'
+      begin: hljs.C_NUMBER_RE + '\\b',
+      relevance: 0
     },
     OBJECT,
     ARRAY,

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -2,7 +2,18 @@ import * as regex from './regex.js';
 import { inherit } from './utils.js';
 
 // keywords that should have no default relevance value
-const COMMON_KEYWORDS = 'of and for in not or if then'.split(' ');
+const COMMON_KEYWORDS = [
+  'of',
+  'and',
+  'for',
+  'in',
+  'not',
+  'or',
+  'if',
+  'then',
+  'parent', // common variable name
+  'list' // common variable name
+];
 
 // compilation
 

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -12,7 +12,8 @@ const COMMON_KEYWORDS = [
   'if',
   'then',
   'parent', // common variable name
-  'list' // common variable name
+  'list', // common variable name
+  'value' // common variable name
 ];
 
 // compilation

--- a/test/detect/csharp/default.txt
+++ b/test/detect/csharp/default.txt
@@ -9,6 +9,7 @@ namespace MyApplication
     {
         public static List<int> JustDoIt(int count)
         {
+            Span<int> numbers = stackalloc int[length];
             Console.WriteLine($"Hello {Name}!");
             return new List<int>(new int[] { 1, 2, 3 })
         }

--- a/test/markup/pgsql/dollar_strings.expect.txt
+++ b/test/markup/pgsql/dollar_strings.expect.txt
@@ -1,9 +1,9 @@
 <span class="hljs-keyword">CREATE</span> <span class="hljs-keyword">OR REPLACE</span> <span class="hljs-keyword">FUNCTION</span> hello_world(param_your_name <span class="hljs-type">text</span>)
 <span class="hljs-keyword">RETURNS</span> <span class="hljs-type">text</span> <span class="hljs-keyword">AS</span>
-$$<span class="ruby">
-SELECT <span class="hljs-string">&#x27;Hello world. My name is &#x27;</span> <span class="hljs-params">||</span> param_your_name <span class="hljs-params">||</span> <span class="hljs-string">&#x27;.&#x27;</span>;
+$$<span class="pgsql">
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">&#x27;Hello world. My name is &#x27;</span> || param_your_name || <span class="hljs-string">&#x27;.&#x27;</span>;
 $$</span>
 <span class="hljs-keyword">language</span> <span class="hljs-keyword">sql</span> <span class="hljs-keyword">STRICT</span>;
 
-<span class="hljs-keyword">SELECT</span> sql_expression($sql$<span class="ruby">SELECT hello_world($phrase$Regina<span class="hljs-string">&#x27;s elephant&#x27;</span>s dog$phrase$)
-    <span class="hljs-params">||</span> $phrase$ I made a cat<span class="hljs-string">&#x27;s meow today.$phrase$ $sql$</span></span>);
+<span class="hljs-keyword">SELECT</span> sql_expression($sql$<span class="tcl">SELECT hello_world($phrase$Regina&#x27;s elephant&#x27;s dog$phrase$)
+    || $phrase$ I made a cat&#x27;s meow today.$phrase$ $sql$</span>);


### PR DESCRIPTION
These changes were made using a modified test suite from https://github.com/andreasjansson/language-detection.el

Before:

```
67% correct. 80% first or second correct.
```

After: 

```
72% detection is correct.  84% first OR second detected language is correct.
```

So a 4-5% measurable improvement and there are probably also additional improvements "hidden" as in matches that are still not correct, but likely to be better than they were before - though that's a hard one to measure. (it's very hard to tell the difference between Lisp-like languages, etc)

There were a few common areas of focus:

- Removing incorrect `illegal` to allow auto-detect to work for languages that were being flagged as illegal
- Remove double scoring element of many `beginKeywords `rules... I'm wondering if this shouldn't be done at the parser level itself.
- Add illegal in a few places to make false positives less likely.
- Increase match precision of some rules (also guard against false positives)
- Reduce relevancy of rules that could potentially match almost anything (name rules for Lisp like languages, `||` in Ruby matching params when it could be OR or a concat operator in SQL, etc...)