### PR TITLE
Add "make" as an alias for "Makefile" (#2883)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ New Languages:
 
 - Added 3rd party Red & Rebol grammar to SUPPORTED_LANGUAGES (#2872) [Oldes Huhuman][]
 
+Language improvements:
+
+- enh(makefile): Add `make` as an alias (#2883) [tripleee][]
+
 Grammar improvements:
 
 - enh(vb) Large rework of VB.net grammar (#2808) [Jan Pilzer][]
@@ -19,6 +23,7 @@ Grammar improvements:
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes
 [Josh Goebel]: https://github.com/joshgoebel
+[tripleee]: https://github.com/tripleee
 
 
 ## Version 10.4.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -109,7 +109,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | LiveCode Server         | livecodeserver         |         |
 | LiveScript              | livescript, ls         |         |
 | Lua                     | lua                    |         |
-| Makefile                | makefile, mk, mak      |         |
+| Makefile                | makefile, mk, mak, make |        |
 | Markdown                | markdown, md, mkdown, mkd |      |
 | Mathematica             | mathematica, mma, wl   |         |
 | Matlab                  | matlab                 |         |

--- a/src/languages/makefile.js
+++ b/src/languages/makefile.js
@@ -69,7 +69,8 @@ export default function(hljs) {
     name: 'Makefile',
     aliases: [
       'mk',
-      'mak'
+      'mak',
+      'make',
     ],
     keywords: {
       $pattern: /[\w-]+/,


### PR DESCRIPTION
Closes #2883, add `make` as an alias for `Makefile`

### Changes

Add the alias and include it in `SUPPORTED_LANGUAGES.md`

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [X] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
