### PR TITLE
Update badge on README to point to GHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Highlight.js
 
-[![Build Status](https://travis-ci.org/highlightjs/highlight.js.svg?branch=master)](https://travis-ci.org/highlightjs/highlight.js) [![Greenkeeper badge](https://badges.greenkeeper.io/highlightjs/highlight.js.svg)](https://greenkeeper.io/) [![install size](https://packagephobia.now.sh/badge?p=highlight.js)](https://packagephobia.now.sh/result?p=highlight.js)
+[![Node.js CI](https://github.com/highlightjs/highlight.js/workflows/Node.js%20CI/badge.svg)](https://github.com/highlightjs/highlight.js/actions?query=workflow%3A%22Node.js+CI%22) [![Greenkeeper badge](https://badges.greenkeeper.io/highlightjs/highlight.js.svg)](https://greenkeeper.io/) [![install size](https://packagephobia.now.sh/badge?p=highlight.js)](https://packagephobia.now.sh/result?p=highlight.js)
 
 Highlight.js is a syntax highlighter written in JavaScript. It works in
 the browser as well as on the server. It works with pretty much any

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Highlight.js
 
-[![Node.js CI](https://github.com/highlightjs/highlight.js/workflows/Node.js%20CI/badge.svg)](https://github.com/highlightjs/highlight.js/actions?query=workflow%3A%22Node.js+CI%22) [![Greenkeeper badge](https://badges.greenkeeper.io/highlightjs/highlight.js.svg)](https://greenkeeper.io/) [![install size](https://packagephobia.now.sh/badge?p=highlight.js)](https://packagephobia.now.sh/result?p=highlight.js)
+[![Build CI](https://github.com/highlightjs/highlight.js/workflows/Node.js%20CI/badge.svg)](https://github.com/highlightjs/highlight.js/actions?query=workflow%3A%22Node.js+CI%22) [![Greenkeeper badge](https://badges.greenkeeper.io/highlightjs/highlight.js.svg)](https://greenkeeper.io/) [![install size](https://packagephobia.now.sh/badge?p=highlight.js)](https://packagephobia.now.sh/result?p=highlight.js)
 
 Highlight.js is a syntax highlighter written in JavaScript. It works in
 the browser as well as on the server. It works with pretty much any


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Just update the badge on the README to use the GHA status instead of Travis

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
