### PR TITLE
Update handling of Python decorators

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -295,3 +295,4 @@ Contributors:
 - Richard Gibson <gibson042@github>
 - Fredrik Ekre <ekrefredrik@gmail.com>
 - Jan Pilzer <Hirse@github>
+- Jonathan Sharpe <mail@jonrshar.pe>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Language Improvements:
 - enh(javascript) Match numeric literals per ECMA-262 spec [Richard Gibson][]
 - enh(java) Match numeric literals per Java Language Specification [Richard Gibson][]
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
+- fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
 
 Dev Improvements:
 
@@ -23,6 +24,7 @@ New themes:
 [Josh Goebel]: https://github.com/joshgoebel
 [Taufik Nurrohman]: https://github.com/taufik-nurrohman
 [Jan Pilzer]: https://github.com/Hirse
+[Jonathan Sharpe]: https://github.com/textbook
 
 
 ## Version 10.3.1

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -275,7 +275,8 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^[\t ]*@[^\d\W]\w+(\.[^\d\W]\w+)*/
+        begin: /^[\t ]*@[^\d\W]\w+(\.[^\d\W]\w+)*/,
+        contains: [PARAMS]
       },
       {
         begin: /\b(print|exec)\(/ // don’t highlight keywords-turned-functions in Python 3

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -275,7 +275,7 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^[\t ]*@/, end: /$/
+        begin: /^[\t ]*@[^\d\W]\w+(\.[^\d\W]\w+)*/
       },
       {
         begin: /\b(print|exec)\(/ // don’t highlight keywords-turned-functions in Python 3

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -275,8 +275,8 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^[\t ]*@[^\d\W]\w+(\.[^\d\W]\w+)*/,
-        contains: [PARAMS]
+        begin: /^[\t ]*@/, end: /(?=#)|$/,
+        contains: [NUMBER, PARAMS, STRING]
       },
       {
         begin: /\b(print|exec)\(/ // don’t highlight keywords-turned-functions in Python 3

--- a/test/detect/python/default.txt
+++ b/test/detect/python/default.txt
@@ -1,4 +1,4 @@
-@requires_authorization
+@requires_authorization(roles=["ADMIN"])
 def somefunc(param1='', param2=0):
     r'''A docstring'''
     if param1 > param2: # interesting

--- a/test/markup/python/decorators.expect.txt
+++ b/test/markup/python/decorators.expect.txt
@@ -10,6 +10,6 @@
 <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
     <span class="hljs-keyword">pass</span>
 
-<span class="hljs-meta">@foo</span>(<span class="hljs-string">&quot;hi&quot;</span>, bar=baz)
+<span class="hljs-meta">@foo(<span class="hljs-params"><span class="hljs-string">&quot;hi&quot;</span>, bar=baz</span>)</span>
 <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/decorators.expect.txt
+++ b/test/markup/python/decorators.expect.txt
@@ -1,0 +1,15 @@
+<span class="hljs-meta">@foo</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">bar</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@foo</span>  <span class="hljs-comment"># bar</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">baz</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@foo.bar.baz</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@foo</span>(<span class="hljs-string">&quot;hi&quot;</span>, bar=baz)
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
+    <span class="hljs-keyword">pass</span>

--- a/test/markup/python/decorators.expect.txt
+++ b/test/markup/python/decorators.expect.txt
@@ -2,7 +2,7 @@
 <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">bar</span>():</span>
     <span class="hljs-keyword">pass</span>
 
-<span class="hljs-meta">@foo</span>  <span class="hljs-comment"># bar</span>
+<span class="hljs-meta">@foo  </span><span class="hljs-comment"># bar</span>
 <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">baz</span>():</span>
     <span class="hljs-keyword">pass</span>
 
@@ -10,6 +10,22 @@
 <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
     <span class="hljs-keyword">pass</span>
 
-<span class="hljs-meta">@foo(<span class="hljs-params"><span class="hljs-string">&quot;hi&quot;</span>, bar=baz</span>)</span>
-<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">qux</span>():</span>
+<span class="hljs-meta">@surround_with(<span class="hljs-params"><span class="hljs-string">&quot;#&quot;</span>, repeat=<span class="hljs-number">3</span></span>)</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">text</span>():</span>
+    <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;hi!&quot;</span>
+
+<span class="hljs-meta">@py38.style</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">func</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@py[<span class="hljs-string">&quot;3.9&quot;</span>].style</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">func</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@py[<span class="hljs-number">3.9</span>].style</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">func</span>():</span>
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-meta">@<span class="hljs-number">2</span> + <span class="hljs-number">2</span> == <span class="hljs-number">5</span></span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">func</span>():</span>
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/decorators.txt
+++ b/test/markup/python/decorators.txt
@@ -1,0 +1,15 @@
+@foo
+def bar():
+    pass
+
+@foo  # bar
+def baz():
+    pass
+
+@foo.bar.baz
+def qux():
+    pass
+
+@foo("hi", bar=baz)
+def qux():
+    pass

--- a/test/markup/python/decorators.txt
+++ b/test/markup/python/decorators.txt
@@ -10,6 +10,22 @@ def baz():
 def qux():
     pass
 
-@foo("hi", bar=baz)
-def qux():
+@surround_with("#", repeat=3)
+def text():
+    return "hi!"
+
+@py38.style
+def func():
+    pass
+
+@py["3.9"].style
+def func():
+    pass
+
+@py[3.9].style
+def func():
+    pass
+
+@2 + 2 == 5
+def func():
     pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #2804.

### Changes
<!--- Describe your changes -->
Modifies the `meta` matching for Python code to handle decorators more accurately. This allows e.g. comments to be correctly formatted in lines starting with `@`.

  - [x] **Python 3.8 and earlier**. Before [PEP614][1] decorators had to be a dotted name.
  - [x] **Python 3.9 and later**. Decorators can be any expression.

  [1]: https://www.python.org/dev/peps/pep-0614/

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
