### PR TITLE
(swift) improvements: support `some`, `@main`; Fix `#` keywords .

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -307,3 +307,4 @@ Contributors:
 - Florian Bezdeka <florian@bezdeka.de>
 - Patrick Scheibe <patrick@halirutan.de>
 - Kyle Brown <kylebrown9@github>
+- Marcus Ortiz <mportiz08@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ Language Improvements:
   - Matching of named-characters aka special symbols like `\[Gamma]`
   - Updated list of version 12.1 built-in symbols
   - Matching of patterns, slots, message-names and braces
+- fix(swift) Handle keywords that start with `#` [Marcus Ortiz][]
+- enh(swift) Match `some` keyword [Marcus Ortiz][]
+- enh(swift) Match `@main` attribute [Marcus Ortiz][]
 
 Dev Improvements:
 
@@ -52,6 +55,7 @@ New themes:
 [Michael Rush]: https://github.com/rushimusmaximus
 [Patrick Scheibe]: https://github.com/halirutan
 [Kyle Brown]: https://github.com/kylebrown9
+[Marcus Ortiz]: https://github.com/mportiz08
 
 
 ## Version 10.3.1

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -10,6 +10,9 @@ Category: common, system
 
 export default function(hljs) {
   var SWIFT_KEYWORDS = {
+      // override the pattern since the default of of /\w+/ is not sufficient to
+      // capture the keywords that start with the character "#"
+      $pattern: /[\w#]+/,
       keyword: '#available #colorLiteral #column #else #elseif #endif #file ' +
         '#fileLiteral #function #if #imageLiteral #line #selector #sourceLocation ' +
         '_ __COLUMN__ __FILE__ __FUNCTION__ __LINE__ Any as as! as? associatedtype ' +

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -18,7 +18,7 @@ export default function(hljs) {
         'get guard if import in indirect infix init inout internal is lazy left let ' +
         'mutating nil none nonmutating open operator optional override postfix precedence ' +
         'prefix private protocol Protocol public repeat required rethrows return ' +
-        'right self Self set static struct subscript super switch throw throws true ' +
+        'right self Self set some static struct subscript super switch throw throws true ' +
         'try try! try? Type typealias unowned var weak where while willSet',
       literal: 'true false nil',
       built_in: 'abs advance alignof alignofValue anyGenerator assert assertionFailure ' +
@@ -148,7 +148,7 @@ export default function(hljs) {
                   '@noreturn|@IBAction|@IBDesignable|@IBInspectable|@IBOutlet|' +
                   '@infix|@prefix|@postfix|@autoclosure|@testable|@available|' +
                   '@nonobjc|@NSApplicationMain|@UIApplicationMain|@dynamicMemberLookup|' +
-                  '@propertyWrapper)\\b'
+                  '@propertyWrapper|@main)\\b'
 
       },
       {

--- a/test/markup/swift/swiftui.expect.txt
+++ b/test/markup/swift/swiftui.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-meta">@main</span>
+<span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">MyApp</span>: <span class="hljs-title">App</span> </span>{
+    <span class="hljs-keyword">var</span> body: <span class="hljs-keyword">some</span> <span class="hljs-type">Scene</span> {
+        <span class="hljs-type">WindowGroup</span> {
+            <span class="hljs-type">Text</span>(<span class="hljs-string">&quot;Hello, world!&quot;</span>)
+        }
+    }
+}

--- a/test/markup/swift/swiftui.expect.txt
+++ b/test/markup/swift/swiftui.expect.txt
@@ -2,7 +2,11 @@
 <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">MyApp</span>: <span class="hljs-title">App</span> </span>{
     <span class="hljs-keyword">var</span> body: <span class="hljs-keyword">some</span> <span class="hljs-type">Scene</span> {
         <span class="hljs-type">WindowGroup</span> {
+            <span class="hljs-keyword">#if</span> os(iOS)
+            <span class="hljs-type">Text</span>(<span class="hljs-string">&quot;Hello, world from iOS!&quot;</span>)
+            <span class="hljs-keyword">#else</span>
             <span class="hljs-type">Text</span>(<span class="hljs-string">&quot;Hello, world!&quot;</span>)
+            <span class="hljs-keyword">#endif</span>
         }
     }
 }

--- a/test/markup/swift/swiftui.txt
+++ b/test/markup/swift/swiftui.txt
@@ -1,0 +1,8 @@
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, world!")
+        }
+    }
+}

--- a/test/markup/swift/swiftui.txt
+++ b/test/markup/swift/swiftui.txt
@@ -2,7 +2,11 @@
 struct MyApp: App {
     var body: some Scene {
         WindowGroup {
+            #if os(iOS)
+            Text("Hello, world from iOS!")
+            #else
             Text("Hello, world!")
+            #endif
         }
     }
 }


### PR DESCRIPTION
General enhancements and a bug fix for highlighting Swift code.
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
Adds highlighting support for new Swift 5.1 and 5.3 features that are heavily utilized in SwiftUI code:

1. [`some` keyword][1] (Introduced in Swift 5.1)
2. [`@main` attribute][2] (Introduced in Swift 5.3)

Fixes a bug where keywords that start with the `#` character (like `#endif` as an example) are not matched.

[1]: https://github.com/apple/swift-evolution/blob/main/proposals/0244-opaque-result-types.md
[2]: https://github.com/apple/swift-evolution/blob/main/proposals/0281-main-attribute.md

### Checklist
- [X] Added markup tests
- [X] Updated the changelog at `CHANGES.md`
- [X] Added myself to `AUTHORS.txt`, under Contributors
