### PR TITLE
fix(js/ts) Prevent while/if/switch from falsly matching as functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Language Improvements:
 
-- fix(js/ts) Prevent while/if/switch from falsly matching as functions () [Josh Goebel][]
+- fix(js/ts) Prevent while/if/switch from falsly matching as functions (#2803) [Josh Goebel][]
 - enh(julia) Update keyword lists for Julia 1.x (#2781) [Fredrik Ekre][]
 - enh(python) Match numeric literals per the language reference [Richard Gibson][]
 - enh(ruby) Match numeric literals per language documentation [Richard Gibson][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 Language Improvements:
 
-- fix(js/ts) Prevent while/if/switch from falsly matching as functions (#2803) [Josh Goebel][]
+- fix(js/ts) Prevent for/while/if/switch from falsly matching as functions (#2803) [Josh Goebel][]
 - enh(julia) Update keyword lists for Julia 1.x (#2781) [Fredrik Ekre][]
 - enh(python) Match numeric literals per the language reference [Richard Gibson][]
 - enh(ruby) Match numeric literals per language documentation [Richard Gibson][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Language Improvements:
 
+- fix(js/ts) Prevent while/if/switch from falsly matching as functions () [Josh Goebel][]
 - enh(julia) Update keyword lists for Julia 1.x (#2781) [Fredrik Ekre][]
 - enh(python) Match numeric literals per the language reference [Richard Gibson][]
 - enh(ruby) Match numeric literals per language documentation [Richard Gibson][]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -362,7 +362,7 @@ export default function(hljs) {
       {
         // prevent this from getting swallowed up by function
         // since they appear "function like"
-        beginKeywords: "while if switch catch"
+        beginKeywords: "while if switch catch for"
       },
       {
         className: 'function',

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -360,6 +360,11 @@ export default function(hljs) {
         illegal: /%/
       },
       {
+        // prevent this from getting swallowed up by function
+        // since they appear "function like"
+        beginKeywords: "while if switch catch"
+      },
+      {
         className: 'function',
         // we have to count the parens to make sure we actually have the correct
         // bounding ( ).  There could be any number of sub-expressions inside

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -19,3 +19,9 @@
   }
   <span class="hljs-function"><span class="hljs-title">onemore</span>(<span class="hljs-params">a=(<span class="hljs-number">3</span>+<span class="hljs-number">2</span>, b=(<span class="hljs-number">5</span>*<span class="hljs-number">9</span>))</span>)</span> {}
 }
+
+<span class="hljs-comment">// these should not be matched as class functions</span>
+<span class="hljs-keyword">while</span>(value) {}
+<span class="hljs-keyword">if</span>(value) {}
+<span class="hljs-keyword">switch</span>(value) {}
+<span class="hljs-keyword">try</span> {} <span class="hljs-keyword">catch</span>(err) {}

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -21,6 +21,7 @@
 }
 
 <span class="hljs-comment">// these should not be matched as class functions</span>
+<span class="hljs-keyword">for</span>(expr; expr; expr) {}
 <span class="hljs-keyword">while</span>(value) {}
 <span class="hljs-keyword">if</span>(value) {}
 <span class="hljs-keyword">switch</span>(value) {}

--- a/test/markup/javascript/class.txt
+++ b/test/markup/javascript/class.txt
@@ -19,3 +19,9 @@ class Car extends Vehicle {
   }
   onemore(a=(3+2, b=(5*9))) {}
 }
+
+// these should not be matched as class functions
+while(value) {}
+if(value) {}
+switch(value) {}
+try {} catch(err) {}

--- a/test/markup/javascript/class.txt
+++ b/test/markup/javascript/class.txt
@@ -21,6 +21,7 @@ class Car extends Vehicle {
 }
 
 // these should not be matched as class functions
+for(expr; expr; expr) {}
 while(value) {}
 if(value) {}
 switch(value) {}


### PR DESCRIPTION
When adding support for detecting what appear to be class functions:

```js
class Dog {
  bark(args) {
    loud = true
  }
}
```

...we seem to have missed that this also matches if, while, switch, etc... so those need to be coded as exceptions to the rule.

### Changes

Adds an exception mode to catch these first before the function rule matches them.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors