### PR TITLE
enh(css) Fix highlighting of numbers in @keyframes 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ Language grammar improvements:
 - enh(asciidoc) Adds support for unconstrained bold syntax (#2869) [Guillaume Grossetie][]
 - enh(c-like) Incorrect highlighting for interger suffix (#2919) [Vaibhav Chanana][]
 - enh(properties) Correctly handle trailing backslash (#2922) [Vaibhav Chanana][]
+- enh(css) Fix highlighting of numbers in keyframe animation (#2934) [Vaibhav Chanana][]
 
 Recent Deprecations:
 

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -68,6 +68,7 @@ export default function(hljs) {
     illegal: /[=|'\$]/,
     contains: [
       hljs.C_BLOCK_COMMENT_MODE,
+      hljs.CSS_NUMBER_MODE,
       {
         className: 'selector-id', begin: /#[A-Za-z0-9_-]+/
       },

--- a/test/markup/css/sample.expect.txt
+++ b/test/markup/css/sample.expect.txt
@@ -43,3 +43,9 @@
     <span class="hljs-attribute">src</span>: <span class="hljs-built_in">url</span>(<span class="hljs-string">&quot;/fonts/OpenSans-Regular-webfont.woff2&quot;</span>) <span class="hljs-built_in">format</span>(<span class="hljs-string">&quot;woff2&quot;</span>),
          <span class="hljs-built_in">url</span>(<span class="hljs-string">&quot;/fonts/OpenSans-Regular-webfont.woff&quot;</span>) <span class="hljs-built_in">format</span>(<span class="hljs-string">&quot;woff&quot;</span>);
   }
+
+<span class="hljs-keyword">@keyframes</span> animation {
+  <span class="hljs-number">10.1%</span> {
+    <span class="hljs-attribute">left</span>: <span class="hljs-number">10px</span>;
+  }
+}

--- a/test/markup/css/sample.txt
+++ b/test/markup/css/sample.txt
@@ -43,3 +43,9 @@ a[href*="example"], * [lang^=en] {
     src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
          url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
   }
+
+@keyframes animation {
+  10.1% {
+    left: 10px;
+  }
+}


### PR DESCRIPTION
Resolves #2934 

### Changes
Now the parser will check for numbers before checking for selector-class and selector-id

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
