### PR TITLE
[julia] Update keywords, built_in and literals for julia 1.X.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -292,3 +292,4 @@ Contributors:
 - Konrad Rudolph <konrad.rudolph@gmail.com>
 - Tom Wallace <thomasmichaelwallace@gmail.com>
 - Michael Newton <miken32@github>
+- Fredrik Ekre <ekrefredrik@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,15 @@
 ## Version 10.4.0 (work in process)
 
+Language Improvements:
+
+- enh(julia) Update keyword lists for Julia 1.X (#2781) [Fredrik Ekre][]
+
 Dev Improvements:
 
 - chore(dev) add theme picker to the tools/developer tool (#2770) [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/joshgoebel
+[Fredrik Ekre]: https://github.com/fredrikekre
 
 
 ## Version 10.3.1

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -2,87 +2,330 @@
 Language: Julia
 Description: Julia is a high-level, high-performance, dynamic programming language.
 Author: Kenta Sato <bicycle1885@gmail.com>
-Contributors: Alex Arslan <ararslan@comcast.net>
+Contributors: Alex Arslan <ararslan@comcast.net>, Fredrik Ekre <ekrefredrik@gmail.com>
 Website: https://julialang.org
 */
 
 export default function(hljs) {
   // Since there are numerous special names in Julia, it is too much trouble
   // to maintain them by hand. Hence these names (i.e. keywords, literals and
-  // built-ins) are automatically generated from Julia v0.6 itself through
+  // built-ins) are automatically generated from Julia 1.5.2 itself through
   // the following scripts for each.
 
-  // ref: http://julia.readthedocs.org/en/latest/manual/variables/#allowed-variable-names
+  // ref: https://docs.julialang.org/en/v1/manual/variables/#Allowed-Variable-Names
   var VARIABLE_NAME_RE = '[A-Za-z_\\u00A1-\\uFFFF][A-Za-z_0-9\\u00A1-\\uFFFF]*';
+
+  // # keyword generator, multi-word keywords handled manually below (Julia 1.5.2)
+  // import REPL.REPLCompletions
+  // res = String["in", "isa", "where"]
+  // for kw in collect(x.keyword for x in REPLCompletions.complete_keyword(""))
+  //     if !(contains(kw, " ") || kw == "struct")
+  //         push!(res, kw)
+  //     end
+  // end
+  // sort!(unique!(res))
+  // foreach(x -> println("\'", x, "\',"), res)
+  var KEYWORD_LIST = [
+    'baremodule',
+    'begin',
+    'break',
+    'catch',
+    'ccall',
+    'const',
+    'continue',
+    'do',
+    'else',
+    'elseif',
+    'end',
+    'export',
+    'false',
+    'finally',
+    'for',
+    'function',
+    'global',
+    'if',
+    'import',
+    'in',
+    'isa',
+    'let',
+    'local',
+    'macro',
+    'module',
+    'quote',
+    'return',
+    'true',
+    'try',
+    'using',
+    'where',
+    'while',
+  ]
+
+  // # literal generator (Julia 1.5.2)
+  // import REPL.REPLCompletions
+  // res = String["true", "false"]
+  // for compl in filter!(x -> isa(x, REPLCompletions.ModuleCompletion) && (x.parent === Base || x.parent === Core),
+  //                     REPLCompletions.completions("", 0)[1])
+  //     try
+  //         v = eval(Symbol(compl.mod))
+  //         if !(v isa Function || v isa Type || v isa TypeVar || v isa Module || v isa Colon)
+  //             push!(res, compl.mod)
+  //         end
+  //     catch e
+  //     end
+  // end
+  // sort!(unique!(res))
+  // foreach(x -> println("\'", x, "\',"), res)
+  var LITERAL_LIST = [
+    'ARGS',
+    'C_NULL',
+    'DEPOT_PATH',
+    'ENDIAN_BOM',
+    'ENV',
+    'Inf',
+    'Inf16',
+    'Inf32',
+    'Inf64',
+    'InsertionSort',
+    'LOAD_PATH',
+    'MergeSort',
+    'NaN',
+    'NaN16',
+    'NaN32',
+    'NaN64',
+    'PROGRAM_FILE',
+    'QuickSort',
+    'RoundDown',
+    'RoundFromZero',
+    'RoundNearest',
+    'RoundNearestTiesAway',
+    'RoundNearestTiesUp',
+    'RoundToZero',
+    'RoundUp',
+    'VERSION|0',
+    'devnull',
+    'false',
+    'im',
+    'missing',
+    'nothing',
+    'pi',
+    'stderr',
+    'stdin',
+    'stdout',
+    'true',
+    'undef',
+    'π',
+    'ℯ',
+  ]
+
+  // # built_in generator (Julia 1.5.2)
+  // import REPL.REPLCompletions
+  // res = String[]
+  // for compl in filter!(x -> isa(x, REPLCompletions.ModuleCompletion) && (x.parent === Base || x.parent === Core),
+  //                     REPLCompletions.completions("", 0)[1])
+  //     try
+  //         v = eval(Symbol(compl.mod))
+  //         if (v isa Type || v isa TypeVar) && (compl.mod != "=>")
+  //             push!(res, compl.mod)
+  //         end
+  //     catch e
+  //     end
+  // end
+  // sort!(unique!(res))
+  // foreach(x -> println("\'", x, "\',"), res)
+  var BUILT_IN_LIST = [
+    'AbstractArray',
+    'AbstractChannel',
+    'AbstractChar',
+    'AbstractDict',
+    'AbstractDisplay',
+    'AbstractFloat',
+    'AbstractIrrational',
+    'AbstractMatrix',
+    'AbstractRange',
+    'AbstractSet',
+    'AbstractString',
+    'AbstractUnitRange',
+    'AbstractVecOrMat',
+    'AbstractVector',
+    'Any',
+    'ArgumentError',
+    'Array',
+    'AssertionError',
+    'BigFloat',
+    'BigInt',
+    'BitArray',
+    'BitMatrix',
+    'BitSet',
+    'BitVector',
+    'Bool',
+    'BoundsError',
+    'CapturedException',
+    'CartesianIndex',
+    'CartesianIndices',
+    'Cchar',
+    'Cdouble',
+    'Cfloat',
+    'Channel',
+    'Char',
+    'Cint',
+    'Cintmax_t',
+    'Clong',
+    'Clonglong',
+    'Cmd',
+    'Colon',
+    'Complex',
+    'ComplexF16',
+    'ComplexF32',
+    'ComplexF64',
+    'CompositeException',
+    'Condition',
+    'Cptrdiff_t',
+    'Cshort',
+    'Csize_t',
+    'Cssize_t',
+    'Cstring',
+    'Cuchar',
+    'Cuint',
+    'Cuintmax_t',
+    'Culong',
+    'Culonglong',
+    'Cushort',
+    'Cvoid',
+    'Cwchar_t',
+    'Cwstring',
+    'DataType',
+    'DenseArray',
+    'DenseMatrix',
+    'DenseVecOrMat',
+    'DenseVector',
+    'Dict',
+    'DimensionMismatch',
+    'Dims',
+    'DivideError',
+    'DomainError',
+    'EOFError',
+    'Enum',
+    'ErrorException',
+    'Exception',
+    'ExponentialBackOff',
+    'Expr',
+    'Float16',
+    'Float32',
+    'Float64',
+    'Function',
+    'GlobalRef',
+    'HTML',
+    'IO',
+    'IOBuffer',
+    'IOContext',
+    'IOStream',
+    'IdDict',
+    'IndexCartesian',
+    'IndexLinear',
+    'IndexStyle',
+    'InexactError',
+    'InitError',
+    'Int',
+    'Int128',
+    'Int16',
+    'Int32',
+    'Int64',
+    'Int8',
+    'Integer',
+    'InterruptException',
+    'InvalidStateException',
+    'Irrational',
+    'KeyError',
+    'LinRange',
+    'LineNumberNode',
+    'LinearIndices',
+    'LoadError',
+    'MIME',
+    'Matrix',
+    'Method',
+    'MethodError',
+    'Missing',
+    'MissingException',
+    'Module',
+    'NTuple',
+    'NamedTuple',
+    'Nothing',
+    'Number',
+    'OrdinalRange',
+    'OutOfMemoryError',
+    'OverflowError',
+    'Pair',
+    'PartialQuickSort',
+    'PermutedDimsArray',
+    'Pipe',
+    'ProcessFailedException',
+    'Ptr',
+    'QuoteNode',
+    'Rational',
+    'RawFD',
+    'ReadOnlyMemoryError',
+    'Real',
+    'ReentrantLock',
+    'Ref',
+    'Regex',
+    'RegexMatch',
+    'RoundingMode',
+    'SegmentationFault',
+    'Set',
+    'Signed',
+    'Some',
+    'StackOverflowError',
+    'StepRange',
+    'StepRangeLen',
+    'StridedArray',
+    'StridedMatrix',
+    'StridedVecOrMat',
+    'StridedVector',
+    'String',
+    'StringIndexError',
+    'SubArray',
+    'SubString',
+    'SubstitutionString',
+    'Symbol',
+    'SystemError',
+    'Task',
+    'TaskFailedException',
+    'Text',
+    'TextDisplay',
+    'Timer',
+    'Tuple',
+    'Type',
+    'TypeError',
+    'TypeVar',
+    'UInt',
+    'UInt128',
+    'UInt16',
+    'UInt32',
+    'UInt64',
+    'UInt8',
+    'UndefInitializer',
+    'UndefKeywordError',
+    'UndefRefError',
+    'UndefVarError',
+    'Union',
+    'UnionAll',
+    'UnitRange',
+    'Unsigned',
+    'Val',
+    'Vararg',
+    'VecElement',
+    'VecOrMat',
+    'Vector',
+    'VersionNumber',
+    'WeakKeyDict',
+    'WeakRef',
+  ]
 
   var KEYWORDS = {
     $pattern: VARIABLE_NAME_RE,
-    // # keyword generator, multi-word keywords handled manually below
-    // foreach(println, ["in", "isa", "where"])
-    // for kw in Base.REPLCompletions.complete_keyword("")
-    //     if !(contains(kw, " ") || kw == "struct")
-    //         println(kw)
-    //     end
-    // end
-    keyword:
-      'in isa where ' +
-      'baremodule begin break catch ccall const continue do else elseif end export false finally for function ' +
-      'global if import importall let local macro module quote return true try using while ' +
-      // legacy, to be deprecated in the next release
-      'type immutable abstract bitstype typealias ',
-
-    // # literal generator
-    // println("true")
-    // println("false")
-    // for name in Base.REPLCompletions.completions("", 0)[1]
-    //     try
-    //         v = eval(Symbol(name))
-    //         if !(v isa Function || v isa Type || v isa TypeVar || v isa Module || v isa Colon)
-    //             println(name)
-    //         end
-    //     end
-    // end
-    literal:
-      'true false ' +
-      'ARGS C_NULL DevNull ENDIAN_BOM ENV I Inf Inf16 Inf32 Inf64 InsertionSort JULIA_HOME LOAD_PATH MergeSort ' +
-      'NaN NaN16 NaN32 NaN64 PROGRAM_FILE QuickSort RoundDown RoundFromZero RoundNearest RoundNearestTiesAway ' +
-      'RoundNearestTiesUp RoundToZero RoundUp STDERR STDIN STDOUT VERSION catalan e|0 eu|0 eulergamma golden im ' +
-      'nothing pi γ π φ ',
-
-    // # built_in generator:
-    // for name in Base.REPLCompletions.completions("", 0)[1]
-    //     try
-    //         v = eval(Symbol(name))
-    //         if v isa Type || v isa TypeVar
-    //             println(name)
-    //         end
-    //     end
-    // end
-    built_in:
-      'ANY AbstractArray AbstractChannel AbstractFloat AbstractMatrix AbstractRNG AbstractSerializer AbstractSet ' +
-      'AbstractSparseArray AbstractSparseMatrix AbstractSparseVector AbstractString AbstractUnitRange AbstractVecOrMat ' +
-      'AbstractVector Any ArgumentError Array AssertionError Associative Base64DecodePipe Base64EncodePipe Bidiagonal '+
-      'BigFloat BigInt BitArray BitMatrix BitVector Bool BoundsError BufferStream CachingPool CapturedException ' +
-      'CartesianIndex CartesianRange Cchar Cdouble Cfloat Channel Char Cint Cintmax_t Clong Clonglong ClusterManager ' +
-      'Cmd CodeInfo Colon Complex Complex128 Complex32 Complex64 CompositeException Condition ConjArray ConjMatrix ' +
-      'ConjVector Cptrdiff_t Cshort Csize_t Cssize_t Cstring Cuchar Cuint Cuintmax_t Culong Culonglong Cushort Cwchar_t ' +
-      'Cwstring DataType Date DateFormat DateTime DenseArray DenseMatrix DenseVecOrMat DenseVector Diagonal Dict ' +
-      'DimensionMismatch Dims DirectIndexString Display DivideError DomainError EOFError EachLine Enum Enumerate ' +
-      'ErrorException Exception ExponentialBackOff Expr Factorization FileMonitor Float16 Float32 Float64 Function ' +
-      'Future GlobalRef GotoNode HTML Hermitian IO IOBuffer IOContext IOStream IPAddr IPv4 IPv6 IndexCartesian IndexLinear ' +
-      'IndexStyle InexactError InitError Int Int128 Int16 Int32 Int64 Int8 IntSet Integer InterruptException ' +
-      'InvalidStateException Irrational KeyError LabelNode LinSpace LineNumberNode LoadError LowerTriangular MIME Matrix ' +
-      'MersenneTwister Method MethodError MethodTable Module NTuple NewvarNode NullException Nullable Number ObjectIdDict ' +
-      'OrdinalRange OutOfMemoryError OverflowError Pair ParseError PartialQuickSort PermutedDimsArray Pipe ' +
-      'PollingFileWatcher ProcessExitedException Ptr QuoteNode RandomDevice Range RangeIndex Rational RawFD ' +
-      'ReadOnlyMemoryError Real ReentrantLock Ref Regex RegexMatch RemoteChannel RemoteException RevString RoundingMode ' +
-      'RowVector SSAValue SegmentationFault SerializationState Set SharedArray SharedMatrix SharedVector Signed ' +
-      'SimpleVector Slot SlotNumber SparseMatrixCSC SparseVector StackFrame StackOverflowError StackTrace StepRange ' +
-      'StepRangeLen StridedArray StridedMatrix StridedVecOrMat StridedVector String SubArray SubString SymTridiagonal ' +
-      'Symbol Symmetric SystemError TCPSocket Task Text TextDisplay Timer Tridiagonal Tuple Type TypeError TypeMapEntry ' +
-      'TypeMapLevel TypeName TypeVar TypedSlot UDPSocket UInt UInt128 UInt16 UInt32 UInt64 UInt8 UndefRefError UndefVarError ' +
-      'UnicodeError UniformScaling Union UnionAll UnitRange Unsigned UpperTriangular Val Vararg VecElement VecOrMat Vector ' +
-      'VersionNumber Void WeakKeyDict WeakRef WorkerConfig WorkerPool '
+    keyword: KEYWORD_LIST.join(" "),
+    literal: LITERAL_LIST.join(" "),
+    built_in: BUILT_IN_LIST.join(" "),
   };
 
   // placeholder for recursive self-reference
@@ -90,7 +333,7 @@ export default function(hljs) {
     keywords: KEYWORDS, illegal: /<\//
   };
 
-  // ref: http://julia.readthedocs.org/en/latest/manual/integers-and-floating-point-numbers/
+  // ref: https://docs.julialang.org/en/v1/manual/integers-and-floating-point-numbers/
   var NUMBER = {
     className: 'number',
     // supported numeric literals:

--- a/test/detect/julia/default.txt
+++ b/test/detect/julia/default.txt
@@ -1,21 +1,5 @@
 ### Types
 
-# Old-style definitions
-
-immutable Point{T<:AbstractFloat}
-    index::Int
-    x::T
-    y::T
-end
-
-abstract A
-
-type B <: A end
-
-typealias P Point{Float16}
-
-# New-style definitions
-
 struct Plus
     f::typeof(+)
 end
@@ -35,7 +19,6 @@ module M
 
 using X
 import Y
-importall Z
 
 export a, b, c
 
@@ -44,7 +27,21 @@ end # module
 baremodule Bare
 end
 
-### New in 0.6
+
+### Miscellaneous
+
+# Some things new for Julia >1.0
+function f(x::Union{String,Missing,Nothing}, y::Tuple{Float64,ComplexF64})
+    if x === nothing
+        println(devnull, "nothing")
+    elseif x === missing
+        println(stderr, "missing")
+    else
+        println(stdout, x)
+    end
+end
+
+f(x::UndefInitializer = undef) = Regex("^hello, world\$")
 
 # where, infix isa, UnionAll
 function F{T}(x::T) where T
@@ -52,8 +49,6 @@ function F{T}(x::T) where T
         i isa UnionAll && return
     end
 end
-
-### Miscellaneous
 
 #=
 Multi


### PR DESCRIPTION
### Changes

This updates the lists of `keyword`, `built_in` and `literal` for Julia 1.X. Julia 1.X was released over 2 years ago so (IMO) it should be safe to remove the old tokens that are not applicable any more, but I don't know what your policy is for such things.

### Checklist
- [x] Tests: I did not find any tests for Julia syntax and adding this is beyond my capabilities (Edit: found this https://github.com/highlightjs/highlight.js/blob/master/test/detect/julia/default.txt so I will update that).
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
