### PR TITLE
add `nim` class for nim (update SUPPORTED_LANGUAGES.md to reflect current behaviour)

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -122,7 +122,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | NSIS                    | nsis                   |         |
 | Never                   | never                  | [highlightjs-never](https://github.com/never-lang/highlightjs-never) |
 | Nginx                   | nginx, nginxconf       |         |
-| Nim                     | nimrod                 |         |
+| Nim                     | nim, nimrod            |         |
 | Nix                     | nix                    |         |
 | Object Constraint Language | ocl                 | [highlightjs-ocl](https://github.com/nhomble/highlightjs-ocl)        |
 | OCaml                   | ocaml, ml              |         |


### PR DESCRIPTION
Nim as class name has been added some time ago, see: https://github.com/highlightjs/highlight.js/commit/0c99483e5bf7e033f906ae65df38ebed8e06d9f4

I guess SUPPORTED_LANGUAGES.md was not updated contextually, this fixes it.

### Changes

add nim as class for Nim language in SUPPORTED_LANGUAGES.md

### Checklist

I think this is just syncing documentation with current behaviour, so I would say none of the stuff below probably applies.

- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
