### PR TITLE
Add Julia to SUPPORTED_LANGUAGES.md

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -95,6 +95,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Java                    | java, jsp              |         |
 | JavaScript              | javascript, js, jsx    |         |
 | Jolie                   | jolie, iol, ol         | [highlightjs-jolie](https://github.com/xiroV/highlightjs-jolie) |
+| Julia                   | julia, julia-repl      |         |
 | Kotlin                  | kotlin, kt             |         |
 | LaTeX                   | tex                    |         |
 | Leaf                    | leaf                   |         |


### PR DESCRIPTION
According to https://meta.stackoverflow.com/questions/274371/what-is-syntax-highlighting-and-how-does-it-work StackOverflow uses the SUPPORTED_LANGUAGES list. Would be great to get Julia in there. Since there is Julia support (https://github.com/highlightjs/highlight.js/blob/master/src/languages/julia.js) I wonder if it is just an oversight that it is not included in this list or is there something else needed to be an officially supported language? Thanks.
