### PR TITLE
enh(swift) Add support for closure arguments (#2871)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Grammar improvements:
 - fix(javascript) Empty block-comments break highlighting (#2896) [Jan Pilzer][]
 - enh(dart) Fix empty block-comments from breaking highlighting (#2898) [Jan Pilzer][]
 - enh(dart) Fix empty doc-comment eating next line [Jan Pilzer][]
-- enh(swift) Add support for closure arguments [Vaibhav Chanana][]
+- enh(swift) Add support for closure arguments (#2871) [Vaibhav Chanana][]
 
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Grammar improvements:
 - fix(javascript) Empty block-comments break highlighting (#2896) [Jan Pilzer][]
 - enh(dart) Fix empty block-comments from breaking highlighting (#2898) [Jan Pilzer][]
 - enh(dart) Fix empty doc-comment eating next line [Jan Pilzer][]
+- enh(swift) Add support for closure arguments [Vaibhav Chanana][]
 
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -96,7 +96,15 @@ export default function(hljs) {
         { begin: /\b0b([01]_*)+\b/ },
       ]
   };
-  SUBST.contains = [NUMBER];
+
+  // shorthand arguments in closures (eg. $0, $1)
+  // more info : https://docs.swift.org/swift-book/LanguageGuide/Closures.html#ID100
+  var CLOSURE_ARGUMENTS = {
+    className: "variable",
+    begin: "\\B\\$\\d+\\b",
+  };
+
+  SUBST.contains = [NUMBER, CLOSURE_ARGUMENTS];
 
   return {
     name: 'Swift',
@@ -107,6 +115,7 @@ export default function(hljs) {
       BLOCK_COMMENT,
       OPTIONAL_USING_TYPE,
       TYPE,
+      CLOSURE_ARGUMENTS,
       NUMBER,
       {
         className: 'function',

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -8,3 +8,5 @@
     <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
   }
 }
+
+reversedNames = names.sorted(by: { <span class="hljs-variable">$0</span> &gt; <span class="hljs-variable">$1</span> } )

--- a/test/markup/swift/functions.txt
+++ b/test/markup/swift/functions.txt
@@ -8,3 +8,5 @@ class MyClass {
     return true
   }
 }
+
+reversedNames = names.sorted(by: { $0 > $1 } )


### PR DESCRIPTION
Resolves #2871 

### Changes
1. Added a new mode to handle closure arguments such as `$0` or `$1`
1. This new mode has also been added as a submode inside STRING because of the following reason
<img src="https://user-images.githubusercontent.com/4337699/101211877-dff3e300-369d-11eb-978e-c75fddeab279.png" height="35px">

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors