### PR TITLE
add support for nested functions within CSS

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -293,3 +293,4 @@ Contributors:
 - Tom Wallace <thomasmichaelwallace@gmail.com>
 - Michael Newton <miken32@github>
 - Fredrik Ekre <ekrefredrik@gmail.com>
+- Kevin Hamer <kevin.hamer@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Language Improvements:
 
 - enh(julia) Update keyword lists for Julia 1.X (#2781) [Fredrik Ekre][]
+- fix(css) Fix highlighting of nested css functions (#2674) [Kevin Hamer][]
 
 Dev Improvements:
 

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -25,6 +25,8 @@ export default function(hljs) {
       }
     ]
   };
+  FUNCTION_LIKE.contains[1].contains.push(FUNCTION_LIKE); // self-reference for nested functions
+
   var VENDOR_PREFIX= {
     begin: /-(webkit|moz|ms|o)-/
   };

--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -17,6 +17,6 @@
 <span class="hljs-selector-tag">div</span>, <span class="hljs-selector-tag">p</span>, <span class="hljs-selector-tag">table</span> { <span class="hljs-attribute">width</span>: <span class="hljs-number">30px</span>; }
 
 <span class="hljs-selector-tag">a</span><span class="hljs-selector-pseudo">:visited</span> { <span class="hljs-attribute">color</span>: blue; }
-<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
+<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">&quot;test&quot;</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }

--- a/test/markup/css/custom-properties-and-functions.expect.txt
+++ b/test/markup/css/custom-properties-and-functions.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-selector-pseudo">:root</span> {
+    <span class="hljs-attribute">--dark-blue</span>: <span class="hljs-number">#005</span>;
+}
+
+<span class="hljs-selector-class">.example</span> {
+    <span class="hljs-attribute">border-color</span>: <span class="hljs-built_in">var</span>(--dark-blue, <span class="hljs-built_in">rgb</span>(<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">255</span>));
+    <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>(<span class="hljs-built_in">var</span>(--dark-blue), <span class="hljs-built_in">var</span>(--white));
+    <span class="hljs-attribute">color</span>: <span class="hljs-built_in">rgb</span>(<span class="hljs-built_in">var</span>(--r), <span class="hljs-built_in">var</span>(--g), <span class="hljs-built_in">var</span>(--b));
+}

--- a/test/markup/css/custom-properties-and-functions.txt
+++ b/test/markup/css/custom-properties-and-functions.txt
@@ -1,0 +1,9 @@
+:root {
+    --dark-blue: #005;
+}
+
+.example {
+    border-color: var(--dark-blue, rgb(0, 0, 255));
+    background: linear-gradient(var(--dark-blue), var(--white));
+    color: rgb(var(--r), var(--g), var(--b));
+}

--- a/test/markup/less/css_consistency.expect.txt
+++ b/test/markup/less/css_consistency.expect.txt
@@ -17,6 +17,6 @@
 <span class="hljs-selector-tag">div</span>, <span class="hljs-selector-tag">p</span>, <span class="hljs-selector-tag">table</span> { <span class="hljs-attribute">width</span>: <span class="hljs-number">30px</span>; }
 
 <span class="hljs-selector-tag">a</span><span class="hljs-selector-pseudo">:visited</span> { <span class="hljs-attribute">color</span>: blue; }
-<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
+<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">&quot;test&quot;</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }

--- a/test/markup/scss/css_consistency.expect.txt
+++ b/test/markup/scss/css_consistency.expect.txt
@@ -17,6 +17,6 @@
 <span class="hljs-selector-tag">div</span>, <span class="hljs-selector-tag">p</span>, <span class="hljs-selector-tag">table</span> { <span class="hljs-attribute">width</span>: <span class="hljs-number">30px</span>; }
 
 <span class="hljs-selector-tag">a</span><span class="hljs-selector-pseudo">:visited</span> { <span class="hljs-attribute">color</span>: blue; }
-<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
+<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">&quot;test&quot;</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }

--- a/test/markup/stylus/css_consistency.expect.txt
+++ b/test/markup/stylus/css_consistency.expect.txt
@@ -17,6 +17,6 @@
 <span class="hljs-selector-tag">div</span>, <span class="hljs-selector-tag">p</span>, <span class="hljs-selector-tag">table</span> { <span class="hljs-attribute">width</span>: <span class="hljs-number">30px</span>; }
 
 <span class="hljs-selector-tag">a</span><span class="hljs-selector-pseudo">:visited</span> { <span class="hljs-attribute">color</span>: blue; }
-<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">"test"</span>; }
+<span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::after</span> { <span class="hljs-attribute">content</span>: <span class="hljs-string">&quot;test&quot;</span>; }
 <span class="hljs-selector-tag">div</span><span class="hljs-selector-pseudo">::before</span> { <span class="hljs-attribute">content</span>: open-quote; }
 <span class="hljs-selector-tag">span</span><span class="hljs-selector-pseudo">:nth-child</span>(<span class="hljs-number">33</span>) { <span class="hljs-attribute">color</span>:red; }


### PR DESCRIPTION
Fixed nested CSS functions - like `var(--example, rgb(255, 255, 255))`, etc. Resolves #2674.

### Changes
This change, while it looks a bit awkward, allows CSS FUNCTION_LIKE patterns to be self referencing and contain themselves. Because it's nested a level, I wasn't able to find a way to use the 'self' keyword.

### Checklist
- [x] Added new markup test files custom-properties-and-functions.txt
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
