### PR TITLE
enh(scheme) allow [] argument lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Language improvements:
 
 Grammar improvements:
 
+- enh(scheme) Allow `[]` for argument lists (#2913) [Josh Goebel][]
 - enh(vb) Large rework of VB.net grammar (#2808) [Jan Pilzer][]
   - Adds support for Date data types, see (#2775)
   - Adds support for `REM` comments and fixes `'''` doctags (#2875) (#2851)

--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -10,10 +10,10 @@ Category: lisp
 */
 
 export default function(hljs) {
-  var SCHEME_IDENT_RE = '[^\\(\\)\\[\\]\\{\\}",\'`;#|\\\\\\s]+';
-  var SCHEME_SIMPLE_NUMBER_RE = '(-|\\+)?\\d+([./]\\d+)?';
-  var SCHEME_COMPLEX_NUMBER_RE = SCHEME_SIMPLE_NUMBER_RE + '[+\\-]' + SCHEME_SIMPLE_NUMBER_RE + 'i';
-  var KEYWORDS = {
+  const SCHEME_IDENT_RE = '[^\\(\\)\\[\\]\\{\\}",\'`;#|\\\\\\s]+';
+  const SCHEME_SIMPLE_NUMBER_RE = '(-|\\+)?\\d+([./]\\d+)?';
+  const SCHEME_COMPLEX_NUMBER_RE = SCHEME_SIMPLE_NUMBER_RE + '[+\\-]' + SCHEME_SIMPLE_NUMBER_RE + 'i';
+  const KEYWORDS = {
     $pattern: SCHEME_IDENT_RE,
     'builtin-name':
       'case-lambda call/cc class define-class exit-handler field import ' +
@@ -51,31 +51,43 @@ export default function(hljs) {
       'with-input-from-file with-output-to-file write write-char zero?'
   };
 
-  var LITERAL = {
+  const LITERAL = {
     className: 'literal',
     begin: '(#t|#f|#\\\\' + SCHEME_IDENT_RE + '|#\\\\.)'
   };
 
-  var NUMBER = {
+  const NUMBER = {
     className: 'number',
     variants: [
-      { begin: SCHEME_SIMPLE_NUMBER_RE, relevance: 0 },
-      { begin: SCHEME_COMPLEX_NUMBER_RE, relevance: 0 },
-      { begin: '#b[0-1]+(/[0-1]+)?' },
-      { begin: '#o[0-7]+(/[0-7]+)?' },
-      { begin: '#x[0-9a-f]+(/[0-9a-f]+)?' }
+      {
+        begin: SCHEME_SIMPLE_NUMBER_RE,
+        relevance: 0
+      },
+      {
+        begin: SCHEME_COMPLEX_NUMBER_RE,
+        relevance: 0
+      },
+      {
+        begin: '#b[0-1]+(/[0-1]+)?'
+      },
+      {
+        begin: '#o[0-7]+(/[0-7]+)?'
+      },
+      {
+        begin: '#x[0-9a-f]+(/[0-9a-f]+)?'
+      }
     ]
   };
 
-  var STRING = hljs.QUOTE_STRING_MODE;
+  const STRING = hljs.QUOTE_STRING_MODE;
 
-  var REGULAR_EXPRESSION = {
+  const REGULAR_EXPRESSION = {
     className: 'regexp',
     begin: '#[pr]x"',
     end: '[^\\\\]"'
   };
 
-  var COMMENT_MODES = [
+  const COMMENT_MODES = [
     hljs.COMMENT(
       ';',
       '$',
@@ -86,69 +98,114 @@ export default function(hljs) {
     hljs.COMMENT('#\\|', '\\|#')
   ];
 
-  var IDENT = {
+  const IDENT = {
     begin: SCHEME_IDENT_RE,
     relevance: 0
   };
 
-  var QUOTED_IDENT = {
+  const QUOTED_IDENT = {
     className: 'symbol',
     begin: '\'' + SCHEME_IDENT_RE
   };
 
-  var BODY = {
+  const BODY = {
     endsWithParent: true,
     relevance: 0
   };
 
-  var QUOTED_LIST = {
+  const QUOTED_LIST = {
     variants: [
-      { begin: /'/ },
-      { begin: '`' }
+      {
+        begin: /'/
+      },
+      {
+        begin: '`'
+      }
     ],
     contains: [
       {
-        begin: '\\(', end: '\\)',
-        contains: ['self', LITERAL, STRING, NUMBER, IDENT, QUOTED_IDENT]
+        begin: '\\(',
+        end: '\\)',
+        contains: [
+          'self',
+          LITERAL,
+          STRING,
+          NUMBER,
+          IDENT,
+          QUOTED_IDENT
+        ]
       }
     ]
   };
 
-  var NAME = {
+  const NAME = {
     className: 'name',
     relevance: 0,
     begin: SCHEME_IDENT_RE,
     keywords: KEYWORDS
   };
 
-  var LAMBDA = {
-    begin: /lambda/, endsWithParent: true, returnBegin: true,
+  const LAMBDA = {
+    begin: /lambda/,
+    endsWithParent: true,
+    returnBegin: true,
     contains: [
       NAME,
       {
         endsParent: true,
         variants: [
-          {begin: /\(/, end: /\)/ },
-          {begin: /\[/, end: /\]/},
+          {
+            begin: /\(/,
+            end: /\)/
+          },
+          {
+            begin: /\[/,
+            end: /\]/
+          }
         ],
-        contains: [IDENT],
+        contains: [ IDENT ]
       }
     ]
   };
 
-  var LIST = {
+  const LIST = {
     variants: [
-      { begin: '\\(', end: '\\)' },
-      { begin: '\\[', end: '\\]' }
+      {
+        begin: '\\(',
+        end: '\\)'
+      },
+      {
+        begin: '\\[',
+        end: '\\]'
+      }
     ],
-    contains: [LAMBDA, NAME, BODY]
+    contains: [
+      LAMBDA,
+      NAME,
+      BODY
+    ]
   };
 
-  BODY.contains = [LITERAL, NUMBER, STRING, IDENT, QUOTED_IDENT, QUOTED_LIST, LIST].concat(COMMENT_MODES);
+  BODY.contains = [
+    LITERAL,
+    NUMBER,
+    STRING,
+    IDENT,
+    QUOTED_IDENT,
+    QUOTED_LIST,
+    LIST
+  ].concat(COMMENT_MODES);
 
   return {
     name: 'Scheme',
     illegal: /\S/,
-    contains: [hljs.SHEBANG(), NUMBER, STRING, QUOTED_IDENT, QUOTED_LIST, LIST].concat(COMMENT_MODES)
+    contains: [
+      hljs.SHEBANG(),
+      NUMBER,
+      STRING,
+      QUOTED_IDENT,
+      QUOTED_LIST,
+      LIST
+    ].concat(COMMENT_MODES)
   };
 }

--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -126,7 +126,11 @@ export default function(hljs) {
     contains: [
       NAME,
       {
-        begin: /\(/, end: /\)/, endsParent: true,
+        endsParent: true,
+        variants: [
+          {begin: /\(/, end: /\)/ },
+          {begin: /\[/, end: /\]/},
+        ],
         contains: [IDENT],
       }
     ]

--- a/test/markup/scheme/lambda.expect.txt
+++ b/test/markup/scheme/lambda.expect.txt
@@ -1,1 +1,7 @@
 (<span class="hljs-name"><span class="hljs-builtin-name">lambda</span></span> (x y z) (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> y z))
+
+(<span class="hljs-name"><span class="hljs-builtin-name">define</span></span> add-point
+  (<span class="hljs-name"><span class="hljs-builtin-name">lambda</span></span> [p1 p2]
+    (<span class="hljs-name">make-point</span>
+      (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> (<span class="hljs-name">point-x</span> p1) (<span class="hljs-name">point-x</span> p2))
+      (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> (<span class="hljs-name">point-y</span> p1) (<span class="hljs-name">point-y</span> p2)))))

--- a/test/markup/scheme/lambda.txt
+++ b/test/markup/scheme/lambda.txt
@@ -1,1 +1,7 @@
 (lambda (x y z) (+ y z))
+
+(define add-point
+  (lambda [p1 p2]
+    (make-point
+      (+ (point-x p1) (point-x p2))
+      (+ (point-y p1) (point-y p2)))))


### PR DESCRIPTION
Resolves #2890.



### Changes

Allow [] argument lists such as:

```
(define add-point
  (lambda [p1 p2]
    (make-point
      (+ (point-x p1) (point-x p2))
      (+ (point-y p1) (point-y p2)))))
```

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors