### PR TITLE
enh(powershell) Add three VALID_VERBS and update the reference link (#2981)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -313,3 +313,4 @@ Contributors:
 - Steven Van Impe <steven.vanimpe@icloud.com>
 - Martin Dørum <martid0311@gmail.com>
 - John Haugeland <stonecypher@gmail.com>
+- davidhcefx <davidhu0903ex3@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Deprecations:
 [Steven Van Impe]: https://github.com/svanimpe/
 [Josh Goebel]: https://github.com/joshgoebel
 [Vaibhav Chanana]: https://github.com/il3ven
+[davidhcefx]: https://github.com/davidhcefx
 
 
 ## Version 10.5.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Language grammar improvements:
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
 - fix(xml) Support single-character namespaces. (#2957) [Jan Pilzer][]
 - enh(ruby) Support for character literals (#2950) [Vaibhav Chanana][]
+- enh(powershell) Add three VALID_VERBS and update the reference link (#2981) [davidhcefx][]
 
 Grammar changes:
 

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -24,16 +24,16 @@ export default function(hljs) {
     "void"
   ];
 
-  // https://msdn.microsoft.com/en-us/library/ms714428(v=vs.85).aspx
+  // https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands
   const VALID_VERBS =
     'Add|Clear|Close|Copy|Enter|Exit|Find|Format|Get|Hide|Join|Lock|' +
     'Move|New|Open|Optimize|Pop|Push|Redo|Remove|Rename|Reset|Resize|' +
     'Search|Select|Set|Show|Skip|Split|Step|Switch|Undo|Unlock|' +
     'Watch|Backup|Checkpoint|Compare|Compress|Convert|ConvertFrom|' +
     'ConvertTo|Dismount|Edit|Expand|Export|Group|Import|Initialize|' +
-    'Limit|Merge|Out|Publish|Restore|Save|Sync|Unpublish|Update|' +
-    'Approve|Assert|Complete|Confirm|Deny|Disable|Enable|Install|Invoke|Register|' +
-    'Request|Restart|Resume|Start|Stop|Submit|Suspend|Uninstall|' +
+    'Limit|Merge|Mount|Out|Publish|Restore|Save|Sync|Unpublish|Update|' +
+    'Approve|Assert|Build|Complete|Confirm|Deny|Deploy|Disable|Enable|Install|Invoke|' +
+    'Register|Request|Restart|Resume|Start|Stop|Submit|Suspend|Uninstall|' +
     'Unregister|Wait|Debug|Measure|Ping|Repair|Resolve|Test|Trace|Connect|' +
     'Disconnect|Read|Receive|Send|Write|Block|Grant|Protect|Revoke|Unblock|' +
     'Unprotect|Use|ForEach|Sort|Tee|Where';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #2981 

### Changes
<!--- Describe your changes -->
- Added three [officially-approved verbs](https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-7.1) into `VALID_VERBS`:
  - `Mount`
  - `Build`
  - `Deploy`
- Update the reference link to: `https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands`.


### Checklist
- [x] Added markup tests, or they don't apply here because this is just a minor modification.
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
