### PR TITLE
(fix) Improve plugin-api types and docs

### DIFF
--- a/docs/plugin-api.rst
+++ b/docs/plugin-api.rst
@@ -13,15 +13,15 @@ You can add a plugin via the ``addPlugin`` API.
 ::
 
   // a plugin can be a class
-  addPlugin(new SimplePlugin())
-  addPlugin(new MoreComplexPlugin(options))
+  addPlugin(new SimplePlugin());
+  addPlugin(new MoreComplexPlugin(options));
 
   // or simply a keyed object of functions
   addPlugin({
-    'after:highlightBlock': (args) => {
-      ...
+    'after:highlightBlock': ({ block, result, text }) => {
+      // ...
     }
-  })
+  });
 
 Class based plugins
 ^^^^^^^^^^^^^^^^^^^
@@ -38,12 +38,12 @@ your class and execute it's callbacks as necessary.
       self.prefix = options.dataPrefix;
     }
 
-    'after:highlightBlock'({block, result}) {
+    'after:highlightBlock'({ block, result, text }) {
       // ...
     }
   }
 
-  hljs.addPlugin(new DataLanguagePlugin({dataPrefix: "hljs"}))
+  hljs.addPlugin(new DataLanguagePlugin({ dataPrefix: 'hljs' }));
 
 Function based plugins
 ^^^^^^^^^^^^^^^^^^^^^
@@ -52,16 +52,17 @@ This approach is best for simpler plugins.
 
 ::
 
-    hljs.addPlugin( {
-      'after:highlightBlock': ({block, result}) => {
-        // move the language from the result into the dataset
-        block.dataset.language = result.language }
-    })
+  hljs.addPlugin({
+    'after:highlightBlock': ({ block, result }) => {
+      // move the language from the result into the dataset
+      block.dataset.language = result.language;
+    }
+  });
 
 Callbacks
 ---------
 
-before:highlight({code, language})
+``before:highlight({code, language})``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed a context object with two keys:
@@ -89,7 +90,7 @@ Note: This callback does not fire from highlighting resulting from auto-language
 It returns nothing.
 
 
-after:highlight(result)
+``after:highlight(result)``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed the ``result`` object after highlighting is
@@ -101,13 +102,13 @@ Note: This callback does not fire from highlighting resulting from auto-language
 It returns nothing.
 
 
-after:highlightBlock({block, result, text})
+``after:highlightBlock({block, result, text})``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed an object with two keys:
 
 block
-  The HTML element of the block that's been highlighted
+  The HTML element of the block that's been highlighted.
 
 result
   The result object returned by `highlight` or `highlightAuto`.
@@ -118,17 +119,15 @@ text
 It returns nothing.
 
 
-before:highlightBlock({block, language})
+``before:highlightBlock({block, language})``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed an object with two keys:
 
 block
-  The HTML element of the block that will be highlighted
+  The HTML element of the block that will be highlighted.
 
 language
   The language determined from the class attribute (or undefined).
 
 It returns nothing.
-
-

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -99,7 +99,7 @@ type PluginEvent = keyof HLJSPlugin;
 type HLJSPlugin = {
     'after:highlight'?: (result: HighlightResult) => void,
     'before:highlight'?: (context: BeforeHighlightContext) => void,
-    'after:highlightBlock'?: (data: { result: HighlightResult}) => void,
+    'after:highlightBlock'?: (data: { block: Element, result: HighlightResult, text: string}) => void,
     'before:highlightBlock'?: (data: { block: Element, language: string}) => void,
 }
 


### PR DESCRIPTION
### Changes
- Fix types of `after:highlightBlock` to reflect actual parameter
- Clean up plugin-api docs

### Checklist
- [x] ~Added markup tests~, or they don't apply here because no code change
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
