### PR TITLE
enh(parser) beginKeyword no longer bestows double relevance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Language grammar improvements:
 
 Parser:
 
+- `beginKeyword` no longer bestows double relevance (#2953) [Josh Goebel][]
 - add `modes.MATCH_NOTHING_RE` that will never match
   - This can be used with `end` to hold a mode open (it must then be ended with
     `endsParent` in one of it's children modes) [Josh Goebel][]

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -508,7 +508,9 @@ const HLJS = function(hljs) {
       result = emitter.toHTML();
 
       return {
-        relevance: relevance,
+        // avoid possible breakage with v10 clients expecting
+        // this to always be an integer
+        relevance: Math.floor(relevance),
         value: result,
         language: languageName,
         illegal: false,

--- a/src/languages/clojure-repl.js
+++ b/src/languages/clojure-repl.js
@@ -11,13 +11,15 @@ Category: lisp
 export default function(hljs) {
   return {
     name: 'Clojure REPL',
-    contains: [{
-      className: 'meta',
-      begin: /^([\w.-]+|\s*#_)?=>/,
-      starts: {
-        end: /$/,
-        subLanguage: 'clojure'
+    contains: [
+      {
+        className: 'meta',
+        begin: /^([\w.-]+|\s*#_)?=>/,
+        starts: {
+          end: /$/,
+          subLanguage: 'clojure'
+        }
       }
-    }]
+    ]
   };
 }

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -8,10 +8,10 @@ Category: lisp
 
 /** @type LanguageFn */
 export default function(hljs) {
-  var SYMBOLSTART = 'a-zA-Z_\\-!.?+*=<>&#\'';
-  var SYMBOL_RE = '[' + SYMBOLSTART + '][' + SYMBOLSTART + '0-9/;:]*';
-  var globals = 'def defonce defprotocol defstruct defmulti defmethod defn- defn defmacro deftype defrecord';
-  var keywords = {
+  const SYMBOLSTART = 'a-zA-Z_\\-!.?+*=<>&#\'';
+  const SYMBOL_RE = '[' + SYMBOLSTART + '][' + SYMBOLSTART + '0-9/;:]*';
+  const globals = 'def defonce defprotocol defstruct defmulti defmethod defn- defn defmacro deftype defrecord';
+  const keywords = {
     $pattern: SYMBOL_RE,
     'builtin-name':
       // Clojure keywords
@@ -45,57 +45,73 @@ export default function(hljs) {
       'lazy-seq spread list* str find-keyword keyword symbol gensym force rationalize'
   };
 
-  var SIMPLE_NUMBER_RE = '[-+]?\\d+(\\.\\d+)?';
+  const SIMPLE_NUMBER_RE = '[-+]?\\d+(\\.\\d+)?';
 
-  var SYMBOL = {
+  const SYMBOL = {
     begin: SYMBOL_RE,
     relevance: 0
   };
-  var NUMBER = {
-    className: 'number', begin: SIMPLE_NUMBER_RE,
+  const NUMBER = {
+    className: 'number',
+    begin: SIMPLE_NUMBER_RE,
     relevance: 0
   };
-  var STRING = hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null});
-  var COMMENT = hljs.COMMENT(
+  const STRING = hljs.inherit(hljs.QUOTE_STRING_MODE, {
+    illegal: null
+  });
+  const COMMENT = hljs.COMMENT(
     ';',
     '$',
     {
       relevance: 0
     }
   );
-  var LITERAL = {
+  const LITERAL = {
     className: 'literal',
     begin: /\b(true|false|nil)\b/
   };
-  var COLLECTION = {
-    begin: '[\\[\\{]', end: '[\\]\\}]'
+  const COLLECTION = {
+    begin: '[\\[\\{]',
+    end: '[\\]\\}]'
   };
-  var HINT = {
+  const HINT = {
     className: 'comment',
     begin: '\\^' + SYMBOL_RE
   };
-  var HINT_COL = hljs.COMMENT('\\^\\{', '\\}');
-  var KEY = {
+  const HINT_COL = hljs.COMMENT('\\^\\{', '\\}');
+  const KEY = {
     className: 'symbol',
     begin: '[:]{1,2}' + SYMBOL_RE
   };
-  var LIST = {
-    begin: '\\(', end: '\\)'
+  const LIST = {
+    begin: '\\(',
+    end: '\\)'
   };
-  var BODY = {
+  const BODY = {
     endsWithParent: true,
     relevance: 0
   };
-  var NAME = {
+  const NAME = {
     keywords: keywords,
     className: 'name',
     begin: SYMBOL_RE,
     relevance: 0,
     starts: BODY
   };
-  var DEFAULT_CONTAINS = [LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL, SYMBOL];
+  const DEFAULT_CONTAINS = [
+    LIST,
+    STRING,
+    HINT,
+    HINT_COL,
+    COMMENT,
+    KEY,
+    COLLECTION,
+    NUMBER,
+    LITERAL,
+    SYMBOL
+  ];
 
-  var GLOBAL = {
+  const GLOBAL = {
     beginKeywords: globals,
     lexemes: SYMBOL_RE,
     end: '(\\[|#|\\d|"|:|\\{|\\)|\\(|$)',
@@ -107,19 +123,34 @@ export default function(hljs) {
         excludeEnd: true,
         // we can only have a single title
         endsParent: true
-      },
+      }
     ].concat(DEFAULT_CONTAINS)
   };
 
-  LIST.contains = [hljs.COMMENT('comment', ''), GLOBAL, NAME, BODY];
+  LIST.contains = [
+    hljs.COMMENT('comment', ''),
+    GLOBAL,
+    NAME,
+    BODY
+  ];
   BODY.contains = DEFAULT_CONTAINS;
   COLLECTION.contains = DEFAULT_CONTAINS;
-  HINT_COL.contains = [COLLECTION];
+  HINT_COL.contains = [ COLLECTION ];
 
   return {
     name: 'Clojure',
-    aliases: ['clj'],
+    aliases: [ 'clj' ],
     illegal: /\S/,
-    contains: [LIST, STRING, HINT, HINT_COL, COMMENT, KEY, COLLECTION, NUMBER, LITERAL]
+    contains: [
+      LIST,
+      STRING,
+      HINT,
+      HINT_COL,
+      COMMENT,
+      KEY,
+      COLLECTION,
+      NUMBER,
+      LITERAL
+    ]
   };
 }

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -116,6 +116,30 @@ export default function(hljs) {
   TUPLE.contains = BASIC_MODES;
   RECORD_ACCESS.contains[1].contains = BASIC_MODES;
 
+  const DIRECTIVES = [
+    "-module",
+    "-record",
+    "-undef",
+    "-export",
+    "-ifdef",
+    "-ifndef",
+    "-author",
+    "-copyright",
+    "-doc",
+    "-vsn",
+    "-import",
+    "-include",
+    "-include_lib",
+    "-compile",
+    "-define",
+    "-else",
+    "-endif",
+    "-file",
+    "-behaviour",
+    "-behavior",
+    "-spec"
+  ];
+
   const PARAMS = {
     className: 'params',
     begin: '\\(',
@@ -155,9 +179,7 @@ export default function(hljs) {
         returnBegin: true,
         keywords: {
           $pattern: '-' + hljs.IDENT_RE,
-          keyword: '-module -record -undef -export -ifdef -ifndef -author -copyright -doc -vsn ' +
-          '-import -include -include_lib -compile -define -else -endif -file -behaviour ' +
-          '-behavior -spec'
+          keyword: DIRECTIVES.map(x => `${x}|1.5`).join(" ")
         },
         contains: [PARAMS]
       },

--- a/src/languages/flix.js
+++ b/src/languages/flix.js
@@ -22,6 +22,7 @@ export default function(hljs) {
 
   const NAME = {
     className: 'title',
+    relevance: 0,
     begin: /[^0-9\n\t "'(),.`{}\[\]:;][^\n\t "'(),.`{}\[\]:;]+|[^0-9\n\t "'(),.`{}\[\]:;=]/
   };
 

--- a/src/languages/gml.js
+++ b/src/languages/gml.js
@@ -825,7 +825,7 @@ export default function(hljs) {
     symbol: 'argument_relative argument argument0 argument1 argument2 ' +
       'argument3 argument4 argument5 argument6 argument7 argument8 ' +
       'argument9 argument10 argument11 argument12 argument13 argument14 ' +
-      'argument15 argument_count x y xprevious yprevious xstart ystart ' +
+      'argument15 argument_count x|0 y|0 xprevious yprevious xstart ystart ' +
       'hspeed vspeed direction speed friction gravity gravity_direction ' +
       'path_index path_position path_positionprevious path_speed ' +
       'path_scale path_orientation path_endaction object_index id solid ' +

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -110,7 +110,8 @@ export default function(hljs) {
       {
         // highlight map keys and named parameters as attrs
         className: 'attr',
-        begin: IDENT_RE + '[ \t]*:'
+        begin: IDENT_RE + '[ \t]*:',
+        relevance: 0
       },
       {
         // catch middle element of the ternary operator

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -21,14 +21,16 @@ export default function(hljs) {
       '/\\*\\*',
       '\\*/',
       {
-        relevance : 0,
-        contains : [
+        relevance: 0,
+        contains: [
           {
             // eat up @'s in emails to prevent them to be recognized as doctags
-            begin: /\w+@/, relevance: 0
-          }, {
-            className : 'doctag',
-            begin : '@[A-Za-z]+'
+            begin: /\w+@/,
+            relevance: 0
+          },
+          {
+            className: 'doctag',
+            begin: '@[A-Za-z]+'
           }
         ]
       }
@@ -37,38 +39,40 @@ export default function(hljs) {
   const REGEXP = {
     className: 'regexp',
     begin: /~?\/[^\/\n]+\//,
-    contains: [
-      hljs.BACKSLASH_ESCAPE
-    ]
+    contains: [ hljs.BACKSLASH_ESCAPE ]
   };
   const NUMBER = variants([
     hljs.BINARY_NUMBER_MODE,
-    hljs.C_NUMBER_MODE,
+    hljs.C_NUMBER_MODE
   ]);
   const STRING = variants([
     {
       begin: /"""/,
       end: /"""/
-    }, {
+    },
+    {
       begin: /'''/,
       end: /'''/
-    }, {
+    },
+    {
       begin: "\\$/",
       end: "/\\$",
       relevance: 10
     },
     hljs.APOS_STRING_MODE,
-    hljs.QUOTE_STRING_MODE,
-    ],
-    { className: "string" }
+    hljs.QUOTE_STRING_MODE
+  ],
+  {
+    className: "string"
+  }
   );
 
-    return {
-        name: 'Groovy',
-        keywords: {
-            built_in: 'this super',
-            literal: 'true false null',
-            keyword:
+  return {
+    name: 'Groovy',
+    keywords: {
+      built_in: 'this super',
+      literal: 'true false null',
+      keyword:
             'byte short char int long boolean float double void ' +
             // groovy specific keywords
             'def as in assert trait ' +
@@ -76,57 +80,61 @@ export default function(hljs) {
             'abstract static volatile transient public private protected synchronized final ' +
             'class interface enum if else for while switch case break default continue ' +
             'throw throws try catch finally implements extends new import package return instanceof'
-        },
+    },
+    contains: [
+      hljs.SHEBANG({
+        binary: "groovy",
+        relevance: 10
+      }),
+      COMMENT,
+      STRING,
+      REGEXP,
+      NUMBER,
+      {
+        className: 'class',
+        beginKeywords: 'class interface trait enum',
+        end: /\{/,
+        illegal: ':',
         contains: [
-            hljs.SHEBANG({
-              binary: "groovy",
-              relevance: 10
-            }),
-            COMMENT,
-            STRING,
-            REGEXP,
-            NUMBER,
-            {
-                className: 'class',
-                beginKeywords: 'class interface trait enum', end: /\{/,
-                illegal: ':',
-                contains: [
-                    {beginKeywords: 'extends implements'},
-                    hljs.UNDERSCORE_TITLE_MODE
-                ]
-            },
-            {
-                className: 'meta',
-                begin: '@[A-Za-z]+',
-                relevance: 0
-            },
-            {
-              // highlight map keys and named parameters as attrs
-              className: 'attr', begin: IDENT_RE + '[ \t]*:'
-            },
-            {
-              // catch middle element of the ternary operator
-              // to avoid highlight it as a label, named parameter, or map key
-              begin: /\?/,
-              end: /:/,
-              relevance: 0,
-              contains: [
-                COMMENT,
-                STRING,
-                REGEXP,
-                NUMBER,
-                'self'
-              ]
-            },
-            {
-                // highlight labeled statements
-                className: 'symbol',
-                begin: '^[ \t]*' + regex.lookahead(IDENT_RE + ':'),
-                excludeBegin: true,
-                end: IDENT_RE + ':',
-                relevance: 0
-            }
-        ],
-        illegal: /#|<\//
-    };
+          {
+            beginKeywords: 'extends implements'
+          },
+          hljs.UNDERSCORE_TITLE_MODE
+        ]
+      },
+      {
+        className: 'meta',
+        begin: '@[A-Za-z]+',
+        relevance: 0
+      },
+      {
+        // highlight map keys and named parameters as attrs
+        className: 'attr',
+        begin: IDENT_RE + '[ \t]*:'
+      },
+      {
+        // catch middle element of the ternary operator
+        // to avoid highlight it as a label, named parameter, or map key
+        begin: /\?/,
+        end: /:/,
+        relevance: 0,
+        contains: [
+          COMMENT,
+          STRING,
+          REGEXP,
+          NUMBER,
+          'self'
+        ]
+      },
+      {
+        // highlight labeled statements
+        className: 'symbol',
+        begin: '^[ \t]*' + regex.lookahead(IDENT_RE + ':'),
+        excludeBegin: true,
+        end: IDENT_RE + ':',
+        relevance: 0
+      }
+    ],
+    illegal: /#|<\//
+  };
 }

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -65,6 +65,11 @@ export default function(hljs) {
       {
         className: 'class',
         beginKeywords: 'class interface enum', end: /[{;=]/, excludeEnd: true,
+        // TODO: can this be removed somehow?
+        // an extra boost because Java is more popular than other languages with
+        // this same syntax feature (this is just to preserve our tests passing
+        // for now)
+        relevance: 1,
         keywords: 'class interface enum',
         illegal: /[:"\[\]]/,
         contains: [

--- a/src/languages/routeros.js
+++ b/src/languages/routeros.js
@@ -104,8 +104,10 @@ export default function(hljs) {
       QUOTE_STRING,
       APOS_STRING,
       VAR,
-      { // attribute=value
-        begin: /[\w-]+=([^\s{}[\]()]+)/,
+      // attribute=value
+      {
+        // > is to avoid matches with => in other grammars
+        begin: /[\w-]+=([^\s{}[\]()>]+)/,
         relevance: 0,
         returnBegin: true,
         contains: [

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -188,7 +188,10 @@ export default function(hljs) {
           begin: '<\\s*',
           contains: [
             {
-              begin: '(' + hljs.IDENT_RE + '::)?' + hljs.IDENT_RE
+              begin: '(' + hljs.IDENT_RE + '::)?' + hljs.IDENT_RE,
+              // we already get points for <, we don't need poitns
+              // for the name also
+              relevance: 0
             }
           ]
         }
@@ -200,6 +203,7 @@ export default function(hljs) {
       // def method_name;
       // def method_name (end of line)
       begin: regex.concat(/def\s*/, regex.lookahead(RUBY_METHOD_RE + "\\s*(\\(|;|$)")),
+      relevance: 0, // relevance comes from kewords
       keywords: "def",
       end: '$|;',
       contains: [

--- a/src/lib/compiler_extensions.js
+++ b/src/lib/compiler_extensions.js
@@ -52,6 +52,7 @@ export function beginKeywords(mode, parent) {
 
   // prevents double relevance, the keywords themselves provide
   // relevance, the mode doesn't need to double it
+  // eslint-disable-next-line no-undefined
   if (mode.relevance === undefined) mode.relevance = 0;
 }
 

--- a/src/lib/compiler_extensions.js
+++ b/src/lib/compiler_extensions.js
@@ -49,6 +49,10 @@ export function beginKeywords(mode, parent) {
   mode.__beforeBegin = skipIfhasPrecedingDot;
   mode.keywords = mode.keywords || mode.beginKeywords;
   delete mode.beginKeywords;
+
+  // prevents double relevance, the keywords themselves provide
+  // relevance, the mode doesn't need to double it
+  if (mode.relevance === undefined) mode.relevance = 0;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Previously something like:

```
{ 
  beginKeywords: "def"
  // which also implies:
  // keywords: "def"
}
```

Would bestow 2 relevance. 1 for the rule match and a second for the
`keywords` match.  This is not correct behavior. A single "token" should
default to a single relevance point, not 2.


### Changes

This changes the default relevance of a mode containing `beginKeywords`
to 0 forcing it to only gain relevance from keyword matches alone.

This of course revealed a few auto-detect balance issues (because some 
grammars had been benefiting from this extra boost) which this PR
also resolves.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors