### PR TITLE
chore(dev) add theme picker to the developer tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 10.4.0 (work in process)
+
+Dev Improvements:
+
+- chore(dev) add theme picker to the tools/developer tool (#2770) [Josh Goebel][]
+
+[Josh Goebel]: https://github.com/joshgoebel
+
+
 ## Version 10.3.0
 
 Language Improvements:
@@ -38,7 +47,8 @@ Deprecations:
 
 [Chris Krycho]: https://github.com/chriskrycho
 [David Pine]: https://github.com/IEvangelist
-[Josh Goebel]: https://github.com/joshgoebel
+
+
 [Ryan Jonasson]: https://github.com/ryanjonasson
 [Philipp Engel]: https://github.com/interkosmos
 [Konrad Rudolph]: https://github.com/klmr

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -226,8 +226,7 @@
         var editor = $(this).parents('.editor');
         editor.toggleClass('visible-structure');
 
-        localStorage.setItem(key_STRUCTURE,
-          editor.hasClass('visible-structure'));
+        localStorage.setItem(key_STRUCTURE, editor.hasClass('visible-structure'));
       });
     });
 

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -66,6 +66,100 @@
         <button id="update-highlighting">Update highlighting</button>
         <button id="show-structure">Show/hide structure</button>
         Language: <select class="languages"><option value="">(Auto)</option></select>
+        Theme: <select class="theme">
+          <option>default.css</option>
+          <option>a11y-dark.css</option>
+          <option>a11y-light.css</option>
+          <option>agate.css</option>
+          <option>an-old-hope.css</option>
+          <option>androidstudio.css</option>
+          <option>arduino-light.css</option>
+          <option>arta.css</option>
+          <option>ascetic.css</option>
+          <option>atelier-cave-dark.css</option>
+          <option>atelier-cave-light.css</option>
+          <option>atelier-dune-dark.css</option>
+          <option>atelier-dune-light.css</option>
+          <option>atelier-estuary-dark.css</option>
+          <option>atelier-estuary-light.css</option>
+          <option>atelier-forest-dark.css</option>
+          <option>atelier-forest-light.css</option>
+          <option>atelier-heath-dark.css</option>
+          <option>atelier-heath-light.css</option>
+          <option>atelier-lakeside-dark.css</option>
+          <option>atelier-lakeside-light.css</option>
+          <option>atelier-plateau-dark.css</option>
+          <option>atelier-plateau-light.css</option>
+          <option>atelier-savanna-dark.css</option>
+          <option>atelier-savanna-light.css</option>
+          <option>atelier-seaside-dark.css</option>
+          <option>atelier-seaside-light.css</option>
+          <option>atelier-sulphurpool-dark.css</option>
+          <option>atelier-sulphurpool-light.css</option>
+          <option>atom-one-dark-reasonable.css</option>
+          <option>atom-one-dark.css</option>
+          <option>atom-one-light.css</option>
+          <option>brown-paper.css</option>
+          <option>codepen-embed.css</option>
+          <option>color-brewer.css</option>
+          <option>darcula.css</option>
+          <option>dark.css</option>
+          <option>default.css</option>
+          <option>docco.css</option>
+          <option>dracula.css</option>
+          <option>far.css</option>
+          <option>foundation.css</option>
+          <option>github-gist.css</option>
+          <option>github.css</option>
+          <option>gml.css</option>
+          <option>googlecode.css</option>
+          <option>gradient-dark.css</option>
+          <option>grayscale.css</option>
+          <option>gruvbox-dark.css</option>
+          <option>gruvbox-light.css</option>
+          <option>hopscotch.css</option>
+          <option>hybrid.css</option>
+          <option>idea.css</option>
+          <option>ir-black.css</option>
+          <option>isbl-editor-dark.css</option>
+          <option>isbl-editor-light.css</option>
+          <option>kimbie.dark.css</option>
+          <option>kimbie.light.css</option>
+          <option>lightfair.css</option>
+          <option>magula.css</option>
+          <option>mono-blue.css</option>
+          <option>monokai-sublime.css</option>
+          <option>monokai.css</option>
+          <option>night-owl.css</option>
+          <option>nord.css</option>
+          <option>obsidian.css</option>
+          <option>ocean.css</option>
+          <option>paraiso-dark.css</option>
+          <option>paraiso-light.css</option>
+          <option>pojoaque.css</option>
+          <option>purebasic.css</option>
+          <option>qtcreator_dark.css</option>
+          <option>qtcreator_light.css</option>
+          <option>railscasts.css</option>
+          <option>rainbow.css</option>
+          <option>routeros.css</option>
+          <option>school-book.css</option>
+          <option>shades-of-purple.css</option>
+          <option>solarized-dark.css</option>
+          <option>solarized-light.css</option>
+          <option>srcery.css</option>
+          <option>sunburst.css</option>
+          <option>tomorrow-night-blue.css</option>
+          <option>tomorrow-night-bright.css</option>
+          <option>tomorrow-night-eighties.css</option>
+          <option>tomorrow-night.css</option>
+          <option>tomorrow.css</option>
+          <option>vs.css</option>
+          <option>vs2015.css</option>
+          <option>xcode.css</option>
+          <option>xt256.css</option>
+          <option>zenburn.css</option>
+        </select>
       </p>
     </div>
     <div>
@@ -85,11 +179,28 @@
   <script>
     hljs.debugMode();
 
+    function saveSettings() {
+      var editor = $("body .editor");
+      var language = editor.find('.languages').val();
+      var code = editor.find('textarea').val();
+      var theme = $(".theme").val();
+      SourceStore.save({
+        language, code, theme
+      })
+    }
+
     $(document).ready(function() {
       var select = $('.languages');
       hljs.listLanguages().forEach(function(l) {
         select.append('<option>' + l + '</option>');
       });
+
+      $(".theme").change(function(e) {
+        var css = e.target.value;
+        var link = $("link[rel=stylesheet]")[0]
+        link.href = `../src/styles/${css}`
+        localStorage.setItem(key_THEME, css);
+      })
 
       $('.editor button#update-highlighting').click(function(e) {
         var editor = $(this).parents('.editor');
@@ -108,37 +219,56 @@
         editor.find('.rendering_stats').text(rendering_stats);
         editor.find('.rendering_time').text(rendering_time);
         editor.find('output').text(result.value);
-        SourceStore.save(source, language);
+        saveSettings();
       });
 
       $('.editor button#show-structure').click(function(e) {
         var editor = $(this).parents('.editor');
         editor.toggleClass('visible-structure');
+
+        localStorage.setItem(key_STRUCTURE,
+          editor.hasClass('visible-structure'));
       });
     });
 
     var SourceStore;
+    var key_CODE = 'hljs-source';
+    var key_LANGUAGE = 'hljs-lang';
+    var key_THEME = 'hljs-theme';
+    var key_STRUCTURE = 'hljs-structure';
     (function(){
       SourceStore = {
-        save: function(source, lang){
-          localStorage.setItem(key_SOURCE, source);
-          localStorage.setItem(key_LANG, lang);
+        save: function({code, language, theme}){
+          localStorage.setItem(key_CODE, code);
+          localStorage.setItem(key_LANGUAGE, language);
+          localStorage.setItem(key_THEME, theme);
         },
         resolve: function(){
-          return [
-            localStorage.getItem(key_SOURCE),
-            localStorage.getItem(key_LANG)
-          ];
+          let code = localStorage.getItem(key_CODE)
+          if (!code) return null;
+
+          return {
+            code,
+            language: localStorage.getItem(key_LANGUAGE),
+            theme: localStorage.getItem(key_THEME),
+          };
         }
       };
-      var key_SOURCE = 'hljs-source';
-      var key_LANG = 'hljs-lang';
       $(function(){
         var data = SourceStore.resolve();
-        if (data == null) return;
-        $('.editor textarea').val(data[0]);
-        $('.editor .languages').val(data[1]);
-        $('.editor button').click();
+        if (!data) return;
+        $('.editor textarea').val(data.code);
+        $('.editor .languages').val(data.language);
+        $('.theme').val(data.theme);
+        $('.editor button').first().click();
+
+        if (localStorage.getItem(key_STRUCTURE) === "true") {
+          var editor = $('body .editor');
+          editor.toggleClass('visible-structure');
+        }
+
+        var link = $("link[rel=stylesheet]")[0]
+        link.href = `../src/styles/${data.theme}`
       });
     }());
 

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -249,7 +249,7 @@
           return {
             code,
             language: localStorage.getItem(key_LANGUAGE),
-            theme: localStorage.getItem(key_THEME),
+            theme: localStorage.getItem(key_THEME) || 'default.css',
           };
         }
       };


### PR DESCRIPTION
Adds theme picker to tools/developer.html, makes it easier to see how
various themes look when developing/improving language grammars.

### Checklist
- [x] Added markup tests, or they don't apply because this change does not touch grammars...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors