### PR TITLE
(parser) new highlightAll() API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,19 @@ Language grammar improvements:
 
 Parser:
 
+- new simpler `highlightAll()` API (#2962) [Josh Goebel][]
+  - this should be a drop-in replacement for both `initHighlighting()` and `initHighlightingOnLoad()`
+  - note: it does not prevent itself from being called multiple times (as the previous API did)
 - allow `keywords` to be an array of strings [Josh Goebel][]
 - add `modes.MATCH_NOTHING_RE` that will never match
-  - This can be used with `end` to hold a mode open (it must then be ended with
-    `endsParent` in one of it's children modes) [Josh Goebel][]
+  - This can be used with `end` to hold a mode open (it must then be ended with `endsParent` in one of it's children modes) [Josh Goebel][]
+
+Deprecations:
+
+- `initHighlighting()` and `initHighlightingOnLoad()` deprecated.
+  - Please use the new `highlightAll()` API instead.
+  - Deprecated as of 10.6.
+  - These will both be aliases to `highlightAll` in v11.
 
 [Michael Newton]: https://github.com/miken32
 [Steven Van Impe]: https://github.com/svanimpe/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ library along with one of the styles and calling [`initHighlightingOnLoad`][1]:
 ```html
 <link rel="stylesheet" href="/path/to/styles/default.css">
 <script src="/path/to/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script>hljs.highlightAll();</script>
 ```
 
 This will find and highlight code inside of `<pre><code>` tags; it tries
@@ -93,7 +93,7 @@ When you need a bit more control over the initialization of
 highlight.js, you can use the [`highlightBlock`][3] and [`configure`][4]
 functions. This allows you to better control *what* to highlight and *when*.
 
-Here’s the equivalent of calling [`initHighlightingOnLoad`][1] using
+Here’s the equivalent of calling [`highlightAll`][1] using
 only vanilla JS:
 
 ```js
@@ -359,7 +359,7 @@ Further in-depth documentation for the API and other topics is at
 
 Authors and contributors are listed in the [AUTHORS.txt][8] file.
 
-[1]: http://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
+[1]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightall
 [2]: http://highlightjs.readthedocs.io/en/latest/css-classes-reference.html
 [3]: http://highlightjs.readthedocs.io/en/latest/api.html#highlightblock-block
 [4]: http://highlightjs.readthedocs.io/en/latest/api.html#configure-options

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@ Highlight.js — это инструмент для подсветки синт�
 ```html
 <link rel="stylesheet" href="/path/to/styles/default.css">
 <script src="/path/to/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script>hljs.highlightAll();</script>
 ```
 
 Библиотека найдёт и раскрасит код внутри тегов `<pre><code>`, попытавшись

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,5 +1,5 @@
 hljs.debugMode();
-hljs.initHighlightingOnLoad();
+hljs.highlightAll();
 
 document.querySelectorAll(".categories > li").forEach((category) => {
   category.addEventListener("click", (event) => {

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -91,14 +91,25 @@ Accepts an object representing options with the values to updated. Other options
   hljs.initHighlighting();
 
 
-``initHighlighting()``
+``highlightAll()``
+------------------
+
+Applies highlighting to all ``<pre><code>...</code></pre>`` blocks on a page.
+This can be called before or after the page's ``onload`` event has fired.
+
+
+``initHighlighting()`` (deprecated as of 10.6)
 ----------------------
+
+*Deprecated:* Please use ``highlightAll()`` instead.
 
 Applies highlighting to all ``<pre><code>...</code></pre>`` blocks on a page.
 
 
-``initHighlightingOnLoad()``
+``initHighlightingOnLoad()`` (deprecated as of 10.6)
 ----------------------------
+
+*Deprecated:* Please use ``highlightAll()`` instead.
 
 Attaches highlighting to the page load event.
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -757,6 +757,9 @@ const HLJS = function(hljs) {
   let wantsHighlight = false;
   let domLoaded = false;
 
+  /**
+   * auto-highlights all pre>code elements on the page
+   */
   function highlightAll() {
     // if we are called too early in the loading process
     if (!domLoaded) { wantsHighlight = true; return; }

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -753,6 +753,25 @@ const HLJS = function(hljs) {
     window.addEventListener('DOMContentLoaded', initHighlighting, false);
   }
 
+  let wantsHighlight = false;
+  let domLoaded = false;
+
+  function highlightAll() {
+    // if we are called too early in the loading process
+    if (!domLoaded) { wantsHighlight = true; return; }
+
+    const blocks = document.querySelectorAll('pre code');
+    blocks.forEach(highlightBlock);
+  }
+
+  function boot() {
+    domLoaded = true;
+    // if a highlight was required before DOM was loaded, do now
+    if (wantsHighlight) highlightAll();
+  }
+
+  window.addEventListener('DOMContentLoaded', boot, false);
+
   /**
    * Register a language grammar module
    *
@@ -878,6 +897,7 @@ const HLJS = function(hljs) {
   Object.assign(hljs, {
     highlight,
     highlightAuto,
+    highlightAll,
     fixMarkup: deprecateFixMarkup,
     highlightBlock,
     configure,

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -744,6 +744,8 @@ const HLJS = function(hljs) {
     if (initHighlighting.called) return;
     initHighlighting.called = true;
 
+    logger.deprecated("10.6.0", "initHighlighting() is deprecated.  Use highlightAll() instead.");
+
     const blocks = document.querySelectorAll('pre code');
     blocks.forEach(highlightBlock);
   };
@@ -751,6 +753,7 @@ const HLJS = function(hljs) {
   // Higlights all when DOMContentLoaded fires
   // TODO: remove v12, deprecated
   function initHighlightingOnLoad() {
+    logger.deprecated("10.6.0", "initHighlightingOnLoad() is deprecated.  Use highlightAll() instead.");
     wantsHighlight = true;
   }
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -739,6 +739,7 @@ const HLJS = function(hljs) {
    *
    * @type {Function & {called?: boolean}}
    */
+  // TODO: remove v12, deprecated
   const initHighlighting = () => {
     if (initHighlighting.called) return;
     initHighlighting.called = true;
@@ -748,9 +749,9 @@ const HLJS = function(hljs) {
   };
 
   // Higlights all when DOMContentLoaded fires
+  // TODO: remove v12, deprecated
   function initHighlightingOnLoad() {
-    // @ts-ignore
-    window.addEventListener('DOMContentLoaded', initHighlighting, false);
+    wantsHighlight = true;
   }
 
   let wantsHighlight = false;
@@ -766,7 +767,7 @@ const HLJS = function(hljs) {
 
   function boot() {
     domLoaded = true;
-    // if a highlight was required before DOM was loaded, do now
+    // if a highlight was requested before DOM was loaded, do now
     if (wantsHighlight) highlightAll();
   }
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -777,7 +777,10 @@ const HLJS = function(hljs) {
     if (wantsHighlight) highlightAll();
   }
 
-  window.addEventListener('DOMContentLoaded', boot, false);
+  // make sure we are in the browser environment
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('DOMContentLoaded', boot, false);
+  }
 
   /**
    * Register a language grammar module

--- a/test/special/index.js
+++ b/test/special/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const hljs     = require('../../build');
+hljs.debugMode(); // tests run in debug mode so errors are raised
+
 const { JSDOM } = require('jsdom');
 const { readFile } = require('fs').promises;
 const utility  = require('../utility');
@@ -19,12 +21,13 @@ describe('special cases tests', () => {
 
     // Setup hljs environment
     hljs.configure({ tabReplace: '    ' });
-    hljs.initHighlighting();
+    let blocks = document.querySelectorAll('pre code');
+    blocks.forEach(hljs.highlightBlock);
 
     // Setup hljs for non-`<pre><code>` tests
     hljs.configure({ useBR: true });
 
-    let blocks = document.querySelectorAll('.code');
+    blocks = document.querySelectorAll('.code');
     blocks.forEach(hljs.highlightBlock);
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ interface PublicApi {
     configure: (options: Partial<HLJSOptions>) => void
     initHighlighting: () => void
     initHighlightingOnLoad: () => void
+    highlightAll: () => void
     registerLanguage: (languageName: string, language: LanguageFn) => void
     listLanguages: () => string[]
     registerAliases: (aliasList: string | string[], { languageName } : {languageName: string}) => void


### PR DESCRIPTION
Progress towards #2277.

### Changes

Added new `highlightAll()` API which deprecates:

- initHighlighting()
- initHighlightingOnLoad()

These are slated to be removed with version 12. (with v11 they will likely just because aliases to `highlightAll()`)

---

The new function can be called at any time and will "just work".

- If called after DOM has loaded, it will immediately highlight.
- If called before, it will wait until the DOM finishes loading, then
highlight.

If there are any cases where `highlightAll()` is needed prior to the DOM `onload` firing, we can discuss those cases between now and v12.  That would seem to be an edge case though I'd guess and could easily be handled with a custom unload handler.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors