### PR TITLE
(theme) Add StackOverflow dark and light themes

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -294,3 +294,4 @@ Contributors:
 - Michael Newton <miken32@github>
 - Richard Gibson <gibson042@github>
 - Fredrik Ekre <ekrefredrik@gmail.com>
+- Jan Pilzer <Hirse@github>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,16 @@ Dev Improvements:
 
 - chore(dev) add theme picker to the tools/developer tool (#2770) [Josh Goebel][]
 
+New themes:
+
+- *StackOverflow Dark* by [Jan Pilzer][]
+- *StackOverflow Light* by [Jan Pilzer][]
+
 [Fredrik Ekre]: https://github.com/fredrikekre
 [Richard Gibson]: https://github.com/gibson042
 [Josh Goebel]: https://github.com/joshgoebel
 [Taufik Nurrohman]: https://github.com/taufik-nurrohman
+[Jan Pilzer]: https://github.com/Hirse
 
 
 ## Version 10.3.1

--- a/src/styles/stackoverflow-dark.css
+++ b/src/styles/stackoverflow-dark.css
@@ -1,0 +1,78 @@
+/*!
+ * StackOverflow.com dark style
+ *
+ * @stackoverflow/stacks v0.56.0
+ * https://github.com/StackExchange/Stacks
+ */
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #ffffff;
+  background: #1c1b1b;
+}
+
+.hljs-comment {
+  color: #999999;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta-keyword,
+.hljs-doctag,
+.hljs-section,
+.hljs-selector-class,
+.hljs-meta,
+.hljs-selector-pseudo,
+.hljs-attr {
+  color: #88aece;
+}
+
+.hljs-attribute {
+  color: v#c59bc1;
+}
+
+.hljs-name,
+.hljs-type,
+.hljs-number,
+.hljs-selector-id,
+.hljs-quote,
+.hljs-template-tag,
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  color: #f08d49;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr,
+.hljs-meta-string {
+  color: #b5bd68;
+}
+
+.hljs-bullet,
+.hljs-code {
+  color: #cccccc;
+}
+
+.hljs-deletion {
+  color: #de7176;
+}
+
+.hljs-addition {
+  color: #76c490;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/src/styles/stackoverflow-light.css
+++ b/src/styles/stackoverflow-light.css
@@ -1,0 +1,78 @@
+/*!
+ * StackOverflow.com light style
+ *
+ * @stackoverflow/stacks v0.56.0
+ * https://github.com/StackExchange/Stacks
+ */
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #2f3337;
+  background: #f6f6f6;
+}
+
+.hljs-comment {
+  color: #656e77;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta-keyword,
+.hljs-doctag,
+.hljs-section,
+.hljs-selector-class,
+.hljs-meta,
+.hljs-selector-pseudo,
+.hljs-attr {
+  color: #015692;
+}
+
+.hljs-attribute {
+  color: #803378;
+}
+
+.hljs-name,
+.hljs-type,
+.hljs-number,
+.hljs-selector-id,
+.hljs-quote,
+.hljs-template-tag,
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  color: #b75501;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr,
+.hljs-meta-string {
+  color: #54790d;
+}
+
+.hljs-bullet,
+.hljs-code {
+  color: #535a60;
+}
+
+.hljs-deletion {
+  color: #c02d2e;
+}
+
+.hljs-addition {
+  color: #2f6f44;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -148,6 +148,8 @@
           <option>solarized-dark.css</option>
           <option>solarized-light.css</option>
           <option>srcery.css</option>
+          <option>stackoverflow-dark.css</option>
+          <option>stackoverflow-light.css</option>
           <option>sunburst.css</option>
           <option>tomorrow-night-blue.css</option>
           <option>tomorrow-night-bright.css</option>


### PR DESCRIPTION
StackOverflow recently [switched to HLJS](https://meta.stackexchange.com/q/353983/253942) and designed two themes that pay attention to being accessible.
![StackOverflow themes](https://user-images.githubusercontent.com/2564094/97660053-c53ea680-1a2d-11eb-922f-b7a73ca8ded1.png)



### Changes
Adding StackOverflow Light and Dark themes

### Checklist
- [x] ~Added markup tests~ N/A, theme only change
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
