### PR TITLE
enh(sql): added `ilike` keyword

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -312,3 +312,4 @@ Contributors:
 - Guillaume Grossetie <ggrossetie@yuzutech.fr>
 - Steven Van Impe <steven.vanimpe@icloud.com>
 - Martin Dørum <martid0311@gmail.com>
+- 0xflotus (https://github.com/0xflotus)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Languages:
 Language grammar improvements:
 
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
+- enh(sql) Added `ìlike` keyword
 
 Parser:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ New Languages:
 Language grammar improvements:
 
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
-- enh(sql) Added `ìlike` keyword
+- enh(sql) Added `ìlike` keyword.
 
 Parser:
 

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -10,7 +10,7 @@ Goals:
 
 SQL is intended to highlight basic/common SQL keywords and expressions
 
-- If pretty much every single SQL server includes supports, then it's a canidate.
+- If pretty much every single SQL server includes supports, then it's a candidate.
 - It is NOT intended to include tons of vendor specific keywords (Oracle, MySQL,
   PostgreSQL) although the list of data types is purposely a bit more expansive.
 - For more specific SQL grammars please see:
@@ -245,6 +245,7 @@ export default function(hljs) {
     "hold",
     "hour",
     "identity",
+    "ilike",
     "in",
     "indicator",
     "initial",

--- a/test/markup/sql/keywords.expect.txt
+++ b/test/markup/sql/keywords.expect.txt
@@ -1,1 +1,2 @@
 <span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.select <span class="hljs-keyword">is</span> <span class="hljs-keyword">null</span>;
+<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.author <span class="hljs-keyword">ilike</span> &#x27a%&#x27;

--- a/test/markup/sql/keywords.expect.txt
+++ b/test/markup/sql/keywords.expect.txt
@@ -1,2 +1,2 @@
 <span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.select <span class="hljs-keyword">is</span> <span class="hljs-keyword">null</span>;
-<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.author <span class="hljs-keyword">ilike</span> <span class="hljs-string">&#x27a%&#x27</span>;
+<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.author <span class="hljs-keyword">ilike</span> <span class="hljs-string">&#x27;a%&#x27;</span>;

--- a/test/markup/sql/keywords.expect.txt
+++ b/test/markup/sql/keywords.expect.txt
@@ -1,2 +1,2 @@
 <span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.select <span class="hljs-keyword">is</span> <span class="hljs-keyword">null</span>;
-<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.author <span class="hljs-keyword">ilike</span> &#x27a%&#x27;
+<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.author <span class="hljs-keyword">ilike</span> <span class="hljs-string">&#x27a%&#x27</span>;

--- a/test/markup/sql/keywords.txt
+++ b/test/markup/sql/keywords.txt
@@ -1,1 +1,2 @@
 select * from t where t.select is null;
+select * from t where t.author ilike 'a%';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
I added `ilike` to keyword list in sql

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
