### PR TITLE
Allow for browser-testing of 'extra' language.

### DIFF
--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -40,10 +40,6 @@ class Language {
     this._sample = "";
     if (fs.existsSync(this.samplePath))
       this._sample = fs.readFileSync(this.samplePath, {encoding: "utf8"});
-    else
-    {
-      console.log("language.js no samplePath for " + this.name);
-    }
     return this._sample;
   }
 

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -44,11 +44,13 @@ class Language {
   }
 
   get samplePath() {
-    if (!this.moduleDir) {
-      return `./test/detect/${this.name}/default.txt`;
+    if (this.moduleDir) {
+      // this is the 'extras' case.
+      return `${this.moduleDir}/test/detect/${this.name}/default.txt`;
     }
     else {
-      return `${this.moduleDir}/test/detect/${this.name}/default.txt`;
+      // this is the common/built-in case.
+      return `./test/detect/${this.name}/default.txt`;
     }
   }
 

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -40,11 +40,20 @@ class Language {
     this._sample = "";
     if (fs.existsSync(this.samplePath))
       this._sample = fs.readFileSync(this.samplePath, {encoding: "utf8"});
+    else
+    {
+      console.log("language.js no samplePath for " + this.name);
+    }
     return this._sample;
   }
 
   get samplePath() {
-    return `./test/detect/${this.name}/default.txt`
+    if (!this.moduleDir) {
+      return `./test/detect/${this.name}/default.txt`;
+    }
+    else {
+      return `${this.moduleDir}/test/detect/${this.name}/default.txt`;
+    }
   }
 
   loadMetadata() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Trivial change to search the extra directory for detect/${lang}/default.txt
for inclusion into index.html for the browser-based testing.  Without
this change, my custom language wouldn't appear in the browser.
No problem for me if you don't wish to integrate this change.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

one liner self explanatory.

### Checklist
- [x ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
