### PR TITLE
(dart) fixes empty comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Grammar improvements:
   - Type suffixes: 123UI (unsigned integer)
   - Improves directives detection and adds support for `Enable`, `Disable`, and `Then` keywords
   - Adds more markup tests
+- enh(dart) Fix empty block-comments from breaking highlighting (#2898) [Jan Pilzer][]
+- enh(dart) Fix empty doc-comment eating next line [Jan Pilzer][]
 
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -152,15 +152,16 @@ export default function(hljs) {
     contains: [
       STRING,
       hljs.COMMENT(
-        '/\\*\\*',
-        '\\*/', {
+        /\/\*\*(?!\/)/,
+        /\*\//,
+        {
           subLanguage: 'markdown',
           relevance: 0
         }
       ),
       hljs.COMMENT(
-        '///+\\s*',
-        '$', {
+        /\/{3,} ?/,
+        /$/, {
           contains: [{
             subLanguage: 'markdown',
             begin: '.',

--- a/test/markup/dart/comment-markdown.expect.txt
+++ b/test/markup/dart/comment-markdown.expect.txt
@@ -5,5 +5,10 @@
 <span class="hljs-comment">/// <span class="markdown"><span class="hljs-code">code;</span></span></span>
 <span class="hljs-comment">/// <span class="markdown"><span class="hljs-code">```</span></span></span>
 <span class="hljs-comment">/// <span class="markdown">text.</span></span>
+<span class="hljs-comment">/// <span class="markdown"><span class="hljs-bullet">*</span> bullet</span></span>
+<span class="hljs-comment">/// <span class="markdown"><span class="hljs-bullet">  *</span> sub-bullet</span></span>
 
-<span class="hljs-comment">/// <span class="markdown">Comment 3.</span></span>
+<span class="hljs-comment">///</span>
+code;
+
+<span class="hljs-comment">/**/</span>code;

--- a/test/markup/dart/comment-markdown.txt
+++ b/test/markup/dart/comment-markdown.txt
@@ -5,5 +5,10 @@
 /// code;
 /// ```
 /// text.
+/// * bullet
+///   * sub-bullet
 
-/// Comment 3.
+///
+code;
+
+/**/code;


### PR DESCRIPTION
Resolves #2898

Also fixes empty doc comments eating the next line:
Expected:
![image](https://user-images.githubusercontent.com/2564094/100555722-4d44e580-3252-11eb-80bf-41161ee06127.png)

Actual:
![image](https://user-images.githubusercontent.com/2564094/100555727-559d2080-3252-11eb-9fea-98e13828bb3a.png)

This type of issue happens easily when using `\s` to mean whitespace within a line as `\s` also matches the `\n`. In most contexts it should probably be replaced by `[\t ]` when using multi-line matching.

### Changes
* Distinguish between an empty block comment (`/**/` and an opening doc-comment (`/**`) by adding a negative look-ahead for `/`.
* Only match for up to a single space following a doc-comment (`///`) instead of any number of whitespace.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
