### PR TITLE
enh(diff) enhance diffs generated by `git format-patch`

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -297,3 +297,4 @@ Contributors:
 - Jan Pilzer <Hirse@github>
 - Jonathan Sharpe <mail@jonrshar.pe>
 - Michael Rush <michaelrush@gmail.com>
+- Florian Bezdeka <florian@bezdeka.de>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,7 @@ Language Improvements:
 - enh(java) Match numeric literals per Java Language Specification [Richard Gibson][]
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
 - fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
-- enh(diff) improve highlighting of hunk identifier lines [Florian Bezdeka][]
-- enh(diff) mark lines starting with "diff --git" as comment [Florian Bezdeka][]
-- enh(diff) mark lines starting with "index " as meta-string [Florian Bezdeka][]
+- enh(diff) improve highlighting of diff for git patches [Florian Bezdeka][]
 
 Dev Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Language Improvements:
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
 - fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
 - enh(diff) improve highlighting of hunk identifier lines [Florian Bezdeka][]
+- enh(diff) mark lines starting with "diff --git" as comment [Florian Bezdeka][]
 
 Dev Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Language Improvements:
 - enh(java) Match numeric literals per Java Language Specification [Richard Gibson][]
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
 - fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
+- enh(diff) improve highlighting of hunk identifier lines [Florian Bezdeka][]
 
 Dev Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Language Improvements:
 - fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
 - enh(diff) improve highlighting of hunk identifier lines [Florian Bezdeka][]
 - enh(diff) mark lines starting with "diff --git" as comment [Florian Bezdeka][]
+- enh(diff) mark lines starting with "index " as meta-string [Florian Bezdeka][]
 
 Dev Improvements:
 

--- a/src/languages/diff.js
+++ b/src/languages/diff.js
@@ -29,7 +29,8 @@ export default function(hljs) {
           {begin: /^-{3}/, end: /$/},
           {begin: /^\*{3} /, end: /$/},
           {begin: /^\+{3}/, end: /$/},
-          {begin: /^\*{15}$/ }
+          {begin: /^\*{15}$/ },
+          {begin: /^diff --git/, end: /$/},
         ]
       },
       {

--- a/src/languages/diff.js
+++ b/src/languages/diff.js
@@ -16,7 +16,7 @@ export default function(hljs) {
         className: 'meta',
         relevance: 10,
         variants: [
-          {begin: /^@@ +-\d+,\d+ +\+\d+,\d+ +@@$/},
+          {begin: /^@@ +-\d+,\d+ +\+\d+,\d+ +@@/},
           {begin: /^\*\*\* +\d+,\d+ +\*\*\*\*$/},
           {begin: /^--- +\d+,\d+ +----$/}
         ]

--- a/src/languages/diff.js
+++ b/src/languages/diff.js
@@ -21,6 +21,12 @@ export default function(hljs) {
           {begin: /^--- +\d+,\d+ +----$/}
         ]
       },
+      {                                                                             
+         className: "meta-string",                                                  
+         variants: [                                                                
+           {begin: /^index/, end: /$/ }                                             
+         ]                                                                          
+      },
       {
         className: 'comment',
         variants: [

--- a/src/languages/diff.js
+++ b/src/languages/diff.js
@@ -21,16 +21,11 @@ export default function(hljs) {
           {begin: /^--- +\d+,\d+ +----$/}
         ]
       },
-      {                                                                             
-         className: "meta-string",                                                  
-         variants: [                                                                
-           {begin: /^index/, end: /$/ }                                             
-         ]                                                                          
-      },
       {
         className: 'comment',
         variants: [
           {begin: /Index: /, end: /$/},
+          {begin: /^index/, end: /$/},
           {begin: /={3,}/, end: /$/},
           {begin: /^-{3}/, end: /$/},
           {begin: /^\*{3} /, end: /$/},

--- a/test/markup/diff/comments.expect.txt
+++ b/test/markup/diff/comments.expect.txt
@@ -1,5 +1,6 @@
 <span class="hljs-comment">Index: languages/demo.js</span>
 <span class="hljs-comment">===================================================================</span>
+<span class="hljs-comment">diff --git a/file.txt b/file.txt</span>
 <span class="hljs-comment">--- languages/demo.js    (revision 199)</span>
 <span class="hljs-comment">+++ languages/demo.js    (revision 200)</span>
 <span class="hljs-meta">@@ -1,8 +1,7 @@</span>

--- a/test/markup/diff/comments.txt
+++ b/test/markup/diff/comments.txt
@@ -1,5 +1,6 @@
 Index: languages/demo.js
 ===================================================================
+diff --git a/file.txt b/file.txt
 --- languages/demo.js    (revision 199)
 +++ languages/demo.js    (revision 200)
 @@ -1,8 +1,7 @@

--- a/test/markup/diff/git-format-patch.expect.txt
+++ b/test/markup/diff/git-format-patch.expect.txt
@@ -1,8 +1,10 @@
+<span class="hljs-comment">diff --git a/file.py b/file.py</span>
 <span class="hljs-comment">--- a/file.py</span>
 <span class="hljs-comment">+++ b/file.py</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span> import logging
 <span class="hljs-addition">+ import shutil</span>
 <span class="hljs-deletion">- import os</span>
+<span class="hljs-comment">diff --git a/file.txt b/file.txt</span>
 <span class="hljs-comment">--- a/file.txt</span>
 <span class="hljs-comment">--- b/file.txt</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span>

--- a/test/markup/diff/git-format-patch.expect.txt
+++ b/test/markup/diff/git-format-patch.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-comment">--- a/file.py</span>
+<span class="hljs-comment">+++ b/file.py</span>
+<span class="hljs-meta">@@ -28,2 +28,2 @@</span> import logging
+<span class="hljs-addition">+ import shutil</span>
+<span class="hljs-deletion">- import os</span>
+<span class="hljs-comment">--- a/file.txt</span>
+<span class="hljs-comment">--- b/file.txt</span>
+<span class="hljs-meta">@@ -28,2 +28,2 @@</span>
+<span class="hljs-deletion">- removal</span>
+<span class="hljs-addition">+ addition</span>

--- a/test/markup/diff/git-format-patch.expect.txt
+++ b/test/markup/diff/git-format-patch.expect.txt
@@ -1,10 +1,12 @@
 <span class="hljs-comment">diff --git a/file.py b/file.py</span>
+<span class="hljs-meta-string">index 123456..789abc 100644</span>
 <span class="hljs-comment">--- a/file.py</span>
 <span class="hljs-comment">+++ b/file.py</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span> import logging
 <span class="hljs-addition">+ import shutil</span>
 <span class="hljs-deletion">- import os</span>
 <span class="hljs-comment">diff --git a/file.txt b/file.txt</span>
+<span class="hljs-meta-string">index 123456..789abc 100644</span>
 <span class="hljs-comment">--- a/file.txt</span>
 <span class="hljs-comment">--- b/file.txt</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span>

--- a/test/markup/diff/git-format-patch.expect.txt
+++ b/test/markup/diff/git-format-patch.expect.txt
@@ -1,12 +1,12 @@
 <span class="hljs-comment">diff --git a/file.py b/file.py</span>
-<span class="hljs-meta-string">index 123456..789abc 100644</span>
+<span class="hljs-comment">index 123456..789abc 100644</span>
 <span class="hljs-comment">--- a/file.py</span>
 <span class="hljs-comment">+++ b/file.py</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span> import logging
 <span class="hljs-addition">+ import shutil</span>
 <span class="hljs-deletion">- import os</span>
 <span class="hljs-comment">diff --git a/file.txt b/file.txt</span>
-<span class="hljs-meta-string">index 123456..789abc 100644</span>
+<span class="hljs-comment">index 123456..789abc 100644</span>
 <span class="hljs-comment">--- a/file.txt</span>
 <span class="hljs-comment">--- b/file.txt</span>
 <span class="hljs-meta">@@ -28,2 +28,2 @@</span>

--- a/test/markup/diff/git-format-patch.txt
+++ b/test/markup/diff/git-format-patch.txt
@@ -1,8 +1,10 @@
+diff --git a/file.py b/file.py
 --- a/file.py
 +++ b/file.py
 @@ -28,2 +28,2 @@ import logging
 + import shutil
 - import os
+diff --git a/file.txt b/file.txt
 --- a/file.txt
 --- b/file.txt
 @@ -28,2 +28,2 @@

--- a/test/markup/diff/git-format-patch.txt
+++ b/test/markup/diff/git-format-patch.txt
@@ -1,10 +1,12 @@
 diff --git a/file.py b/file.py
+index 123456..789abc 100644
 --- a/file.py
 +++ b/file.py
 @@ -28,2 +28,2 @@ import logging
 + import shutil
 - import os
 diff --git a/file.txt b/file.txt
+index 123456..789abc 100644
 --- a/file.txt
 --- b/file.txt
 @@ -28,2 +28,2 @@

--- a/test/markup/diff/git-format-patch.txt
+++ b/test/markup/diff/git-format-patch.txt
@@ -1,0 +1,10 @@
+--- a/file.py
++++ b/file.py
+@@ -28,2 +28,2 @@ import logging
++ import shutil
+- import os
+--- a/file.txt
+--- b/file.txt
+@@ -28,2 +28,2 @@
+- removal
++ addition


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
Improving the highlighting of patches generated with `git format-patch`.

- Mark lines starting with "index " as meta-strings (please check if this is the right class to use...)
- Mark lines starting with "diff --git" as comments
- Improve highlighting of hunk identifier lines (lines starting with @@). It may happen that something follows behind the closing "@@" pair.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
