### PR TITLE
WIP: enh(parser) Better regular expression internals highlighting

### DIFF
--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -52,11 +52,11 @@ export default function (hljs) {
   const GROUP_SPECIALS = [
     // Named group
     'P?<[^>]+>',
-    "'['>'+'",
-    // Zero-length assertions
-    '[|>=!]|<=|<!|',
+    "'[^']+'",
+    // Zero-length assertions, branch reset & atomic
+    '[|>=!]|<=|<!',
     // Modifiers applied inside group
-    `${MODIFIERS}:`,
+    `(?:${MODIFIERS}):`,
     ':'
   ];
 

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -65,30 +65,14 @@ export default function (hljs) {
     begin: `\\(\\?(?:${MODIFIERS})\\)`
   };
 
-  let GROUP = {};
-  GROUP = {
-    className: 'group',
-    begin: `\\((?:\\?(?:${GROUP_SPECIALS.join('|')}))?`, end: /\)/,
-    // starts: {
-    //   // begin: /./, end: /\)/,
-    //   // excludeBegin: true,
-    //   contains: [
-    //     ESCAPE_SEQUENCE,
-    //     CHARACTER_CLASS,
-    //     META,
-    //     COMMENT,
-    //     MODIFIER,
-    //     GROUP
-    //   ]
-    // }
-    contains: [
-      ESCAPE_SEQUENCE,
-      CHARACTER_CLASS,
-      META,
-      COMMENT,
-      MODIFIER,
-      'self'
-    ]
+  const GROUP_BEGIN = {
+    className: 'keyword',
+    begin: `\\((?:\\?(?:${GROUP_SPECIALS.join('|')}))?`
+  };
+
+  const GROUP_END = {
+    className: 'keyword',
+    begin: /\)/
   };
 
   return {
@@ -101,7 +85,8 @@ export default function (hljs) {
       META,
       COMMENT,
       MODIFIER,
-      GROUP
+      GROUP_BEGIN,
+      GROUP_END
     ]
   };
 };

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -45,7 +45,7 @@ export default function (hljs) {
     begin: /[.+*?|^$]|\{[^}]+\}/,
   };
 
-  const COMMENT = hljs.COMMENT(/\(#/, /\)/);
+  const COMMENT = hljs.COMMENT(/\(\?#/, /\)/);
 
   const MODIFIERS = '-?(?:[ictsmnpdJUbqX^]|xx?)';
 

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -67,7 +67,15 @@ export default function (hljs) {
 
   const GROUP_BEGIN = {
     className: 'keyword',
-    begin: `\\((?:\\?(?:${GROUP_SPECIALS.join('|')}))?`
+    begin: /\(/,
+    starts: {
+      contains: [
+        {
+          className: 'meta',
+          begin: `\\?(?:${GROUP_SPECIALS.join('|')})`
+        }
+      ]
+    }
   };
 
   const GROUP_END = {

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -78,6 +78,7 @@ export default function (hljs) {
   return {
     name: 'regex',
     aliases: ['re', 'regexp'],
+    disableAutodetect: true,
 
     contains: [
       ESCAPE_SEQUENCE,

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -42,7 +42,7 @@ export default function (hljs) {
 
   const META = {
     className: 'keyword',
-    begin: /[.+*?|^$]|\{[^}]+\}/,
+    begin: /[.+*?|^$]|\{(?:\d+(?:,\d*)?|,\d+)\}/,
   };
 
   const COMMENT = hljs.COMMENT(/\(\?#/, /\)/);

--- a/src/languages/regex.js
+++ b/src/languages/regex.js
@@ -1,0 +1,107 @@
+/*
+Language: regex
+Description: Regular expressions 
+Author: Konrad Rudolph <konrad.rudolph@gmail.com>
+*/
+
+export default function (hljs) {
+  const ESCAPE_SEQUENCE = {
+    className: 'built_in',
+    begin: [
+      // Unicode script/block/category
+      /\\[pP](?:[^{]|\{\^?[^}]+\})/,
+      // Unicode character
+      /\\[ux](?:[0-9a-fA-F]{1,4}|\{[0-9a-fA-F]{1,4}\})/,
+      // Backreferences
+      /\\k(?:'-?\d+'|<-?\d+>|{-?\d+})/,
+      /\\g(?:'-?\d+'|<-?\d+>|{-?\d+}|-?\d+)/,
+      // Everything else
+      /\\./
+    ].map(r => r.source).join('|')
+  };
+
+  const CHARACTER_CLASS = {
+    className: 'string',
+    begin: /\[\^?]?/,
+    end: /]/,
+    contains: [
+      {
+        className: 'literal',
+        variants: [
+          // POSIX named character class.
+          { begin: /\[:\^?/, end: /:]/ },
+          // POSIX collation sequences.
+          { begin: /\[\./, end: /\.]/ },
+          // POSIX character equivalence.
+          { begin: /\[=/, end: /=]/ }
+        ]
+      },
+      ESCAPE_SEQUENCE
+    ]
+  };
+
+  const META = {
+    className: 'keyword',
+    begin: /[.+*?|^$]|\{[^}]+\}/,
+  };
+
+  const COMMENT = hljs.COMMENT(/\(#/, /\)/);
+
+  const MODIFIERS = '-?(?:[ictsmnpdJUbqX^]|xx?)';
+
+  const GROUP_SPECIALS = [
+    // Named group
+    'P?<[^>]+>',
+    "'['>'+'",
+    // Zero-length assertions
+    '[|>=!]|<=|<!|',
+    // Modifiers applied inside group
+    `${MODIFIERS}:`,
+    ':'
+  ];
+
+  const MODIFIER = {
+    className: 'meta',
+    begin: `\\(\\?(?:${MODIFIERS})\\)`
+  };
+
+  let GROUP = {};
+  GROUP = {
+    className: 'group',
+    begin: `\\((?:\\?(?:${GROUP_SPECIALS.join('|')}))?`, end: /\)/,
+    // starts: {
+    //   // begin: /./, end: /\)/,
+    //   // excludeBegin: true,
+    //   contains: [
+    //     ESCAPE_SEQUENCE,
+    //     CHARACTER_CLASS,
+    //     META,
+    //     COMMENT,
+    //     MODIFIER,
+    //     GROUP
+    //   ]
+    // }
+    contains: [
+      ESCAPE_SEQUENCE,
+      CHARACTER_CLASS,
+      META,
+      COMMENT,
+      MODIFIER,
+      'self'
+    ]
+  };
+
+  return {
+    name: 'regex',
+    aliases: ['re', 'regexp'],
+
+    contains: [
+      ESCAPE_SEQUENCE,
+      CHARACTER_CLASS,
+      META,
+      COMMENT,
+      MODIFIER,
+      GROUP
+    ]
+  };
+};


### PR DESCRIPTION
This PR adds a new language definition for regular expressions.

#2751 discusses adding more nuanced regex highlighting as a nested mode to existing languages. By contrast, this PR concerns highlighting regex as a standalone language (though of course it might be worth investigating how to enable it as a nested mode).

Notably, [Stack Overflow used to support syntax highlighting of regular expressions, specifically](https://meta.stackexchange.com/a/184109/1968) but now no longer does.

This is work in progress, and there are some outstanding questions, notably

* What’s the canonical name *vs.* aliases? (At the moment: `regex`; aliases: `re` , `regexp`).
* Which class names to use to highlight individual regex features?
    * The ones I’m currently using are (not necessarily good) suggestions
* How extensive should the highlighting be anyway?
* What regex dialects do we support?
    * My attempt was to capture as many different dialects as possible — PCRE, POSIX and other languages.
* How to implement groups such that parentheses, as well as modifier sequences (`?…` directly after the opening parenthesis) are somehow highlighted? My initial attempt via `starts` didn’t work (commented out code).
* Should character class ranges (e.g. `[0-9A-F]`) be highlighted specially?

### Missing features

I don’t necessarily plan to implement these in this PR unless there’s interest, since they’re fairly esoteric:

* [if-then-else conditionals](https://www.regular-expressions.info/conditional.html) (`(?(re)then|else)` etc.)
* [subroutines](https://www.regular-expressions.info/subroutine.html) (`(?(DEFINE)(?'name're))`, `(?&name)`)
* [free-spacing regex](https://www.regular-expressions.info/freespacing.html) (`x` mode)
* character class set operations (`[class-[sub]]`, `[class&&[intersect]]`, `[class&&intersect]`)
* [escaping via `\Q…\E`](https://www.regular-expressions.info/characters.html#special) (`\Q` and `\E` are currently highlighted as regular escape sequences, the stuff in between gets no special treatment)
* [ASCII escape sequence tokens `\cX` and octal escape sequences](https://www.regular-expressions.info/nonprint.html) (how widespread are these?)
* The lexer does not try to guess if it’s dealing with the basic POSIX dialect, i.e. `|`, `+` etc. are always treated as special, and `\|`, `\+` etc. are always treated as escape sequences

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors