### PR TITLE
(chore) Clean up linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,27 +2,21 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    node: true,
-    mocha: true
+    node: true
   },
   extends: [
     "eslint:recommended",
     "standard"
   ],
-  globals: {
-    Atomics: "readonly",
-    SharedArrayBuffer: "readonly"
-  },
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: "module"
   },
-  // parser: '@typescript-eslint/parser',
   plugins: [
     "@typescript-eslint"
   ],
   rules: {
-    "no-var": 1,
+    "no-var": "warn",
     "init-declarations": ["error", "always"],
     "array-callback-return": "error",
     "block-scoped-var": "error",
@@ -55,32 +49,47 @@ module.exports = {
       files: ["src/languages/*.js"],
       rules: {
         "no-unused-expressions": "off",
-        // // languages are all over the map and we don't want to
-        // // do a mass edit so turn off the most egregious rule violations
+        // languages are all over the map and we don't want to
+        // do a mass edit so turn off the most egregious rule violations
         // indent: "off",
-        camelcase: 0,
-        "no-control-regex": 0,
-        "no-useless-escape": 0,
-        "comma-dangle": 1,
+        camelcase: "off",
+        "no-control-regex": "off",
+        "no-useless-escape": "off",
+        "comma-dangle": "warn",
         "array-bracket-spacing": ["error", "always"
-        //   {
-        //     objectsInArrays: true
+          // {
+          //   objectsInArrays: true
           // }
         ],
-        // "object-curly-spacing": 1,
+        // "object-curly-spacing": "warn",
         // "key-spacing": "off",
-        // "array-bracket-spacing": [1],
-        "array-bracket-newline": [1, {
+        // "array-bracket-spacing": ["warn"],
+        "array-bracket-newline": ["warn", {
           multiline: true,
           minItems: 2
         }],
-        "array-element-newline": 1,
+        "array-element-newline": "warn",
         "object-curly-newline": [1, {
           minProperties: 1
         }],
         "object-property-newline": [2,
           { allowAllPropertiesOnSameLine: false }
         ]
+      }
+    },
+    {
+      files: ["test/**/*.js"],
+      env: {
+        mocha: true
+      },
+      parserOptions: {
+        ecmaVersion: 2021
+      }
+    },
+    {
+      files: ["tools/**/*.js"],
+      parserOptions: {
+        ecmaVersion: 2021
       }
     }
   ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     ecmaVersion: 2015,
     sourceType: "module"
   },
+  // parser: '@typescript-eslint/parser',
   plugins: [
     "@typescript-eslint"
   ],
@@ -83,13 +84,13 @@ module.exports = {
         mocha: true
       },
       parserOptions: {
-        ecmaVersion: 2021
+        ecmaVersion: 2018
       }
     },
     {
       files: ["tools/**/*.js"],
       parserOptions: {
-        ecmaVersion: 2021
+        ecmaVersion: 2018
       }
     }
   ]

--- a/.eslintrc.lang.js
+++ b/.eslintrc.lang.js
@@ -2,13 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    node: true,
-    mocha: true
-  },
-  extends: [],
-  globals: {
-    Atomics: "readonly",
-    SharedArrayBuffer: "readonly"
+    node: true
   },
   parserOptions: {
     ecmaVersion: 2015,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,16 +6,16 @@ name: Lint
 on:
   pull_request:
     branches:
-      - master
+    - master
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "*" # latest
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run lint-languages
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: "*" # latest
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run lint-languages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,28 +4,18 @@
 name: Lint
 
 on:
-#   push:
-    # branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [15.x]
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - name: Lint the main source
-      run: npx eslint src/*.js src/lib/*.js
-    - name: Lint the language grammars
-      run: npx eslint --no-eslintrc -c .eslintrc.lang.js src/languages/**/*.js
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "*" # latest
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run lint-languages

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,0 @@
-// whole codebase isn't ES8/9 yet, but our tests and some things are
-{
-    "esversion": 9,
-    "node": true,
-    // eslint warns us about semicolons
-    "-W033": false
-}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "mocha": "mocha",
-    "lint": "eslint -c .eslintrc.js src/*.js src/lib/*.js",
+    "lint": "eslint src/*.js src/lib/*.js src/plugins/*.js",
+    "lint-languages": "eslint --no-eslintrc -c .eslintrc.lang.js src/languages/**/*.js",
     "build_and_test": "npm run build && npm run test",
     "build": "node ./tools/build.js -t node",
     "build-cdn": "node ./tools/build.js -t cdn",

--- a/src/languages/perl.js
+++ b/src/languages/perl.js
@@ -159,7 +159,7 @@ export default function(hljs) {
             /\//,
             /(\\.|[^\\\/])*/,
             /\//,
-            REGEX_MODIFIERS,
+            REGEX_MODIFIERS
           ),
           relevance: 10
         },

--- a/src/plugins/merge_html.js
+++ b/src/plugins/merge_html.js
@@ -1,10 +1,10 @@
-import { escapeHTML } from "../lib/utils.js"
+import { escapeHTML } from "../lib/utils.js";
 
 /* plugin itself */
 
 /** @type {HLJSPlugin} */
 export const mergeHTMLPlugin = {
-  "after:highlightBlock": ( {block, result, text}) => {
+  "after:highlightBlock": ({ block, result, text }) => {
     const originalStream = nodeStream(block);
     if (!originalStream.length) return;
 
@@ -14,7 +14,7 @@ export const mergeHTMLPlugin = {
   }
 };
 
-/* Stream merging support functoins */
+/* Stream merging support functions */
 
 /**
  * @typedef Event

--- a/src/plugins/vue.js
+++ b/src/plugins/vue.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { escapeHTML } from "../lib/utils";
+import { escapeHTML } from "../lib/utils.js";
 
 function hasValueOrEmptyAttribute(value) {
   return Boolean(value || value === "");
@@ -17,7 +17,7 @@ export function BuildVuePlugin(hljs) {
     computed: {
       className() {
         if (this.unknownLanguage) return "";
-  
+
         return "hljs " + this.detectedLanguage;
       },
       highlighted() {
@@ -27,8 +27,8 @@ export function BuildVuePlugin(hljs) {
           this.unknownLanguage = true;
           return escapeHTML(this.code);
         }
-  
-        let result;
+
+        let result = {};
         if (this.autoDetect) {
           result = hljs.highlightAuto(this.code);
           this.detectedLanguage = result.language;
@@ -51,12 +51,13 @@ export function BuildVuePlugin(hljs) {
       return createElement("pre", {}, [
         createElement("code", {
           class: this.className,
-          domProps: { innerHTML: this.highlighted }})
+          domProps: { innerHTML: this.highlighted }
+        })
       ]);
     }
     // template: `<pre><code :class="className" v-html="highlighted"></code></pre>`
   };
-  
+
   const VuePlugin = {
     install(Vue) {
       Vue.component('highlightjs', Component);


### PR DESCRIPTION
### Changes
- Remove JSHint config
- ~Switch ESLint config to JSON (for JSON-schema support)~
- Change `npm` lint script to include `src/plugins` folder
  - Fix some linting issues in the vue plugin
  - Fix some linting issues in the `merge_html` plugin
- Add `lint-languages` npm script
- Clean up lint workflow
  - Use latest node
  - Use `npm ci` for faster and more reliable dependency installs
  - Use new `npm lint` scripts
- Add new ESLint configs for `test` and `tools`, which are not included in CI, but help during development

### Checklist
- [x] Added markup tests, or they don't apply here because it's not a code change
- [ ] Updated the changelog at `CHANGES.md` - NA?
