### PR TITLE
enh(shell) recognize prompt that contain tilde(s) 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ New Languages:
 
 Language Improvements:
 
+- enh(shell) Recognize prompts which contain tilde `~` (#2859) [Guillaume Grossetie][]
 - enh(shell) Add support for multiline commands with line continuation `\` (#2861) [Guillaume Grossetie][]
 - enh(autodetect) Over 30+ improvements to auto-detect (#2745) [Josh Goebel][]
     - 4-5% improvement in auto-detect against large sample set

--- a/src/languages/shell.js
+++ b/src/languages/shell.js
@@ -14,7 +14,10 @@ export default function(hljs) {
     contains: [
       {
         className: 'meta',
-        begin: /^\s{0,3}[/\w\d[\]()@-]*[>%$#]/,
+        // We cannot add \s (spaces) in the regular expression otherwise it will be too broad and produce unexpected result.
+        // For instance, in the following example, it would match "echo /path/to/home >" as a prompt:
+        // echo /path/to/home > t.exe
+        begin: /^\s{0,3}[/~\w\d[\]()@-]*[>%$#]/,
         starts: {
           end: /[^\\](?=\s*$)/,
           subLanguage: 'bash'

--- a/test/markup/shell/prompt-with-tilde.expected.txt
+++ b/test/markup/shell/prompt-with-tilde.expected.txt
@@ -1,0 +1,4 @@
+<span class="hljs-meta">~/docs&gt;</span><span class="bash"> cat readme.adoc</span>
+= Highlight.js
+
+Highlight.js is a syntax highlighter written in JavaScript.

--- a/test/markup/shell/prompt-with-tilde.txt
+++ b/test/markup/shell/prompt-with-tilde.txt
@@ -1,0 +1,4 @@
+~/docs> cat readme.adoc
+= Highlight.js
+
+Highlight.js is a syntax highlighter written in JavaScript.


### PR DESCRIPTION
resolves #2858

### Changes

Add space (`\s`) and tilde (`~`) in the list of characters that a prompt can contain.

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
