### PR TITLE
Use Array.from(NodeList).forEach() for IE11

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -744,7 +744,7 @@ const HLJS = function(hljs) {
     initHighlighting.called = true;
 
     const blocks = document.querySelectorAll('pre code');
-    blocks.forEach(highlightBlock);
+    Array.from(blocks).forEach(highlightBlock);
   };
 
   // Higlights all when DOMContentLoaded fires


### PR DESCRIPTION
Fixes #2940 
