### PR TITLE
enh(parser) allow keywords to be an array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Language grammar improvements:
 
 Parser:
 
+- allow `keywords` to be an array of strings [Josh Goebel][]
 - add `modes.MATCH_NOTHING_RE` that will never match
   - This can be used with `end` to hold a mode open (it must then be ended with
     `endsParent` in one of it's children modes) [Josh Goebel][]

--- a/docs/language-guide.rst
+++ b/docs/language-guide.rst
@@ -1,3 +1,5 @@
+.. highlight:: javascript
+
 Language definition guide
 =========================
 
@@ -64,12 +66,14 @@ and most interesting parsing happens inside tags.
 Keywords
 --------
 
-In the simple case language keywords can be defined with a string, separated by space:
+In the simple case language keywords can be defined with a string (space delimited) or array:
 
 ::
 
   {
-    keywords: 'else for if while'
+    keywords: 'else for if while',
+    // or with an array
+    keywords: ['else', 'for', 'if', 'while']
   }
 
 Some languages have different kinds of "keywords" that might not be called as
@@ -83,7 +87,7 @@ object, each property of which defines its own group of keywords:
   {
     keywords: {
       keyword: 'else for if while',
-      literal: 'false true null'
+      literal: ['false','true','null']
     }
   }
 

--- a/docs/mode-reference.rst
+++ b/docs/mode-reference.rst
@@ -375,12 +375,13 @@ constant that you repeat multiple times within different modes of your grammar.
 keywords
 ^^^^^^^^
 
-- **type**: object / string
+- **type**: object / string / array
 
-Keyword definition comes in two forms:
+Keyword definition comes in three forms:
 
 * ``'for while if|0 else weird_voodoo|10 ... '`` -- a string of space-separated keywords with an optional relevance over a pipe
 * ``{keyword: ' ... ', literal: ' ... ', $pattern: /\w+/ }`` -- an object that describes multiple sets of keywords and the pattern used to find them
+* ``["for", "while", "if|0", ...]`` -- an array of keywords (with optional relevance via ``|``)
 
 For detailed explanation see :doc:`Language definition guide </language-guide>`.
 

--- a/src/languages/abnf.js
+++ b/src/languages/abnf.js
@@ -63,7 +63,7 @@ export default function(hljs) {
   return {
     name: 'Augmented Backus-Naur Form',
     illegal: regexes.unexpectedChars,
-    keywords: keywords.join(" "),
+    keywords: keywords,
     contains: [
       ruleDeclarationMode,
       commentMode,

--- a/src/languages/accesslog.js
+++ b/src/languages/accesslog.js
@@ -42,7 +42,7 @@ export default function(_hljs) {
         className: 'string',
         begin: regex.concat(/"/, regex.either(...HTTP_VERBS)),
         end: /"/,
-        keywords: HTTP_VERBS.join(" "),
+        keywords: HTTP_VERBS,
         illegal: /\n/,
         relevance: 5,
         contains: [

--- a/src/languages/axapta.js
+++ b/src/languages/axapta.js
@@ -139,9 +139,9 @@ export default function(hljs) {
   ];
 
   const KEYWORDS = {
-    keyword: NORMAL_KEYWORDS.join(' '),
-    built_in: BUILT_IN_KEYWORDS.join(' '),
-    literal: LITERAL_KEYWORDS.join(' ')
+    keyword: NORMAL_KEYWORDS,
+    built_in: BUILT_IN_KEYWORDS,
+    literal: LITERAL_KEYWORDS
   };
 
   return {

--- a/src/languages/coffeescript.js
+++ b/src/languages/coffeescript.js
@@ -44,9 +44,9 @@ export default function(hljs) {
   const excluding = (list) =>
     (kw) => !list.includes(kw);
   const KEYWORDS = {
-    keyword: ECMAScript.KEYWORDS.concat(COFFEE_KEYWORDS).filter(excluding(NOT_VALID_KEYWORDS)).join(" "),
-    literal: ECMAScript.LITERALS.concat(COFFEE_LITERALS).join(" "),
-    built_in: ECMAScript.BUILT_INS.concat(COFFEE_BUILT_INS).join(" ")
+    keyword: ECMAScript.KEYWORDS.concat(COFFEE_KEYWORDS).filter(excluding(NOT_VALID_KEYWORDS)),
+    literal: ECMAScript.LITERALS.concat(COFFEE_LITERALS),
+    built_in: ECMAScript.BUILT_INS.concat(COFFEE_BUILT_INS)
   };
   const JS_IDENT_RE = '[A-Za-z$_][0-9A-Za-z$_]*';
   const SUBST = {

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -148,9 +148,9 @@ export default function(hljs) {
   ];
 
   var KEYWORDS = {
-    keyword: NORMAL_KEYWORDS.concat(CONTEXTUAL_KEYWORDS).join(' '),
-    built_in: BUILT_IN_KEYWORDS.join(' '),
-    literal: LITERAL_KEYWORDS.join(' ')
+    keyword: NORMAL_KEYWORDS.concat(CONTEXTUAL_KEYWORDS),
+    built_in: BUILT_IN_KEYWORDS,
+    literal: LITERAL_KEYWORDS
   };
   var TITLE_MODE = hljs.inherit(hljs.TITLE_MODE, {begin: '[a-zA-Z](\\.?\\w)*'});
   var NUMBERS = {

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -142,7 +142,7 @@ export default function(hljs) {
           'querySelector',
           'querySelectorAll',
           'window'
-        ]).join(' '),
+        ]),
     $pattern: /[A-Za-z][A-Za-z0-9_]*\??/
   };
 

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -41,7 +41,7 @@ export default function(hljs) {
       'view',
       'with',
       'yield'
-    ].join(" ")
+    ]
   };
 
   const LITERALS = {
@@ -50,7 +50,7 @@ export default function(hljs) {
       'false',
       'undefined',
       'null'
-    ].join(" ")
+    ]
   };
 
   // as defined in https://handlebarsjs.com/guide/expressions.html#literal-segments

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -58,9 +58,9 @@ export default function(hljs) {
   };
   const KEYWORDS = {
     $pattern: ECMAScript.IDENT_RE,
-    keyword: ECMAScript.KEYWORDS.join(" "),
-    literal: ECMAScript.LITERALS.join(" "),
-    built_in: ECMAScript.BUILT_INS.join(" ")
+    keyword: ECMAScript.KEYWORDS,
+    literal: ECMAScript.LITERALS,
+    built_in: ECMAScript.BUILT_INS
   };
 
   // https://tc39.es/ecma262/#sec-literals-numeric-literals

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -323,9 +323,9 @@ export default function(hljs) {
 
   var KEYWORDS = {
     $pattern: VARIABLE_NAME_RE,
-    keyword: KEYWORD_LIST.join(" "),
-    literal: LITERAL_LIST.join(" "),
-    built_in: BUILT_IN_LIST.join(" "),
+    keyword: KEYWORD_LIST,
+    literal: LITERAL_LIST,
+    built_in: BUILT_IN_LIST,
   };
 
   // placeholder for recursive self-reference

--- a/src/languages/livescript.js
+++ b/src/languages/livescript.js
@@ -56,9 +56,9 @@ export default function(hljs) {
     '__indexOf'
   ];
   const KEYWORDS = {
-    keyword: ECMAScript.KEYWORDS.concat(LIVESCRIPT_KEYWORDS).join(" "),
-    literal: ECMAScript.LITERALS.concat(LIVESCRIPT_LITERALS).join(" "),
-    built_in: ECMAScript.BUILT_INS.concat(LIVESCRIPT_BUILT_INS).join(" ")
+    keyword: ECMAScript.KEYWORDS.concat(LIVESCRIPT_KEYWORDS),
+    literal: ECMAScript.LITERALS.concat(LIVESCRIPT_LITERALS),
+    built_in: ECMAScript.BUILT_INS.concat(LIVESCRIPT_BUILT_INS)
   };
   const JS_IDENT_RE = '[A-Za-z$_](?:-[0-9A-Za-z$_]|[0-9A-Za-z$_])*';
   const TITLE = hljs.inherit(hljs.TITLE_MODE, {

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -124,9 +124,9 @@ export default function(hljs) {
   ];
 
   const KEYWORDS = {
-    keyword: RESERVED_WORDS.join(' '),
-    built_in: BUILT_INS.join(' '),
-    literal: LITERALS.join(' ')
+    keyword: RESERVED_WORDS,
+    built_in: BUILT_INS,
+    literal: LITERALS
   };
 
   const PROMPT = {

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -619,7 +619,7 @@ export default function(hljs) {
   const FUNCTION_CALL = {
     begin: regex.concat(/\b/, regex.either(...FUNCTIONS), /\s*\(/),
     keywords: {
-      built_in: FUNCTIONS.join(" ")
+      built_in: FUNCTIONS
     }
   };
 
@@ -646,19 +646,19 @@ export default function(hljs) {
     keywords: {
       $pattern: /\b[\w\.]+/,
       keyword:
-        reduceRelevancy(KEYWORDS, { when: (x) => x.length < 3 }).join(" "),
-      literal: LITERALS.join(" "),
-      type: TYPES.join(" "),
-      built_in: POSSIBLE_WITHOUT_PARENS.join(" ")
+        reduceRelevancy(KEYWORDS, { when: (x) => x.length < 3 }),
+      literal: LITERALS,
+      type: TYPES,
+      built_in: POSSIBLE_WITHOUT_PARENS
     },
     contains: [
       {
         begin: regex.either(...COMBOS),
         keywords: {
           $pattern: /[\w\.]+/,
-          keyword: KEYWORDS.concat(COMBOS).join(" "),
-          literal: LITERALS.join(" "),
-          type: TYPES.join(" ")
+          keyword: KEYWORDS.concat(COMBOS),
+          literal: LITERALS,
+          type: TYPES
         },
       },
       {

--- a/src/languages/stan.js
+++ b/src/languages/stan.js
@@ -473,9 +473,9 @@ export default function(hljs) {
     aliases: [ 'stanfuncs' ],
     keywords: {
       $pattern: hljs.IDENT_RE,
-      title: BLOCKS.join(' '),
-      keyword: STATEMENTS.concat(VAR_TYPES).concat(SPECIAL_FUNCTIONS).join(' '),
-      built_in: FUNCTIONS.join(' ')
+      title: BLOCKS,
+      keyword: STATEMENTS.concat(VAR_TYPES).concat(SPECIAL_FUNCTIONS),
+      built_in: FUNCTIONS
     },
     contains: [
       hljs.C_LINE_COMMENT_MODE,
@@ -521,7 +521,7 @@ export default function(hljs) {
       },
       {
         begin: '~\\s*(' + hljs.IDENT_RE + ')\\s*\\(',
-        keywords: DISTRIBUTIONS.join(' ')
+        keywords: DISTRIBUTIONS
       },
       {
         className: 'number',

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -226,7 +226,7 @@ export default function(hljs) {
         {
           begin: /\(/,
           end: /\)/,
-          keywords: Swift.availabilityKeywords.join(' '),
+          keywords: Swift.availabilityKeywords,
           contains: [
             ...OPERATORS,
             NUMBER,
@@ -445,7 +445,7 @@ export default function(hljs) {
         keywords: [
           ...Swift.precedencegroupKeywords,
           ...Swift.literals
-        ].join(' '),
+        ],
         contains: [ TYPE ]
       }
     ]

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -68,9 +68,8 @@ export default function(hljs) {
       /#\w+/ // number keywords
     ),
     keyword: PLAIN_KEYWORDS
-      .concat(Swift.numberSignKeywords)
-      .join(" "),
-    literal: Swift.literals.join(" ")
+      .concat(Swift.numberSignKeywords),
+    literal: Swift.literals
   };
   const KEYWORD_MODES = [
     DOT_KEYWORD,

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -50,9 +50,9 @@ export default function(hljs) {
   ];
   const KEYWORDS = {
     $pattern: ECMAScript.IDENT_RE,
-    keyword: ECMAScript.KEYWORDS.concat(TS_SPECIFIC_KEYWORDS).join(" "),
-    literal: ECMAScript.LITERALS.join(" "),
-    built_in: ECMAScript.BUILT_INS.concat(TYPES).join(" ")
+    keyword: ECMAScript.KEYWORDS.concat(TS_SPECIFIC_KEYWORDS),
+    literal: ECMAScript.LITERALS,
+    built_in: ECMAScript.BUILT_INS.concat(TYPES)
   };
   const DECORATOR = {
     className: 'meta',

--- a/src/languages/vbscript.js
+++ b/src/languages/vbscript.js
@@ -37,7 +37,7 @@ export default function(hljs) {
     // relevance 0 because this is acting as a beginKeywords really
     relevance:0,
     keywords: {
-      built_in: BUILT_IN_FUNCTIONS.join(" ")
+      built_in: BUILT_IN_FUNCTIONS
     }
   };
 
@@ -51,7 +51,7 @@ export default function(hljs) {
         'if then else on error option explicit new private property let get public randomize ' +
         'redim rem select case set stop sub while wend with end to elseif is or xor and not ' +
         'class_initialize class_terminate default preserve in me byval byref step resume goto',
-      built_in: BUILT_IN_OBJECTS.join(" "),
+      built_in: BUILT_IN_OBJECTS,
       literal:
         'true false null nothing empty'
     },


### PR DESCRIPTION
This has bugged me for a long time and I can't think of a good reason to not allow this - and encourage more array usage without forcing users to convert them back into strings for us.

### Changes

Allows keywords to be an array which avoids the need for repeating
`join(" ")` in 500 places.

Long-term I think we should deprecate the string syntax, but right now they can live side by side.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

<!--- Describe your changes -->

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors