### PR TITLE
Add missing comma to SUPPORTED_LANGUAGES.md

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -12,7 +12,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | ABNF                    | abnf                   |         |
 | Access logs             | accesslog              |         |
 | Ada                     | ada                    |         |
-| Arduino (C++ w/Arduino libs) | arduino ino           |         |
+| Arduino (C++ w/Arduino libs) | arduino, ino           |         |
 | ARM assembler           | armasm, arm            |         |
 | AVR assembler           | avrasm                 |         |
 | ActionScript            | actionscript, as       |         |


### PR DESCRIPTION
Small error: there was a missing comma in the SUPPORTED_LANGUAGES.md