### PR TITLE
Fix CSS Function-Like Bug

### DIFF
--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -6,7 +6,7 @@ Website: https://developer.mozilla.org/en-US/docs/Web/CSS
 
 /** @type LanguageFn */
 export default function(hljs) {
-  var FUNCTION_LIKE = {
+  const FUNCTION_LIKE = {
     begin: /[\w-]+\(/, returnBegin: true,
     contains: [
       {
@@ -19,11 +19,12 @@ export default function(hljs) {
           hljs.APOS_STRING_MODE,
           hljs.QUOTE_STRING_MODE,
           hljs.CSS_NUMBER_MODE,
+          FUNCTION_LIKE
         ]
       }
     ]
   }
-  var ATTRIBUTE = {
+  const ATTRIBUTE = {
     className: 'attribute',
     begin: /\S/, end: ':', excludeEnd: true,
     starts: {
@@ -43,12 +44,12 @@ export default function(hljs) {
       ]
     }
   }
-  var AT_IDENTIFIER = '@[a-z-]+' // @font-face
-  var AT_MODIFIERS = "and or not only"
-  var MEDIA_TYPES = "all print screen speech"
-  var AT_PROPERTY_RE = /@\-?\w[\w]*(\-\w+)*/ // @-webkit-keyframes
-  var IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
-  var RULE = {
+  const AT_IDENTIFIER = '@[a-z-]+' // @font-face
+  const AT_MODIFIERS = "and or not only"
+  const MEDIA_TYPES = "all print screen speech"
+  const AT_PROPERTY_RE = /@\-?\w[\w]*(\-\w+)*/ // @-webkit-keyframes
+  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
+  const RULE = {
     begin: /(?:[A-Z\_\.\-]+|--[a-zA-Z0-9_-]+)\s*:/, returnBegin: true, end: ';', endsWithParent: true,
     contains: [
       ATTRIBUTE

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -45,16 +45,16 @@ export default function(hljs) {
     }
   }
   const AT_IDENTIFIER = '@[a-z-]+' // @font-face
-  const AT_MODIFIERS = "and or not only"
-  const MEDIA_TYPES = "all print screen speech"
+  const AT_MODIFIERS = 'and or not only'
+  const MEDIA_TYPES = 'all braille embossed handheld print projection screen speech tty tv' // <https://www.w3.org/TR/CSS21/media.html>
   const AT_PROPERTY_RE = /@\-?\w[\w]*(\-\w+)*/ // @-webkit-keyframes
-  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
+  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*'
   const RULE = {
     begin: /(?:[A-Z\_\.\-]+|--[a-zA-Z0-9_-]+)\s*:/, returnBegin: true, end: ';', endsWithParent: true,
     contains: [
       ATTRIBUTE
     ]
-  };
+  }
 
   return {
     name: 'CSS',
@@ -108,7 +108,7 @@ export default function(hljs) {
             contains: [
               {
                 begin: /[a-z-]+:/,
-                className:"attribute"
+                className: 'attribute'
               },
               hljs.APOS_STRING_MODE,
               hljs.QUOTE_STRING_MODE,
@@ -126,9 +126,9 @@ export default function(hljs) {
         illegal: /\S/,
         contains: [
           hljs.C_BLOCK_COMMENT_MODE,
-          RULE,
+          RULE
         ]
       }
     ]
-  };
+  }
 }

--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -20,3 +20,13 @@
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }
+
+<span class="hljs-selector-tag">div</span> {
+  <span class="hljs-attribute">color</span>: <span class="hljs-built_in">rgb</span>(<span class="hljs-built_in">var</span>(--r), <span class="hljs-built_in">var</span>(--g), <span class="hljs-built_in">var</span>(--b));
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>( <span class="hljs-built_in">var</span>(--black), <span class="hljs-built_in">var</span>(--white) );
+  <span class="hljs-attribute">border-color</span>: <span class="hljs-built_in">rgb</span>(
+    <span class="hljs-built_in">var</span>(--r),
+    <span class="hljs-built_in">var</span>(--g),
+    <span class="hljs-built_in">var</span>(--b)
+  );
+}

--- a/test/markup/css/css_consistency.txt
+++ b/test/markup/css/css_consistency.txt
@@ -20,3 +20,13 @@ a:visited { color: blue; }
 div::after { content: "test"; }
 div::before { content: open-quote; }
 span:nth-child(33) { color:red; }
+
+div {
+  color: rgb(var(--r), var(--g), var(--b));
+  background: linear-gradient( var(--black), var(--white) );
+  border-color: rgb(
+    var(--r),
+    var(--g),
+    var(--b)
+  );
+}

--- a/test/markup/less/css_consistency.expect.txt
+++ b/test/markup/less/css_consistency.expect.txt
@@ -20,3 +20,13 @@
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }
+
+<span class="hljs-selector-tag">div</span> {
+  <span class="hljs-attribute">color</span>: <span class="hljs-built_in">rgb</span>(<span class="hljs-built_in">var</span>(--r), <span class="hljs-built_in">var</span>(--g), <span class="hljs-built_in">var</span>(--b));
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>( <span class="hljs-built_in">var</span>(--black), <span class="hljs-built_in">var</span>(--white) );
+  <span class="hljs-attribute">border-color</span>: <span class="hljs-built_in">rgb</span>(
+    <span class="hljs-built_in">var</span>(--r),
+    <span class="hljs-built_in">var</span>(--g),
+    <span class="hljs-built_in">var</span>(--b)
+  );
+}

--- a/test/markup/less/css_consistency.txt
+++ b/test/markup/less/css_consistency.txt
@@ -20,3 +20,13 @@ a:visited { color: blue; }
 div::after { content: "test"; }
 div::before { content: open-quote; }
 span:nth-child(33) { color:red; }
+
+div {
+  color: rgb(var(--r), var(--g), var(--b));
+  background: linear-gradient( var(--black), var(--white) );
+  border-color: rgb(
+    var(--r),
+    var(--g),
+    var(--b)
+  );
+}

--- a/test/markup/scss/css_consistency.expect.txt
+++ b/test/markup/scss/css_consistency.expect.txt
@@ -20,3 +20,13 @@
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }
+
+<span class="hljs-selector-tag">div</span> {
+  <span class="hljs-attribute">color</span>: <span class="hljs-built_in">rgb</span>(<span class="hljs-built_in">var</span>(--r), <span class="hljs-built_in">var</span>(--g), <span class="hljs-built_in">var</span>(--b));
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>( <span class="hljs-built_in">var</span>(--black), <span class="hljs-built_in">var</span>(--white) );
+  <span class="hljs-attribute">border-color</span>: <span class="hljs-built_in">rgb</span>(
+    <span class="hljs-built_in">var</span>(--r),
+    <span class="hljs-built_in">var</span>(--g),
+    <span class="hljs-built_in">var</span>(--b)
+  );
+}

--- a/test/markup/scss/css_consistency.txt
+++ b/test/markup/scss/css_consistency.txt
@@ -20,3 +20,13 @@ a:visited { color: blue; }
 div::after { content: "test"; }
 div::before { content: open-quote; }
 span:nth-child(33) { color:red; }
+
+div {
+  color: rgb(var(--r), var(--g), var(--b));
+  background: linear-gradient( var(--black), var(--white) );
+  border-color: rgb(
+    var(--r),
+    var(--g),
+    var(--b)
+  );
+}

--- a/test/markup/stylus/css_consistency.expect.txt
+++ b/test/markup/stylus/css_consistency.expect.txt
@@ -20,3 +20,13 @@
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }
+
+<span class="hljs-selector-tag">div</span> {
+  <span class="hljs-attribute">color</span>: <span class="hljs-built_in">rgb</span>(<span class="hljs-built_in">var</span>(--r), <span class="hljs-built_in">var</span>(--g), <span class="hljs-built_in">var</span>(--b));
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>( <span class="hljs-built_in">var</span>(--black), <span class="hljs-built_in">var</span>(--white) );
+  <span class="hljs-attribute">border-color</span>: <span class="hljs-built_in">rgb</span>(
+    <span class="hljs-built_in">var</span>(--r),
+    <span class="hljs-built_in">var</span>(--g),
+    <span class="hljs-built_in">var</span>(--b)
+  );
+}

--- a/test/markup/stylus/css_consistency.txt
+++ b/test/markup/stylus/css_consistency.txt
@@ -20,3 +20,13 @@ a:visited { color: blue; }
 div::after { content: "test"; }
 div::before { content: open-quote; }
 span:nth-child(33) { color:red; }
+
+div {
+  color: rgb(var(--r), var(--g), var(--b));
+  background: linear-gradient( var(--black), var(--white) );
+  border-color: rgb(
+    var(--r),
+    var(--g),
+    var(--b)
+  );
+}


### PR DESCRIPTION
Pattern like `rgb(var(--r), var(--g), var(--b))` does not count the first `var()` as another CSS function.

### Checklist
- [ ] Tested.
- [ ] Updated the changelog at `CHANGES.md`