### PR TITLE
enh(cpp) support pack expansion in function declarations

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -311,3 +311,4 @@ Contributors:
 - Marcus Ortiz <mportiz08@gmail.com>
 - Guillaume Grossetie <ggrossetie@yuzutech.fr>
 - Steven Van Impe <steven.vanimpe@icloud.com>
+- Martin Dørum <martid0311@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ New Languages:
 
 Language improvements:
 
+- enh(cpp): Support C++ pack expansion in function arguments [Martin Dørum][]
 - enh(makefile): Add `make` as an alias (#2883) [tripleee][]
 - fix(http) avoid recursive sublanguage and tighten rules (#2893) [Josh Goebel][]
 - enh(swift) Improved grammar for strings (#2819) [Steven Van Impe][]
@@ -28,6 +29,7 @@ Grammar improvements:
 - enh(dart) Fix empty doc-comment eating next line [Jan Pilzer][]
 - enh(asciidoc) Adds support for unconstrained bold syntax (#2869) [Guillaume Grossetie][]
 
+[Martin Dørum]: https://github.com/mortie
 [Jan Pilzer]: https://github.com/Hirse
 [Oldes Huhuman]: https://github.com/Oldes
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/c-like.js
+++ b/src/languages/c-like.js
@@ -187,7 +187,7 @@ export default function(hljs) {
     end: /[{;=]/,
     excludeEnd: true,
     keywords: CPP_KEYWORDS,
-    illegal: /[^\w\s\*&:<>]/,
+    illegal: /[^\w\s\*&:<>.]/,
     contains: [
       { // to prevent it from being confused as the function title
         begin: DECLTYPE_AUTO_RE,

--- a/test/markup/cpp/function-declarations.expect.txt
+++ b/test/markup/cpp/function-declarations.expect.txt
@@ -13,4 +13,8 @@
 <span class="hljs-comment">// template</span>
 <span class="hljs-function">boost::optional&lt;application&gt; <span class="hljs-title">handle_key</span><span class="hljs-params">(application state, key_code key, coord size)</span></span>;
 
+<span class="hljs-comment">// pack expansion in function arguments</span>
+<span class="hljs-function"><span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T...&gt;
+<span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(T... args)</span> </span>{}
+
 test();

--- a/test/markup/cpp/function-declarations.txt
+++ b/test/markup/cpp/function-declarations.txt
@@ -13,4 +13,8 @@ B::type test() {};
 // template
 boost::optional<application> handle_key(application state, key_code key, coord size);
 
+// pack expansion in function arguments
+template<typename T...>
+void foo(T... args) {}
+
 test();


### PR DESCRIPTION
Make dots legal in function declarations, which is necessary for variadic functions with parameter packs in C++: https://en.cppreference.com/w/cpp/language/parameter_pack

Resolves #2917 

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
