### PR TITLE
enh(javascript) Match numeric literals per ECMA-262 spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Language Improvements:
 - enh(julia) Update keyword lists for Julia 1.x (#2781) [Fredrik Ekre][]
 - enh(python) Match numeric literals per the language reference [Richard Gibson][]
 - enh(ruby) Match numeric literals per language documentation [Richard Gibson][]
+- enh(javascript) Match numeric literals per ECMA-262 spec [Richard Gibson][]
 
 Dev Improvements:
 

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -63,29 +63,36 @@ export default function(hljs) {
     literal: ECMAScript.LITERALS.join(" "),
     built_in: ECMAScript.BUILT_INS.join(" ")
   };
-  const nonDecimalLiterals = (prefixLetters, validChars) =>
-    `\\b0[${prefixLetters}][${validChars}]([${validChars}_]*[${validChars}])?n?`;
-  const noLeadingZeroDecimalDigits = /[1-9]([0-9_]*\d)?/;
-  const decimalDigits = /\d([0-9_]*\d)?/;
-  const exponentPart = regex.concat(/[eE][+-]?/, decimalDigits);
+
+  // https://tc39.es/ecma262/#sec-literals-numeric-literals
+  const decimalDigits = '[0-9](_?[0-9])*';
+  const frac = `\\.(${decimalDigits})`;
+  // DecimalIntegerLiteral, including Annex B NonOctalDecimalIntegerLiteral
+  // https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
+  const decimalInteger = `0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*`;
   const NUMBER = {
     className: 'number',
     variants: [
-      { begin: nonDecimalLiterals('bB', '01') }, // Binary literals
-      { begin: nonDecimalLiterals('oO', '0-7') }, // Octal literals
-      { begin: nonDecimalLiterals('xX', '0-9a-fA-F') }, // Hexadecimal literals
-      { begin: regex.concat(/\b/, noLeadingZeroDecimalDigits, 'n') }, // Non-zero BigInt literals
-      { begin: regex.concat(/(\b0)?\./, decimalDigits, regex.optional(exponentPart)) }, // Decimal literals between 0 and 1
-      { begin: regex.concat(
-        /\b/,
-        noLeadingZeroDecimalDigits,
-        regex.optional(regex.concat(/\./, regex.optional(decimalDigits))), // fractional part
-        regex.optional(exponentPart)
-        ) }, // Decimal literals >= 1
-      { begin: /\b0[\.n]?/ }, // Zero literals (`0`, `0.`, `0n`)
+      // DecimalLiteral
+      { begin: `(\\b(${decimalInteger})((${frac})|\\.)?|(${frac}))` +
+        `[eE][+-]?(${decimalDigits})\\b` },
+      { begin: `\\b(${decimalInteger})\\b((${frac})\\b|\\.)?|(${frac})\\b` },
+
+      // DecimalBigIntegerLiteral
+      { begin: `\\b(0|[1-9](_?[0-9])*)n\\b` },
+
+      // NonDecimalIntegerLiteral
+      { begin: "\\b0[bB][0-1](_?[0-1])*n?\\b" },
+      { begin: "\\b0[oO][0-7](_?[0-7])*n?\\b" },
+      { begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b" },
+
+      // LegacyOctalIntegerLiteral (does not include underscore separators)
+      // https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
+      { begin: "\\b0[0-7]+n?\\b" },
     ],
     relevance: 0
   };
+
   const SUBST = {
     className: 'subst',
     begin: '\\$\\{',

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -82,9 +82,9 @@ export default function(hljs) {
       { begin: `\\b(0|[1-9](_?[0-9])*)n\\b` },
 
       // NonDecimalIntegerLiteral
+      { begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b" },
       { begin: "\\b0[bB][0-1](_?[0-1])*n?\\b" },
       { begin: "\\b0[oO][0-7](_?[0-7])*n?\\b" },
-      { begin: "\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b" },
 
       // LegacyOctalIntegerLiteral (does not include underscore separators)
       // https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals

--- a/test/markup/javascript/numbers.expect.txt
+++ b/test/markup/javascript/numbers.expect.txt
@@ -22,6 +22,12 @@
 -<span class="hljs-number">.000_001</span> <span class="hljs-comment">// 1 millionth</span>
 <span class="hljs-number">1e10_000</span>  <span class="hljs-comment">// 10^10000 -- granted, far less useful / in-range...</span>
 
+<span class="hljs-number">.0</span>, <span class="hljs-number">.00</span>,  <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">40.0</span>,  <span class="hljs-number">0.</span>, <span class="hljs-number">10.</span>
+<span class="hljs-number">.0</span>, <span class="hljs-number">.0_0</span>, <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">4_0.0</span>, <span class="hljs-number">0.</span>, <span class="hljs-number">1_0.</span>
+
+<span class="hljs-number">.0e10</span>,  <span class="hljs-number">.00e+10</span>,  <span class="hljs-number">.9e-10</span>,  <span class="hljs-number">4.2E10</span>,  <span class="hljs-number">40.0E+08</span>,   <span class="hljs-number">0.E-10</span>,  <span class="hljs-number">0.e100</span>,   <span class="hljs-number">1010e+10</span>
+<span class="hljs-number">.0e1_0</span>, <span class="hljs-number">.0_0e+10</span>, <span class="hljs-number">.9e-1_0</span>, <span class="hljs-number">4.2E1_0</span>, <span class="hljs-number">4_0.0E+0_8</span>, <span class="hljs-number">0.E-1_0</span>, <span class="hljs-number">0.e1_0_0</span>, <span class="hljs-number">10_10e+10</span>
+
 <span class="hljs-keyword">let</span> nibbles = <span class="hljs-number">0b1010_0001_1000_0101</span>;
 <span class="hljs-keyword">let</span> message = <span class="hljs-number">0xA0_B0_C0</span>;
 
@@ -48,3 +54,24 @@
 <span class="hljs-number">2_0_0n</span>
 <span class="hljs-number">20_0n</span>
 -<span class="hljs-number">20_0n</span>
+<span class="hljs-number">0B1n</span>
+<span class="hljs-number">0O1n</span>
+<span class="hljs-number">0X1n</span>
+
+<span class="hljs-comment">// Annex B numeric literals</span>
+<span class="hljs-comment">// https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals</span>
+<span class="hljs-number">00</span>, <span class="hljs-number">04</span>, <span class="hljs-number">0777</span>, <span class="hljs-number">08</span>, <span class="hljs-number">008</span>
+
+<span class="hljs-comment">// expressions containing numeric literals</span>
+<span class="hljs-number">0.</span>.toString, <span class="hljs-number">1e1</span>.toString, fn(<span class="hljs-number">.5</span>)
+
+<span class="hljs-comment">// expressions not containing numeric literals</span>
+x0.e1
+
+<span class="hljs-comment">// invalid pseudo-numeric expressions</span>
+1__0
+0b1__0
+1e_1
+0b1e1
+0N
+<span class="hljs-number">00</span>.

--- a/test/markup/javascript/numbers.txt
+++ b/test/markup/javascript/numbers.txt
@@ -22,6 +22,12 @@ let amount = 1_234_500; // 1,234,500
 -.000_001 // 1 millionth
 1e10_000  // 10^10000 -- granted, far less useful / in-range...
 
+.0, .00,  .9, 4.2, 40.0,  0., 10.
+.0, .0_0, .9, 4.2, 4_0.0, 0., 1_0.
+
+.0e10,  .00e+10,  .9e-10,  4.2E10,  40.0E+08,   0.E-10,  0.e100,   1010e+10
+.0e1_0, .0_0e+10, .9e-1_0, 4.2E1_0, 4_0.0E+0_8, 0.E-1_0, 0.e1_0_0, 10_10e+10
+
 let nibbles = 0b1010_0001_1000_0101;
 let message = 0xA0_B0_C0;
 
@@ -48,3 +54,24 @@ let x7 = 0x5_2;            // OK (hexadecimal literal)
 2_0_0n
 20_0n
 -20_0n
+0B1n
+0O1n
+0X1n
+
+// Annex B numeric literals
+// https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
+00, 04, 0777, 08, 008
+
+// expressions containing numeric literals
+0..toString, 1e1.toString, fn(.5)
+
+// expressions not containing numeric literals
+x0.e1
+
+// invalid pseudo-numeric expressions
+1__0
+0b1__0
+1e_1
+0b1e1
+0N
+00.


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-literals-numeric-literals
https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals

### Changes
Brought JavaScript numeric literal variants in line with the [spec](https://tc39.es/ecma262/#sec-literals-numeric-literals), just like was done for Python in #2780 and Ruby in #2788.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors