### PR TITLE
Add link to Laravel Blade plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 10.6.0 (wip)
+
+New Languages:
+
+- Added 3rd party Laravel Blade grammar to SUPPORTED_LANGUAGES (#2944) [Michael Newton][]
+
+[Michael Newton]: https://github.com/miken32
+
+
 ## Version 10.5.0
 
 Build:
@@ -84,7 +93,7 @@ Recent Deprecations:
 [Steven Van Impe]: https://github.com/svanimpe/
 [Vaibhav Chanana]: https://github.com/il3ven
 [Guillaume Grossetie]: https://github.com/mogztter
-[Michael Newton]: https://github.com/miken32
+
 
 ## Version 10.4.1 (tentative)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Parser:
 New Languages:
 
 - Added 3rd party Red & Rebol grammar to SUPPORTED_LANGUAGES (#2872) [Oldes Huhuman][]
+- Added 3rd party Laravel Blade grammar to SUPPORTED_LANGUAGES (#2944) [Michael Newton][]
 
 Language grammar improvements:
 
@@ -83,6 +84,7 @@ Recent Deprecations:
 [Steven Van Impe]: https://github.com/svanimpe/
 [Vaibhav Chanana]: https://github.com/il3ven
 [Guillaume Grossetie]: https://github.com/mogztter
+[Michael Newton]: https://github.com/miken32
 
 ## Version 10.4.1 (tentative)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@ Parser:
 New Languages:
 
 - Added 3rd party Red & Rebol grammar to SUPPORTED_LANGUAGES (#2872) [Oldes Huhuman][]
-- Added 3rd party Laravel Blade grammar to SUPPORTED_LANGUAGES (#2944) [Michael Newton][]
 
 Language grammar improvements:
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -30,6 +30,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Bash                    | bash, sh, zsh          |         |
 | Basic                   | basic                  |         |
 | BBCode                  | bbcode                 | [highlightjs-bbcode](https://github.com/RedGuy7/highlightjs-bbcode) |
+| Blade (Laravel)         | blade                  | [highlightjs-blade](https://github.com/miken32/highlightjs-blade) |
 | BNF                     | bnf                    |         |
 | Brainfuck               | brainfuck, bf          |         |
 | C#                      | csharp, cs             |         |


### PR DESCRIPTION
Adding a link to 3rd-party language plugin. Source, tests, and precompiled CDN are included.