### PR TITLE
fix(js) prevent runaway regex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Language Improvements:
 - fix(javascipt/typescript) `constructor` is now highlighted as a function title (not keyword) (#2727) [Josh Goebel][]
 - fix(c-like) preprocessor directives not detected after else (#2738) [Josh Goebel][]
 - enh(javascript) allow `#` for private class fields (#2701) [Chris Krycho][]
+- fix(js) prevent runaway regex (#2746) [Josh Goebel][]
 - fix(bash) enh(bash) allow nested params (#2731) [Josh Goebel][]
 - fix(python) Fix highlighting of keywords and strings (#2713, #2715) [Konrad Rudolph][]
 - fix(fsharp) Prevent `(*)` from being detected as a multi-line comment [Josh Goebel][]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -239,7 +239,9 @@ export default function(hljs) {
           regex.lookahead(regex.concat(
             // we also need to allow for multiple possible comments inbetween
             // the first key:value pairing
-            /(((\/\/.*$)|(\/\*(.|\n)*\*\/))\s*)*/,
+            /(\/\/.*$)*/,
+            /(\/\*(.|\n)*\*\/)*/,
+            /\s*/,
             IDENT_RE + '\\s*:'))),
         relevance: 0,
         contains: [


### PR DESCRIPTION
Evidentally detecting a serious of comments one after another can
still lead to a runaway regex when you have a ton of comments in
a large file.

This should still cover most common cases.