### PR TITLE
(Swift) Support raw strings

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -296,3 +296,4 @@ Contributors:
 - Fredrik Ekre <ekrefredrik@gmail.com>
 - Jan Pilzer <Hirse@github>
 - Jonathan Sharpe <mail@jonrshar.pe>
+- Steven Van Impe <steven.vanimpe@icloud.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Language Improvements:
 - enh(java) Match numeric literals per Java Language Specification [Richard Gibson][]
 - enh(php) highlight variables (#2785) [Taufik Nurrohman][]
 - fix(python) Handle comments on decorators (#2804) [Jonathan Sharpe][]
+- enh(swift) Highlight raw strings in Swift (#2819) [Steven Van Impe][]
 
 Dev Improvements:
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -67,6 +67,9 @@ export default function(hljs) {
     variants: [
       {begin: /"""/, end: /"""/},
       {begin: /"/, end: /"/},
+      {begin: /#"/, end: /"#/},
+      {begin: /##"/, end: /"##/},
+      {begin: /###"/, end: /"###/},
     ]
   };
   var NUMBERS = {

--- a/test/markup/swift/multiline-string.expect.txt
+++ b/test/markup/swift/multiline-string.expect.txt
@@ -1,3 +1,0 @@
-<span class="hljs-keyword">var</span> string = <span class="hljs-string">&quot;&quot;&quot;
-    var a = not actually code
-&quot;&quot;&quot;</span>

--- a/test/markup/swift/multiline-string.txt
+++ b/test/markup/swift/multiline-string.txt
@@ -1,3 +1,0 @@
-var string = """
-    var a = not actually code
-"""

--- a/test/markup/swift/strings.expect.txt
+++ b/test/markup/swift/strings.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-keyword">var</span> string = <span class="hljs-string">&quot;&quot;&quot;
+    var a = not actually code
+&quot;&quot;&quot;</span>
+
+<span class="hljs-built_in">print</span>(<span class="hljs-string">##&quot;Use #&quot; and &quot;# to delimit a raw string.&quot;##</span>)

--- a/test/markup/swift/strings.txt
+++ b/test/markup/swift/strings.txt
@@ -1,0 +1,5 @@
+var string = """
+    var a = not actually code
+"""
+
+print(##"Use #" and "# to delimit a raw string."##)


### PR DESCRIPTION
Resolves #2819 

### Changes

Add support for raw strings with up to three leading/trailing hashes. In theory, raw strings can have any number of hashes, as long as they’re balanced, but more than one is rarely used.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
