### PR TITLE
fix(js) empty block-comment breaks highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Grammar improvements:
   - Type suffixes: 123UI (unsigned integer)
   - Improves directives detection and adds support for `Enable`, `Disable`, and `Then` keywords
   - Adds more markup tests
-- enh(javascript) Fix empty block-comments from breaking highlighting (#2896) [Jan Pilzer][]
+- fix(javascript) Empty block-comments break highlighting (#2896) [Jan Pilzer][]
 
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Grammar improvements:
   - Type suffixes: 123UI (unsigned integer)
   - Improves directives detection and adds support for `Enable`, `Disable`, and `Then` keywords
   - Adds more markup tests
+- enh(javascript) Fix empty block-comments from breaking highlighting (#2896) [Jan Pilzer][]
 
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -135,7 +135,7 @@ export default function(hljs) {
     ]
   };
   const JSDOC_COMMENT = hljs.COMMENT(
-    '/\\*\\*',
+    /\/\*\*(?!\/)/,
     '\\*/',
     {
       relevance: 0,

--- a/test/markup/javascript/block-comments.expect.txt
+++ b/test/markup/javascript/block-comments.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-comment">/* Block-Comment */</span>
+
+<span class="hljs-comment">/* Can
+   Be
+   Multi-
+   Line
+*/</span>
+
+<span class="hljs-comment">/**/</span>

--- a/test/markup/javascript/block-comments.txt
+++ b/test/markup/javascript/block-comments.txt
@@ -1,0 +1,9 @@
+/* Block-Comment */
+
+/* Can
+   Be
+   Multi-
+   Line
+*/
+
+/**/


### PR DESCRIPTION
Resolves #2896

### Changes
Distinguish between an empty block comment `/**/` and an opening JSDoc `/**` by adding a negative look-ahead for a `/`.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
