### PR TITLE
fix(c/cpp) line continuation in single-line comments

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -289,3 +289,4 @@ Contributors:
 - Jim Mason <jmason@ibinx.com>
 - lioshi <lioshi@lioshi.com>
 - David Pine <david.pine.7@gmail.com>
+- Konrad Rudolph <konrad.rudolph@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Language Improvements:
 
+- fix(cpp) implement backslash line continuation in comments (#2757) [Konrad Rudolph][]
 - fix(cpp) improve parsing issues with templates (#2752) [Josh Goebel][]
 - enh(cpp) add support for `enum (struct|class)` and `union` (#2752) [Josh Goebel][]
 - fix(js/ts) Fix nesting of `{}` inside template literals SUBST expression (#2748) [Josh Goebel][]

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -18,6 +18,9 @@ export default function(hljs) {
   function optional(s) {
     return '(?:' + s + ')?';
   }
+  var C_LINE_COMMENT_MODE = hljs.COMMENT('//', '$', {
+    contains: [{begin: /\\\n/}]
+  });
   var DECLTYPE_AUTO_RE = 'decltype\\(auto\\)'
   var NAMESPACE_RE = '[a-zA-Z_]\\w*::'
   var TEMPLATE_ARGUMENT_RE = '<.*?>';
@@ -80,7 +83,7 @@ export default function(hljs) {
         begin: /<.*?>/, end: /$/,
         illegal: '\\n',
       },
-      hljs.C_LINE_COMMENT_MODE,
+      C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE
     ]
   };
@@ -121,7 +124,7 @@ export default function(hljs) {
   var EXPRESSION_CONTAINS = [
     PREPROCESSOR,
     CPP_PRIMITIVE_TYPES,
-    hljs.C_LINE_COMMENT_MODE,
+    C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,
     NUMBERS,
     STRINGS
@@ -173,7 +176,7 @@ export default function(hljs) {
         keywords: CPP_KEYWORDS,
         relevance: 0,
         contains: [
-          hljs.C_LINE_COMMENT_MODE,
+          C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE,
           STRINGS,
           NUMBERS,
@@ -185,7 +188,7 @@ export default function(hljs) {
             relevance: 0,
             contains: [
               'self',
-              hljs.C_LINE_COMMENT_MODE,
+              C_LINE_COMMENT_MODE,
               hljs.C_BLOCK_COMMENT_MODE,
               STRINGS,
               NUMBERS,
@@ -195,7 +198,7 @@ export default function(hljs) {
         ]
       },
       CPP_PRIMITIVE_TYPES,
-      hljs.C_LINE_COMMENT_MODE,
+      C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       PREPROCESSOR
     ]

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -18,6 +18,9 @@ export default function(hljs) {
   function optional(s) {
     return '(?:' + s + ')?';
   }
+  // added for historic reasons because `hljs.C_LINE_COMMENT_MODE` does 
+  // not include such support nor can we be sure all the grammars depending
+  // on it would desire this behavior
   var C_LINE_COMMENT_MODE = hljs.COMMENT('//', '$', {
     contains: [{begin: /\\\n/}]
   });

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -27,3 +27,7 @@
     anotherthing();
 <span class="hljs-meta">#<span class="hljs-meta-keyword">endif</span></span>
 }
+
+<span class="hljs-comment">// this is a continued\
+comment.</span>
+end

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -27,3 +27,7 @@ if (p) {
     anotherthing();
 #endif
 }
+
+// this is a continued\
+comment.
+end


### PR DESCRIPTION
Resolves #2757 

### Changes

Use a custom definition for single-line comments in `c-like` instead of deferring to `hljs.C_LINE_COMMENT_MODE`. The only difference is a new nested mode that eats `\\\n`.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors