### PR TITLE
enh(java) Match numeric literals per Java Language Specification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Language Improvements:
 - enh(python) Match numeric literals per the language reference [Richard Gibson][]
 - enh(ruby) Match numeric literals per language documentation [Richard Gibson][]
 - enh(javascript) Match numeric literals per ECMA-262 spec [Richard Gibson][]
+- enh(java) Match numeric literals per Java Language Specification [Richard Gibson][]
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
 
 Dev Improvements:

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -27,44 +27,38 @@ export default function(hljs) {
       },
     ]
   };
-  /**
-   * A given sequence, possibly with underscores
-   * @type {(s: string | RegExp) => string}  */
-  var SEQUENCE_ALLOWING_UNDERSCORES = (seq) => regex.concat('[', seq, ']+([', seq, '_]*[', seq, ']+)?');
-  var JAVA_NUMBER_MODE = {
+
+  // https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.10
+  var decimalDigits = '[0-9](_*[0-9])*';
+  var frac = `\\.(${decimalDigits})`;
+  var hexDigits = '[0-9a-fA-F](_*[0-9a-fA-F])*';
+  var NUMBER = {
     className: 'number',
     variants: [
-      { begin: `\\b(0[bB]${SEQUENCE_ALLOWING_UNDERSCORES('01')})[lL]?` }, // binary
-      { begin: `\\b(0${SEQUENCE_ALLOWING_UNDERSCORES('0-7')})[dDfFlL]?` }, // octal
-      {
-        begin: regex.concat(
-          /\b0[xX]/,
-          regex.either(
-            regex.concat(SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'), /\./, SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9')),
-            regex.concat(SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'), /\.?/),
-            regex.concat(/\./, SEQUENCE_ALLOWING_UNDERSCORES('a-fA-F0-9'))
-          ),
-          /([pP][+-]?(\d+))?/,
-          /[fFdDlL]?/ // decimal & fp mixed for simplicity
-        )
-      },
-      // scientific notation
-      { begin: regex.concat(
-        /\b/,
-        regex.either(
-          regex.concat(/\d*\./, SEQUENCE_ALLOWING_UNDERSCORES("\\d")), // .3, 3.3, 3.3_3
-          SEQUENCE_ALLOWING_UNDERSCORES("\\d") // 3, 3_3
-        ),
-        /[eE][+-]?[\d]+[dDfF]?/)
-      },
-      // decimal & fp mixed for simplicity
-      { begin: regex.concat(
-        /\b/,
-        SEQUENCE_ALLOWING_UNDERSCORES(/\d/),
-        regex.optional(/\.?/),
-        regex.optional(SEQUENCE_ALLOWING_UNDERSCORES(/\d/)),
-        /[dDfFlL]?/)
-      }
+      // DecimalFloatingPointLiteral
+      // including ExponentPart
+      { begin: `(\\b(${decimalDigits})((${frac})|\\.)?|(${frac}))` +
+        `[eE][+-]?(${decimalDigits})[fFdD]?\\b` },
+      // excluding ExponentPart
+      { begin: `\\b(${decimalDigits})((${frac})[fFdD]?\\b|\\.([fFdD]\\b)?)` },
+      { begin: `(${frac})[fFdD]?\\b` },
+      { begin: `\\b(${decimalDigits})[fFdD]\\b` },
+
+      // HexadecimalFloatingPointLiteral
+      { begin: `\\b0[xX]((${hexDigits})\\.?|(${hexDigits})?\\.(${hexDigits}))` +
+        `[pP][+-]?(${decimalDigits})[fFdD]?\\b` },
+
+      // DecimalIntegerLiteral
+      { begin: '\\b(0|[1-9](_*[0-9])*)[lL]?\\b' },
+
+      // HexIntegerLiteral
+      { begin: `\\b0[xX](${hexDigits})[lL]?\\b` },
+
+      // OctalIntegerLiteral
+      { begin: '\\b0(_*[0-7])*[lL]?\\b' },
+
+      // BinaryIntegerLiteral
+      { begin: '\\b0[bB][01](_*[01])*[lL]?\\b' },
     ],
     relevance: 0
   };
@@ -160,7 +154,7 @@ export default function(hljs) {
               ANNOTATION,
               hljs.APOS_STRING_MODE,
               hljs.QUOTE_STRING_MODE,
-              hljs.C_NUMBER_MODE,
+              NUMBER,
               hljs.C_BLOCK_COMMENT_MODE
             ]
           },
@@ -168,7 +162,7 @@ export default function(hljs) {
           hljs.C_BLOCK_COMMENT_MODE
         ]
       },
-      JAVA_NUMBER_MODE,
+      NUMBER,
       ANNOTATION
     ]
   };

--- a/test/markup/java/numbers.expect.txt
+++ b/test/markup/java/numbers.expect.txt
@@ -1,35 +1,105 @@
-<span class="hljs-keyword">long</span> creditCardNumber = <span class="hljs-number">1234_5678_9012_3456L</span>;
-<span class="hljs-keyword">long</span> socialSecurityNumber = <span class="hljs-number">999_99_9999L</span>;
-<span class="hljs-keyword">float</span> pi = <span class="hljs-number">3.14_15F</span>;
-<span class="hljs-keyword">long</span> hexBytes = <span class="hljs-number">0xFF_EC_DE_5E</span>;
-<span class="hljs-keyword">long</span> hexWords = <span class="hljs-number">0xCAFE_BABE</span>;
-<span class="hljs-keyword">long</span> maxLong = <span class="hljs-number">0x7fff_ffff_ffff_ffffL</span>;
-<span class="hljs-keyword">byte</span> nybbles = <span class="hljs-number">0b0010_0101</span>;
-<span class="hljs-keyword">long</span> bytes = <span class="hljs-number">0b11010010_01101001_10010100_10010010</span>;
-<span class="hljs-keyword">int</span> n = <span class="hljs-number">1234</span> + Contacts._ID;
-<span class="hljs-keyword">float</span> f = <span class="hljs-number">0x1.4p2f</span>;
-<span class="hljs-keyword">double</span> d = <span class="hljs-number">0x.ep-6</span>;
-<span class="hljs-keyword">int</span> octal = <span class="hljs-number">0777</span>;
-<span class="hljs-keyword">float</span> f = <span class="hljs-number">2e3f</span>;
-<span class="hljs-keyword">double</span> d = <span class="hljs-number">1.2e4D</span>;
-a = <span class="hljs-number">0x4fa6p2</span>;
-b = <span class="hljs-number">0x.4p2</span>;
-c = <span class="hljs-number">0xa.ffp3f</span>;
-d = <span class="hljs-number">0x1.0p2F</span>;
-e = <span class="hljs-number">0x1.0p2f</span>;
-f = <span class="hljs-number">0x1p1</span>;
-g = <span class="hljs-number">0x.3p4d</span>;
-h = <span class="hljs-number">0x1.2ep5D</span>;
-i = <span class="hljs-number">0x1.p2</span>;
-<span class="hljs-keyword">int</span> i = <span class="hljs-number">23</span>;
-<span class="hljs-keyword">byte</span> mask = <span class="hljs-number">0x0f</span>;
-<span class="hljs-keyword">int</span> i = <span class="hljs-number">4</span>;
-<span class="hljs-keyword">byte</span> mask = <span class="hljs-number">0xa</span>;
-<span class="hljs-keyword">float</span> f = <span class="hljs-number">5.4</span>;
-<span class="hljs-keyword">float</span> f = <span class="hljs-number">2e3</span>;
-<span class="hljs-keyword">int</span> n = <span class="hljs-number">0b1</span>;
-<span class="hljs-keyword">float</span> f = <span class="hljs-number">3.</span>;
-f = <span class="hljs-number">3_3.</span>;
-<span class="hljs-comment">// <span class="hljs-doctag">TODO:</span> in the future</span>
-<span class="hljs-comment">// float f = .2;</span>
-<span class="hljs-comment">// f = .2_022;</span>
+<span class="hljs-keyword">int</span>[] decimalIntegers = {
+	<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">10</span>,  <span class="hljs-number">999</span>,
+	<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">1_0</span>, <span class="hljs-number">9_9__9</span>,
+};
+<span class="hljs-keyword">long</span>[] longDecimalIntegers = {
+	<span class="hljs-number">0l</span>, <span class="hljs-number">1L</span>, <span class="hljs-number">10l</span>,  <span class="hljs-number">999L</span>,
+	<span class="hljs-number">0L</span>, <span class="hljs-number">1l</span>, <span class="hljs-number">1_0L</span>, <span class="hljs-number">9_9__9l</span>,
+};
+
+<span class="hljs-keyword">int</span>[] hexIntegers = {
+	<span class="hljs-number">0x0</span>, <span class="hljs-number">0Xa0</span>,  <span class="hljs-number">0X7FF</span>,   <span class="hljs-number">0xd3aD</span>,    <span class="hljs-number">0x00000000ffffffff</span>,
+	<span class="hljs-number">0X0</span>, <span class="hljs-number">0xa_0</span>, <span class="hljs-number">0x7__FF</span>, <span class="hljs-number">0Xd__3_aD</span>, <span class="hljs-number">0X0000_0000__ffff_ffff</span>,
+};
+<span class="hljs-keyword">long</span>[] longHexIntegers = {
+	<span class="hljs-number">0x0L</span>, <span class="hljs-number">0Xa0l</span>,  <span class="hljs-number">0X7FFL</span>,   <span class="hljs-number">0xd3aDl</span>,    <span class="hljs-number">0x7fffffffffffffffL</span>,
+	<span class="hljs-number">0X0l</span>, <span class="hljs-number">0xa_0L</span>, <span class="hljs-number">0x7__FFl</span>, <span class="hljs-number">0Xd__3_aDL</span>, <span class="hljs-number">0X7fff_ffff__ffff_ffffl</span>,
+};
+
+<span class="hljs-keyword">int</span>[] octalIntegers = {
+	<span class="hljs-number">00</span>,  <span class="hljs-number">001</span>,   <span class="hljs-number">0777</span>,
+	<span class="hljs-number">0_0</span>, <span class="hljs-number">0__01</span>, <span class="hljs-number">07__77</span>,
+};
+<span class="hljs-keyword">long</span>[] longOctalIntegers = {
+	<span class="hljs-number">00l</span>,  <span class="hljs-number">001L</span>,   <span class="hljs-number">0777l</span>,
+	<span class="hljs-number">0_0L</span>, <span class="hljs-number">0__01l</span>, <span class="hljs-number">07__77L</span>,
+};
+
+<span class="hljs-keyword">int</span>[] binaryIntegers = {
+	<span class="hljs-number">0b0</span>, <span class="hljs-number">0B11</span>,  <span class="hljs-number">0B000</span>,   <span class="hljs-number">0b01011</span>,
+	<span class="hljs-number">0b0</span>, <span class="hljs-number">0B1_1</span>, <span class="hljs-number">0B00__0</span>, <span class="hljs-number">0b01__0_1__1</span>,
+};
+<span class="hljs-keyword">long</span>[] longBinaryIntegers = {
+	<span class="hljs-number">0b0l</span>, <span class="hljs-number">0B11L</span>,  <span class="hljs-number">0B000l</span>,   <span class="hljs-number">0b01011L</span>,
+	<span class="hljs-number">0b0L</span>, <span class="hljs-number">0B1_1l</span>, <span class="hljs-number">0B00__0L</span>, <span class="hljs-number">0b01__0_1__1l</span>,
+};
+
+
+<span class="hljs-keyword">double</span>[] doubleDecimalIntegers = {
+	<span class="hljs-number">0d</span>, <span class="hljs-number">00D</span>,  <span class="hljs-number">1d</span>, <span class="hljs-number">00800d</span>,
+	<span class="hljs-number">0D</span>, <span class="hljs-number">0_0d</span>, <span class="hljs-number">1D</span>, <span class="hljs-number">0_0__8__0_0D</span>,
+};
+<span class="hljs-keyword">float</span>[] floatDecimalIntegers = {
+	<span class="hljs-number">0f</span>, <span class="hljs-number">00F</span>,  <span class="hljs-number">1f</span>, <span class="hljs-number">00800f</span>,
+	<span class="hljs-number">0F</span>, <span class="hljs-number">0_0f</span>, <span class="hljs-number">1F</span>, <span class="hljs-number">0_0__8__0_0F</span>,
+};
+
+<span class="hljs-keyword">double</span>[] doubleDecimals = {
+	<span class="hljs-number">.0</span>, <span class="hljs-number">.00</span>,   <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">40.010</span>,     <span class="hljs-number">0.</span>, <span class="hljs-number">00.</span>,  <span class="hljs-number">10.</span>,
+	<span class="hljs-number">.0</span>, <span class="hljs-number">.0__0</span>, <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">4_0.0__1_0</span>, <span class="hljs-number">0.</span>, <span class="hljs-number">0_0.</span>, <span class="hljs-number">1__0.</span>,
+
+	<span class="hljs-number">.0D</span>, <span class="hljs-number">.00d</span>,   <span class="hljs-number">.9D</span>, <span class="hljs-number">4.2d</span>, <span class="hljs-number">40.010D</span>,     <span class="hljs-number">0.d</span>, <span class="hljs-number">00.D</span>,  <span class="hljs-number">10.d</span>,
+	<span class="hljs-number">.0d</span>, <span class="hljs-number">.0__0D</span>, <span class="hljs-number">.9d</span>, <span class="hljs-number">4.2D</span>, <span class="hljs-number">4_0.0__1_0d</span>, <span class="hljs-number">0.D</span>, <span class="hljs-number">0_0.d</span>, <span class="hljs-number">1__0.D</span>,
+};
+<span class="hljs-keyword">float</span>[] floatDecimals = {
+	<span class="hljs-number">.0F</span>, <span class="hljs-number">.00f</span>,   <span class="hljs-number">.9F</span>, <span class="hljs-number">4.2f</span>, <span class="hljs-number">40.010F</span>,     <span class="hljs-number">0.f</span>, <span class="hljs-number">00.F</span>,  <span class="hljs-number">10.f</span>,
+	<span class="hljs-number">.0f</span>, <span class="hljs-number">.0__0F</span>, <span class="hljs-number">.9f</span>, <span class="hljs-number">4.2F</span>, <span class="hljs-number">4_0.0__1_0f</span>, <span class="hljs-number">0.F</span>, <span class="hljs-number">0_0.f</span>, <span class="hljs-number">1__0.F</span>,
+};
+
+<span class="hljs-keyword">double</span>[] doubleDecimalExponents = {
+	<span class="hljs-number">.0e10</span>,  <span class="hljs-number">.00e+10</span>,  <span class="hljs-number">.9e-10</span>,  <span class="hljs-number">4.2E10</span>,  <span class="hljs-number">40.010E+08</span>,      <span class="hljs-number">0.E-10</span>,  <span class="hljs-number">00.e100</span>,    <span class="hljs-number">00800e+10</span>,
+	<span class="hljs-number">.0e1_0</span>, <span class="hljs-number">.0_0e+10</span>, <span class="hljs-number">.9e-1_0</span>, <span class="hljs-number">4.2E1_0</span>, <span class="hljs-number">4_0.0__1_0E+0_8</span>, <span class="hljs-number">0.E-1_0</span>, <span class="hljs-number">0_0.e1_0_0</span>, <span class="hljs-number">0_0__8__00e+1___0</span>,
+
+	<span class="hljs-number">.0e10d</span>,  <span class="hljs-number">.00e+10D</span>,  <span class="hljs-number">.9e-10d</span>,  <span class="hljs-number">4.2E10D</span>,  <span class="hljs-number">40.010E+08d</span>,      <span class="hljs-number">0.E-10D</span>,  <span class="hljs-number">00.e100d</span>,    <span class="hljs-number">00800e+10D</span>,
+	<span class="hljs-number">.0e1_0D</span>, <span class="hljs-number">.0_0e+10d</span>, <span class="hljs-number">.9e-1_0D</span>, <span class="hljs-number">4.2E1_0d</span>, <span class="hljs-number">4_0.0__1_0E+0_8D</span>, <span class="hljs-number">0.E-1_0d</span>, <span class="hljs-number">0_0.e1_0_0D</span>, <span class="hljs-number">0_0__8__00e+1___0d</span>,
+};
+<span class="hljs-keyword">float</span>[] floatDecimalExponents = {
+	<span class="hljs-number">.0e10f</span>,  <span class="hljs-number">.00e+10F</span>,  <span class="hljs-number">.9e-10f</span>,  <span class="hljs-number">4.2E10F</span>,  <span class="hljs-number">40.010E+08f</span>,      <span class="hljs-number">0.E-10F</span>,  <span class="hljs-number">00.e100f</span>,    <span class="hljs-number">00800e+10F</span>,
+	<span class="hljs-number">.0e1_0F</span>, <span class="hljs-number">.0_0e+10f</span>, <span class="hljs-number">.9e-1_0F</span>, <span class="hljs-number">4.2E1_0f</span>, <span class="hljs-number">4_0.0__1_0E+0_8F</span>, <span class="hljs-number">0.E-1_0f</span>, <span class="hljs-number">0_0.e1_0_0F</span>, <span class="hljs-number">0_0__8__00e+1___0f</span>,
+};
+
+<span class="hljs-keyword">double</span>[] doubleHexExponents = {
+	<span class="hljs-number">0x0p0</span>, <span class="hljs-number">0x.ep6</span>, <span class="hljs-number">0Xa0.p+01</span>,   <span class="hljs-number">0X.7FFp-18</span>,      <span class="hljs-number">0xd3aD.B00p9</span>,
+	<span class="hljs-number">0X0P0</span>, <span class="hljs-number">0x.Ep6</span>, <span class="hljs-number">0xa_0.p+0_1</span>, <span class="hljs-number">0X.7__F_FP-1__8</span>, <span class="hljs-number">0Xd__3_aD.b00p9</span>,
+
+	<span class="hljs-number">0x0p0D</span>, <span class="hljs-number">0x.ep6D</span>, <span class="hljs-number">0Xa0.p+01d</span>,   <span class="hljs-number">0X.7FFp-18D</span>,      <span class="hljs-number">0xd3aD.B00p9d</span>,
+	<span class="hljs-number">0X0P0d</span>, <span class="hljs-number">0x.eP6d</span>, <span class="hljs-number">0xa_0.p+0_1D</span>, <span class="hljs-number">0X.7__F_FP-1__8d</span>, <span class="hljs-number">0Xd__3_aD.b00p9D</span>,
+};
+<span class="hljs-keyword">float</span>[] floatHexExponents = {
+	<span class="hljs-number">0x0p0F</span>, <span class="hljs-number">0x.ep6F</span>, <span class="hljs-number">0Xa0.p+01f</span>,   <span class="hljs-number">0X.7FFp-18F</span>,      <span class="hljs-number">0xf3aF.B00p9f</span>,
+	<span class="hljs-number">0X0P0f</span>, <span class="hljs-number">0x.eP6f</span>, <span class="hljs-number">0xa_0.p+0_1F</span>, <span class="hljs-number">0X.7__F_FP-1__8f</span>, <span class="hljs-number">0Xf__3_aF.b00p9F</span>,
+};
+
+
+<span class="hljs-comment">// expressions containing numeric literals</span>
+fn(<span class="hljs-number">.5</span>);
+fn(<span class="hljs-number">5.</span>);
+
+<span class="hljs-comment">// expressions not containing numeric literals</span>
+fn(x0.d);
+
+<span class="hljs-comment">// invalid pseudo-numeric literals</span>
+<span class="hljs-keyword">int</span>[] badNonDecimalIntegers =      { 08,  0_8,  019,     0x0g,      0B02, };
+<span class="hljs-keyword">long</span>[] longBadNonDecimalIntegers = { 08L, 0_8l, 01_9L,   0x0__GL,   0B0_2l, };
+
+<span class="hljs-keyword">int</span>[] badUnderscoreIntegers =      { 3_,  0x_0,  0X1_,  0B_0,  0b1_, };
+<span class="hljs-keyword">long</span>[] longBadUnderscoreIntegers = { 3_l, 0X_0L, 0x1_l, 0b_0L, 0B1_l, };
+
+<span class="hljs-keyword">double</span>[] doubleBadDecimals = { 0_d, 0_.,  <span class="hljs-number">0.</span>_1,  <span class="hljs-number">0.</span>_D, <span class="hljs-number">0.</span>1_d, };
+<span class="hljs-keyword">float</span>[] floatBadDecimals =   { 0_F, 0_.f, <span class="hljs-number">0.</span>_1F, <span class="hljs-number">0.</span>_f, <span class="hljs-number">0.</span>1_F, };
+
+<span class="hljs-keyword">double</span>[] doubleBadDecimalExponents = { 0_e0,  <span class="hljs-number">0.</span>_E1,  1e_2,  2E3_,  3e4_d, };
+<span class="hljs-keyword">float</span>[] floatBadDecimalExponents =   { 0_e0f, <span class="hljs-number">0.</span>_E1F, 1e_2f, 2E3_F, 3e4_f, };
+
+<span class="hljs-keyword">double</span>[] doubleBadHexExponents = { 0x0pA,  0x0_P0,  <span class="hljs-number">0x0</span>._p1,  0x1P_2,  0x2p3_,  0x3P4_D, };
+<span class="hljs-keyword">float</span>[] floatBadHexExponents =   { 0x0pAF, 0x0_P0f, <span class="hljs-number">0x0</span>._p1F, 0x1P_2f, 0x2p3_F, 0x3P4_f, };

--- a/test/markup/java/numbers.txt
+++ b/test/markup/java/numbers.txt
@@ -1,35 +1,105 @@
-long creditCardNumber = 1234_5678_9012_3456L;
-long socialSecurityNumber = 999_99_9999L;
-float pi = 3.14_15F;
-long hexBytes = 0xFF_EC_DE_5E;
-long hexWords = 0xCAFE_BABE;
-long maxLong = 0x7fff_ffff_ffff_ffffL;
-byte nybbles = 0b0010_0101;
-long bytes = 0b11010010_01101001_10010100_10010010;
-int n = 1234 + Contacts._ID;
-float f = 0x1.4p2f;
-double d = 0x.ep-6;
-int octal = 0777;
-float f = 2e3f;
-double d = 1.2e4D;
-a = 0x4fa6p2;
-b = 0x.4p2;
-c = 0xa.ffp3f;
-d = 0x1.0p2F;
-e = 0x1.0p2f;
-f = 0x1p1;
-g = 0x.3p4d;
-h = 0x1.2ep5D;
-i = 0x1.p2;
-int i = 23;
-byte mask = 0x0f;
-int i = 4;
-byte mask = 0xa;
-float f = 5.4;
-float f = 2e3;
-int n = 0b1;
-float f = 3.;
-f = 3_3.;
-// TODO: in the future
-// float f = .2;
-// f = .2_022;
+int[] decimalIntegers = {
+	0, 1, 10,  999,
+	0, 1, 1_0, 9_9__9,
+};
+long[] longDecimalIntegers = {
+	0l, 1L, 10l,  999L,
+	0L, 1l, 1_0L, 9_9__9l,
+};
+
+int[] hexIntegers = {
+	0x0, 0Xa0,  0X7FF,   0xd3aD,    0x00000000ffffffff,
+	0X0, 0xa_0, 0x7__FF, 0Xd__3_aD, 0X0000_0000__ffff_ffff,
+};
+long[] longHexIntegers = {
+	0x0L, 0Xa0l,  0X7FFL,   0xd3aDl,    0x7fffffffffffffffL,
+	0X0l, 0xa_0L, 0x7__FFl, 0Xd__3_aDL, 0X7fff_ffff__ffff_ffffl,
+};
+
+int[] octalIntegers = {
+	00,  001,   0777,
+	0_0, 0__01, 07__77,
+};
+long[] longOctalIntegers = {
+	00l,  001L,   0777l,
+	0_0L, 0__01l, 07__77L,
+};
+
+int[] binaryIntegers = {
+	0b0, 0B11,  0B000,   0b01011,
+	0b0, 0B1_1, 0B00__0, 0b01__0_1__1,
+};
+long[] longBinaryIntegers = {
+	0b0l, 0B11L,  0B000l,   0b01011L,
+	0b0L, 0B1_1l, 0B00__0L, 0b01__0_1__1l,
+};
+
+
+double[] doubleDecimalIntegers = {
+	0d, 00D,  1d, 00800d,
+	0D, 0_0d, 1D, 0_0__8__0_0D,
+};
+float[] floatDecimalIntegers = {
+	0f, 00F,  1f, 00800f,
+	0F, 0_0f, 1F, 0_0__8__0_0F,
+};
+
+double[] doubleDecimals = {
+	.0, .00,   .9, 4.2, 40.010,     0., 00.,  10.,
+	.0, .0__0, .9, 4.2, 4_0.0__1_0, 0., 0_0., 1__0.,
+
+	.0D, .00d,   .9D, 4.2d, 40.010D,     0.d, 00.D,  10.d,
+	.0d, .0__0D, .9d, 4.2D, 4_0.0__1_0d, 0.D, 0_0.d, 1__0.D,
+};
+float[] floatDecimals = {
+	.0F, .00f,   .9F, 4.2f, 40.010F,     0.f, 00.F,  10.f,
+	.0f, .0__0F, .9f, 4.2F, 4_0.0__1_0f, 0.F, 0_0.f, 1__0.F,
+};
+
+double[] doubleDecimalExponents = {
+	.0e10,  .00e+10,  .9e-10,  4.2E10,  40.010E+08,      0.E-10,  00.e100,    00800e+10,
+	.0e1_0, .0_0e+10, .9e-1_0, 4.2E1_0, 4_0.0__1_0E+0_8, 0.E-1_0, 0_0.e1_0_0, 0_0__8__00e+1___0,
+
+	.0e10d,  .00e+10D,  .9e-10d,  4.2E10D,  40.010E+08d,      0.E-10D,  00.e100d,    00800e+10D,
+	.0e1_0D, .0_0e+10d, .9e-1_0D, 4.2E1_0d, 4_0.0__1_0E+0_8D, 0.E-1_0d, 0_0.e1_0_0D, 0_0__8__00e+1___0d,
+};
+float[] floatDecimalExponents = {
+	.0e10f,  .00e+10F,  .9e-10f,  4.2E10F,  40.010E+08f,      0.E-10F,  00.e100f,    00800e+10F,
+	.0e1_0F, .0_0e+10f, .9e-1_0F, 4.2E1_0f, 4_0.0__1_0E+0_8F, 0.E-1_0f, 0_0.e1_0_0F, 0_0__8__00e+1___0f,
+};
+
+double[] doubleHexExponents = {
+	0x0p0, 0x.ep6, 0Xa0.p+01,   0X.7FFp-18,      0xd3aD.B00p9,
+	0X0P0, 0x.Ep6, 0xa_0.p+0_1, 0X.7__F_FP-1__8, 0Xd__3_aD.b00p9,
+
+	0x0p0D, 0x.ep6D, 0Xa0.p+01d,   0X.7FFp-18D,      0xd3aD.B00p9d,
+	0X0P0d, 0x.eP6d, 0xa_0.p+0_1D, 0X.7__F_FP-1__8d, 0Xd__3_aD.b00p9D,
+};
+float[] floatHexExponents = {
+	0x0p0F, 0x.ep6F, 0Xa0.p+01f,   0X.7FFp-18F,      0xf3aF.B00p9f,
+	0X0P0f, 0x.eP6f, 0xa_0.p+0_1F, 0X.7__F_FP-1__8f, 0Xf__3_aF.b00p9F,
+};
+
+
+// expressions containing numeric literals
+fn(.5);
+fn(5.);
+
+// expressions not containing numeric literals
+fn(x0.d);
+
+// invalid pseudo-numeric literals
+int[] badNonDecimalIntegers =      { 08,  0_8,  019,     0x0g,      0B02, };
+long[] longBadNonDecimalIntegers = { 08L, 0_8l, 01_9L,   0x0__GL,   0B0_2l, };
+
+int[] badUnderscoreIntegers =      { 3_,  0x_0,  0X1_,  0B_0,  0b1_, };
+long[] longBadUnderscoreIntegers = { 3_l, 0X_0L, 0x1_l, 0b_0L, 0B1_l, };
+
+double[] doubleBadDecimals = { 0_d, 0_.,  0._1,  0._D, 0.1_d, };
+float[] floatBadDecimals =   { 0_F, 0_.f, 0._1F, 0._f, 0.1_F, };
+
+double[] doubleBadDecimalExponents = { 0_e0,  0._E1,  1e_2,  2E3_,  3e4_d, };
+float[] floatBadDecimalExponents =   { 0_e0f, 0._E1F, 1e_2f, 2E3_F, 3e4_f, };
+
+double[] doubleBadHexExponents = { 0x0pA,  0x0_P0,  0x0._p1,  0x1P_2,  0x2p3_,  0x3P4_D, };
+float[] floatBadHexExponents =   { 0x0pAF, 0x0_P0f, 0x0._p1F, 0x1P_2f, 0x2p3_F, 0x3P4_f, };


### PR DESCRIPTION
https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.10

### Changes
Brought Java numeric literal variants in line with the language specification, just like was done for Python in #2780 and Ruby in #2788 and JavaScript in #2790.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
