### PR TITLE
Add Chapel as a supported third-party language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 New languages:
 
-- add(chapel) Added initial third-party Chapel language support (#2806) [Brad Chamberlain][]
+- Added Chapel grammar to SUPPORTED_LANGUAGES (#2806) [Brad Chamberlain][]
 
 Language Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 10.4.0 (work in process)
 
+New languages:
+
+- add(chapel) Added initial third-party Chapel language support (#2806) [Brad Chamberlain][]
+
 Language Improvements:
 
 - enh(julia) Update keyword lists for Julia 1.x (#2781) [Fredrik Ekre][]

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -42,6 +42,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | CSS                     | css                    |         |
 | Cap’n Proto             | capnproto, capnp       |         |
 | Chaos                   | chaos, kaos            | [highlightjs-chaos](https://github.com/chaos-lang/highlightjs-chaos) |
+| Chapel                  | chapel, chpl           | [highlightjs-chapel](https://github.com/chapel-lang/highlightjs-chapel) |
 | Cisco CLI               | cisco                  | [highlightjs-cisco-cli](https://github.com/BMatheas/highlightjs-cisco-cli) |
 | Clojure                 | clojure, clj           |         |
 | CoffeeScript            | coffeescript, coffee, cson, iced | |


### PR DESCRIPTION
Resolves #2800 

### Changes

This adds an entry for the Chapel language, giving `chapel` and `chpl` as its two aliases, and pointing to our repo at https://github.com/chapel-lang/highlightjs-chapel.  
### Checklist
- [x] Added markup tests, or they don't apply here because they're in our repo
- [x] Updated the changelog at `CHANGES.md`
- [ ] ~Added myself to `AUTHORS.txt`, under Contributors~ (wasn't certain whether adding a third-party package warranted being added to AUTHORS.txt and @joshgoebel didn't seem certain either)

[Note: I haven't done the last two items because it's not clear to me whether they apply to something as minor as adding a new third-party language to the list.  Please let me know]