### PR TITLE
(swift) Support operator and precedencegroup declarations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,15 @@ Language grammar improvements:
 
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
 
+Parser:
+
+- add `modes.MATCH_NOTHING_RE` that will never match
+  - This can be used with `end` to hold a mode open (it must then be ended with
+    `endsParent` in one of it's children modes) [Josh Goebel][]
+
 [Michael Newton]: https://github.com/miken32
 [Steven Van Impe]: https://github.com/svanimpe/
+[Josh Goebel]: https://github.com/joshgoebel
 
 
 ## Version 10.5.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,12 @@ New Languages:
 
 - Added 3rd party Laravel Blade grammar to SUPPORTED_LANGUAGES (#2944) [Michael Newton][]
 
+Language grammar improvements:
+
+- enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
+
 [Michael Newton]: https://github.com/miken32
+[Steven Van Impe]: https://github.com/svanimpe/
 
 
 ## Version 10.5.0

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -117,15 +117,22 @@ export const keywords = [
 // NOTE: Contextual keywords are reserved only in specific contexts.
 // Ideally, these should be matched using modes to avoid false positives.
 
-// TODO: Create a PRECEDENCE_GROUP mode to match the remaining contextual keywords:
-// assignment associativity higherThan left lowerThan none right
-// These aren't included in the list because they result in mostly false positives.
-
 // Literals.
 export const literals = [
   'false',
   'nil',
   'true'
+];
+
+// Keywords used in precedence groups.
+export const precedencegroupKeywords = [
+  'assignment',
+  'associativity',
+  'higherThan',
+  'left',
+  'lowerThan',
+  'none',
+  'right'
 ];
 
 // Keywords that start with a number sign (#).

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -416,11 +416,8 @@ export default function(hljs) {
   // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID380
   const OPERATOR_DECLARATION = {
     beginKeywords: 'operator',
+    end: hljs.MATCH_NOTHING_RE,
     contains: [
-      {
-        match: /\s+/,
-        relevance: 0
-      },
       {
         className: 'title',
         match: Swift.operator,
@@ -433,11 +430,8 @@ export default function(hljs) {
   // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID550
   const PRECEDENCEGROUP = {
     beginKeywords: 'precedencegroup',
+    end: hljs.MATCH_NOTHING_RE,
     contains: [
-      {
-        match: /\s+/,
-        relevance: 0
-      },
       {
         className: 'title',
         match: Swift.typeIdentifier,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -413,6 +413,49 @@ export default function(hljs) {
     ],
     illegal: /\[|%/
   };
+  // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID380
+  const OPERATOR_DECLARATION = {
+    beginKeywords: 'operator',
+    contains: [
+      {
+        match: /\s+/,
+        relevance: 0
+      },
+      {
+        className: 'title',
+        match: Swift.operator,
+        endsParent: true,
+        relevance: 0
+      }
+    ]
+  };
+
+  // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID550
+  const PRECEDENCEGROUP = {
+    beginKeywords: 'precedencegroup',
+    contains: [
+      {
+        match: /\s+/,
+        relevance: 0
+      },
+      {
+        className: 'title',
+        match: Swift.typeIdentifier,
+        relevance: 0
+      },
+      {
+        begin: /{/,
+        end: /}/,
+        relevance: 0,
+        endsParent: true,
+        keywords: [
+          ...Swift.precedencegroupKeywords,
+          ...Swift.literals
+        ].join(' '),
+        contains: [ TYPE ]
+      }
+    ]
+  };
 
   // Add supported submodes to string interpolation.
   for (const variant of STRING.variants) {
@@ -460,6 +503,8 @@ export default function(hljs) {
           ...KEYWORD_MODES
         ]
       },
+      OPERATOR_DECLARATION,
+      PRECEDENCEGROUP,
       {
         beginKeywords: 'import',
         end: /$/,

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -2,6 +2,7 @@ import { inherit } from './utils.js';
 import * as regex from './regex.js';
 
 // Common regexps
+export const MATCH_NOTHING_RE = /\b\B/;
 export const IDENT_RE = '[a-zA-Z]\\w*';
 export const UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
 export const NUMBER_RE = '\\b\\d+(\\.\\d+)?';

--- a/test/markup/swift/operator-declarations.expect.txt
+++ b/test/markup/swift/operator-declarations.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-keyword">prefix</span> <span class="hljs-keyword">operator</span> <span class="hljs-title">+++</span>
+<span class="hljs-keyword">postfix</span> <span class="hljs-keyword">operator</span> <span class="hljs-title">+++</span>
+<span class="hljs-keyword">infix</span> <span class="hljs-keyword">operator</span> <span class="hljs-title">+-</span>: <span class="hljs-type">AdditionPrecedence</span>

--- a/test/markup/swift/operator-declarations.txt
+++ b/test/markup/swift/operator-declarations.txt
@@ -1,0 +1,3 @@
+prefix operator +++
+postfix operator +++
+infix operator +-: AdditionPrecedence

--- a/test/markup/swift/precedencegroup.expect.txt
+++ b/test/markup/swift/precedencegroup.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-keyword">precedencegroup</span> <span class="hljs-title">MyGroup</span> {
+  <span class="hljs-keyword">higherThan</span>: <span class="hljs-type">OtherGroup</span>, <span class="hljs-type">AnotherGroup</span>
+  <span class="hljs-keyword">lowerThan</span>: <span class="hljs-type">OtherGroup</span>, <span class="hljs-type">AnotherGroup</span>
+  <span class="hljs-keyword">assignment</span>: <span class="hljs-keyword">true</span>
+  <span class="hljs-keyword">associativity</span>: <span class="hljs-keyword">left</span>
+  <span class="hljs-keyword">associativity</span>: <span class="hljs-keyword">right</span>
+  <span class="hljs-keyword">associativity</span>: <span class="hljs-keyword">none</span>
+}

--- a/test/markup/swift/precedencegroup.txt
+++ b/test/markup/swift/precedencegroup.txt
@@ -1,0 +1,8 @@
+precedencegroup MyGroup {
+  higherThan: OtherGroup, AnotherGroup
+  lowerThan: OtherGroup, AnotherGroup
+  assignment: true
+  associativity: left
+  associativity: right
+  associativity: none
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,6 +58,7 @@ interface ModesAPI {
     // built in regex
     IDENT_RE: string
     UNDERSCORE_IDENT_RE: string
+    MATCH_NOTHING_RE: string
     NUMBER_RE: string
     C_NUMBER_RE: string
     BINARY_NUMBER_RE: string


### PR DESCRIPTION
This was the final thing on my list :)

- Adds support for `title` highlighting in an operator declaration.
- Same for a `precedencegroup` declaration.
- Highlights the contextual keywords in a `precedencegroup`. These keywords were removed from the global list because they're very rarely used and would cause mostly incorrect highlights as global keywords.