### PR TITLE
(xml) Support single-character namespaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Languages:
 Language grammar improvements:
 
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
+- fix(xml) Support single-character namespaces. (#2957) [Jan Pilzer][]
 
 Parser:
 

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -10,7 +10,7 @@ import * as regex from '../lib/regex.js';
 /** @type LanguageFn */
 export default function(hljs) {
   // Element names can contain letters, digits, hyphens, underscores, and periods
-  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]+:/), /[A-Z0-9_.-]*/);
+  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]*:/), /[A-Z0-9_.-]*/);
   const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
   const XML_ENTITIES = {
     className: 'symbol',

--- a/test/markup/xml/namespace.expect.txt
+++ b/test/markup/xml/namespace.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-meta">&lt;?xml version=&quot;1.0&quot; encoding=&quot;ISO-8859-1&quot; ?&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">xs:schema</span> <span class="hljs-attr">xmlns:xs</span>=<span class="hljs-string">&quot;http://www.w3.org/2001/XMLSchema&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">xs:schema</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">s:schema</span> <span class="hljs-attr">xmlns:s</span>=<span class="hljs-string">&quot;http://www.w3.org/2001/XMLSchema&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">s:schema</span>&gt;</span>

--- a/test/markup/xml/namespace.txt
+++ b/test/markup/xml/namespace.txt
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>
+<s:schema xmlns:s="http://www.w3.org/2001/XMLSchema"></s:schema>


### PR DESCRIPTION
Resolves #2957

### Changes
Update xml tag-regex to not require a second character for the namespace.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
