### PR TITLE
Ensure git is installed in docker image

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -290,3 +290,4 @@ Contributors:
 - lioshi <lioshi@lioshi.com>
 - David Pine <david.pine.7@gmail.com>
 - Konrad Rudolph <konrad.rudolph@gmail.com>
+- Michael Newton <miken32@github>

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 FROM node:12-slim
 RUN apt-get update -qq \
     && apt-get install --yes --no-install-recommends \
-        nginx \
+        nginx git \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /var/www/html
 COPY package*.json /var/www/html/


### PR DESCRIPTION
The base image was changed from node12 to node12-slim in commit 14e1f65. Git is not included in the node12-slim image, making it impossible to build the test environment:

```
# node tools/build.js -n python
Starting build.
Finished build.
Writing docs files.
Writing demo files.
Writing style files.
Preparing languages.
.
Building highlight.js.
/bin/sh: 1: git: not found
(node:36) UnhandledPromiseRejectionWarning: Error: Command failed: git rev-parse HEAD
/bin/sh: 1: git: not found
```

### Changes
Install `git` with `apt` as part of image setup.

### Checklist
- [x] Added markup tests, or they don't apply here because... (no code changes)
- [x] Updated the changelog at `CHANGES.md` (not needed, changes in commit 14e1f65 were not released)
- [x] Added myself to `AUTHORS.txt`, under Contributors
