### PR TITLE
enh(ruby) add support for real, imaginary, and e-notation numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Dev Improvements:
 
 - chore(dev) add theme picker to the tools/developer tool (#2770) [Josh Goebel][]
+- fix(ruby) add support for expontential, real, and imaginary notation (#2766) [Kevin Hamer][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -128,7 +128,7 @@ export default function(hljs) {
     },
     {
       className: 'number',
-      begin: '(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b',
+      begin: '(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?([ri]|[eE][-+]?[0-9_]+i?)?)|[0_]\\b',
       relevance: 0
     },
     {

--- a/test/markup/ruby/numbers.expect.txt
+++ b/test/markup/ruby/numbers.expect.txt
@@ -1,0 +1,3 @@
+number = <span class="hljs-number">1.0e1_2</span>
+number = <span class="hljs-number">1.0e1_2i</span>
+number = <span class="hljs-number">1.0r</span>

--- a/test/markup/ruby/numbers.txt
+++ b/test/markup/ruby/numbers.txt
@@ -1,0 +1,3 @@
+number = 1.0e1_2
+number = 1.0e1_2i
+number = 1.0r


### PR DESCRIPTION
Changes to regex for matching numbers in ruby. Resolves #2766.

### Changes
Changes the number regex for ruby to support exponential notation (1e123) as well as adding a trailing `r` or `i` - for real or imaginary numbers.

### Checklist
- [x] Added new markup/ruby/numbers.txt tests
- [x] Added a note to the changelog
- [x] Added myself to `AUTHORS.txt` under Contributors