### PR TITLE
Fix build missed opts

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -85,7 +85,7 @@ async function doTarget(target, buildDir) {
   const build = require(`./build_${target}`);
   process.env.BUILD_DIR = buildDir;
   await clean(buildDir);
-  await build.build({ languages: commander.args, minify: commander.minify });
+  await build.build({ languages: commander.args, minify: commander.opts().minify });
 }
 
 async function doBuild() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I added direct reading of options from the commander, since the previous challenge did not work.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

I haven't noticed any problems on this topic yet.

### Changes
<!--- Describe your changes -->

The previous

```js
$> commander.minify;
undefined
```

If we call `node build.js` with `-n` or `--no-minify`

```js
$> commander.opts().minify;
false
```

If we call `node build.js` without `-n` or `--no-minify`

```js
$> commander.opts().minify;
true
```

### Checklist
- [x] Markup tests don't apply here because it's a code misprint.
- [ ] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
