### PR TITLE
chore(build) NPM publish of cdn-assets and highlight.js via GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+
+on:
+  # pull_request:
+    # branches: [ master ]
+  push:
+    tags:
+      - "*beta*"
+      - "*pre*"
+      # - "1[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  prerelease:
+    name: Pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout highlight.js
+        uses: actions/checkout@v2
+
+      - name: Tag is ${{ github.ref }}.
+        # we have to repeat ourselves here since the environment is not actually updated
+        # until the next step executes, so we can't access $TAG_NAME yet
+        run: |
+          echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "MAJOR_VERSION=$(echo ${GITHUB_REF/refs\/tags\//} | cut -d'.' -f1)" >> $GITHUB_ENV
+      - name: Make sure we are pushing a tag...
+        if: ${{ !contains(github.ref,'refs/tags/') }}
+        run: false
+        # run: echo "TAG_NAME=0.0.0-test0" >> $GITHUB_ENV
+
+      - if: ${{ contains(github.ref, 'beta') || contains(github.ref, 'pre') }}
+        run: |
+          echo "NPM_TAG=beta" >> $GITHUB_ENV
+          echo "RELEASING=beta" >> $GITHUB_ENV
+
+      - if: ${{ !(contains(github.ref, 'beta') || contains(github.ref, 'pre')) }}
+        run: |
+          echo "NPM_TAG=latest" >> $GITHUB_ENV
+          echo "RELEASING=stable" >> $GITHUB_ENV
+
+      - name: match-tag-to-package-version
+        uses: geritol/match-tag-to-package-version@0.0.2
+        env:
+          TAG_PREFIX: refs/tags/ # Optional, default prefix refs/tags/
+
+      - name: Use Node.js 15.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 15.x
+      - name: Build Node.js package
+        run: |
+          npm install
+          node ./tools/build.js -t node
+          npm test
+
+      - name: Publish highlight.js to NPM
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          check-version: true
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./build/package.json
+          tag: ${{ env.NPM_TAG }}
+
+      - if: steps.publish.outputs.type != 'none'
+        run: |
+          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"
+
+        # if stable release
+      - name: Stable Release
+        if: env.RELEASING == 'stable'
+        run: echo "BRANCH_NAME=${MAJOR_VERSION}-stable" >> $GITHUB_ENV
+        # else (beta)
+      - name: Beta Release
+        if: env.RELEASING == 'beta'
+        run: echo "BRANCH_NAME=master" >> $GITHUB_ENV
+      - name: Confirm release is either stable or beta
+        if: ${{ !(env.RELEASING == 'stable' || env.RELEASING == 'beta') }}
+        run: |
+          echo We seem to be releasing `${RELEASING}`.
+          false
+
+      - name: Checkout cdn-release
+        uses: actions/checkout@v2
+        with:
+          repository: 'highlightjs/cdn-release'
+          path: 'cdn-release'
+          token: ${{ secrets.CDN_REPO_TOKEN }}
+          ref: ${{ env.BRANCH_NAME }}
+
+      - name: Build CDN package
+        run: node ./tools/build.js -t cdn :common
+
+      - name: Commmit & Push cdn-release ${{ env.TAG_NAME }}
+        working-directory: ./cdn-release
+        run: |
+          rm -r ./build
+          mv ../build/ ./build/
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add ./build/
+          git commit -m'Update to version ${{ env.TAG_NAME }}'
+          git tag ${TAG_NAME}
+          git push -f --atomic origin ${BRANCH_NAME} ${TAG_NAME}
+
+      - name: Publish cdn-assets to NPM
+        id: publish_cdn
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          check-version: true
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./cdn-release/build/package.json
+          tag: ${{ env.NPM_TAG }}
+
+        # log.info('Updating CDN repo at %s' % settings.HLJS_CDN_SOURCE)
+        # run(['nodejs', 'tools/build.js', '--target', 'cdn', ':common'])
+        # os.chdir(settings.HLJS_CDN_SOURCE)
+        # run(['git', 'pull', '-f'])
+        # lines = run(['git', '--git-dir', os.path.join(settings.HLJS_CDN_SOURCE, '.git'), 'tag'])
+        # build_dir = os.path.join(settings.HLJS_CDN_SOURCE, 'build')
+        # if version in lines:
+        #     log.info('Tag %s already exists in the local CDN repo' % version)
+        # else:
+        #     if os.path.exists(build_dir):
+        #         shutil.rmtree(build_dir)
+        #     shutil.move(os.path.join(settings.HLJS_SOURCE, 'build'), build_dir)
+        #     run(['git', 'add', '.'])
+        #     run(['git', 'commit', '-m', 'Update to version %s' % version])
+        #     run(['git', 'tag', version])
+        # run(['git', 'push'])
+        # run(['git', 'push', '--tags'])
+        # npm_publish(build_dir)
+        # os.chdir(settings.HLJS_SOURCE)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: false
         # run: echo "TAG_NAME=0.0.0-test0" >> $GITHUB_ENV
 
-      - if: ${{ contains(github.ref, 'beta') || contains(github.ref, 'pre') }}
+      - if: contains(github.ref, 'beta') || contains(github.ref, 'pre')
         run: |
           echo "NPM_TAG=beta" >> $GITHUB_ENV
           echo "RELEASING=beta" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Release
 
 on:
-  # pull_request:
-    # branches: [ master ]
   push:
     tags:
       - "*beta*"
       - "*pre*"
+      # uncomment this later when we're ready for production releases
       # - "1[0-9]+.[0-9]+.[0-9]+"
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ extra/
 
 # misc
 /work
+/website


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

- GitHub action to build the library and publish to NPM (whether beta or release)
- Also updates `cdn-release` and publishes to NPM  (`cdn-assets`)

### Checklist

- [x] Polish (final cleanups)
- [x] When not dev/beta should use the appropriate `10-stable` branch, etc.
- [x] Test pushing real tag to highlight.js (10.4.0-beta0 or some such) and see if it goes all the way thru the process
- [ ] Which identify to use for secret tokens (GitHub and NPM)?  (if we need a new identity a separate issue may be spun off to track that). **Created new issue.**
- [ ] Before using for release we'll need to alter the website release scripts (works for beta since the website build scripts ignore betas).  **Understood.**

---

- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md` (not needed)
- [x] Added myself to `AUTHORS.txt`, under Contributors