### PR TITLE
(chore) fix contributor parsing in AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -27,7 +27,7 @@ Former Core Team members:
 Contributors:
 
 - Peter Leonov <gojpeg@gmail.com>
-- Vanessa Sochat <@vsoch>
+- Vanessa Sochat (https://github.com/vsoch)
 - Victor Karamzin <Victor.Karamzin@enterra-inc.com>
 - Vsevolod Solovyov <vsevolod.solovyov@gmail.com>
 - Anton Kovalyov <anton@kovalyov.net>
@@ -298,16 +298,16 @@ Contributors:
 - David Pine <david.pine.7@gmail.com>
 - Konrad Rudolph <konrad.rudolph@gmail.com>
 - Tom Wallace <thomasmichaelwallace@gmail.com>
-- Michael Newton <miken32@github>
-- Richard Gibson <gibson042@github>
+- Michael Newton (https://github.com/miken32)
+- Richard Gibson (https://github.com/gibson042)
 - Fredrik Ekre <ekrefredrik@gmail.com>
-- Jan Pilzer <Hirse@github>
+- Jan Pilzer (https://github.com/Hirse)
 - Jonathan Sharpe <mail@jonrshar.pe>
 - Michael Rush <michaelrush@gmail.com>
 - Florian Bezdeka <florian@bezdeka.de>
 - Marat Nagayev <nagaevmt@yandex.ru>
 - Patrick Scheibe <patrick@halirutan.de>
-- Kyle Brown <kylebrown9@github>
+- Kyle Brown (https://github.com/kylebrown9)
 - Marcus Ortiz <mportiz08@gmail.com>
 - Guillaume Grossetie <ggrossetie@yuzutech.fr>
 - Steven Van Impe <steven.vanimpe@icloud.com>

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -41,23 +41,18 @@ async function buildNodeHighlightJS() {
 }
 
 async function buildPackageJSON() {
-  const CONTRIBUTOR = /^- (.*) <(.*)>$/
+  const CONTRIBUTOR = /^- ([^<(]+( ?<.+>)?( ?\(http.+\))?)/;
 
-  let authors = await fs.readFile("AUTHORS.txt", {encoding: "utf8"})
-  let lines = authors.split(/\r?\n/)
-  let json = require("../package")
-  json.contributors = lines.reduce((acc, line) => {
-    let matches = line.match(CONTRIBUTOR)
+  const authors = await fs.readFile("AUTHORS.txt", { encoding: "utf8" });
+  const lines = authors.split(/\r?\n/);
+  const packageJson = require("../package");
 
-    if (matches) {
-      acc.push({
-        name: matches[1],
-        email: matches[2]
-      })
-    }
-    return acc;
-  }, []);
-  await fs.writeFile(`${process.env.BUILD_DIR}/package.json`, JSON.stringify(json, null, '   '));
+  packageJson.contributors = lines
+    .map(line => line.match(CONTRIBUTOR))
+    .filter((matches) => matches)
+    .map((matches) => matches[1]);
+
+  await fs.writeFile(`${process.env.BUILD_DIR}/package.json`, JSON.stringify(packageJson, null, 2));
 }
 
 async function buildLanguages(languages) {


### PR DESCRIPTION
When building the list of contributors for the `package.json`, contributors that added their link instead of their email are parsed incorrectly:
![image](https://user-images.githubusercontent.com/2564094/102577167-546e4f00-40ac-11eb-96da-376b0f7bb53d.png)

### Changes
- Update format of the list of authors 
- Updates parsing logic
- Format `package.json` contributor list to string format
  ![image](https://user-images.githubusercontent.com/2564094/102577775-8af89980-40ad-11eb-942d-3d876b07a872.png)

npm documentation:
> ![image](https://user-images.githubusercontent.com/2564094/102577238-8aabce80-40ac-11eb-8453-6c582b12431b.png)
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#people-fields-author-contributors

### Checklist
- [x] ~Added markup tests~ NA
- [x] ~Updated the changelog at `CHANGES.md`~
- [x] Added myself to `AUTHORS.txt`, under Contributors
