### PR TITLE
enh(scala) fix triple quoted string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ New Languages:
 
 Language grammar improvements:
 
-- enh(scala) fix triple quoted strings [Josh Goebel][]
+- enh(scala) fix triple quoted strings (#2987) [Josh Goebel][]
 - enh(perl) Much improved regex detection (#2960) [Josh Goebel][]
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
 - fix(xml) Support single-character namespaces. (#2957) [Jan Pilzer][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ New Languages:
 
 Language grammar improvements:
 
-- env(perl) Much improved regex detection (#2960) [Josh Goebel][]
+- enh(scala) fix triple quoted strings [Josh Goebel][]
+- enh(perl) Much improved regex detection (#2960) [Josh Goebel][]
 - enh(swift) Improved highlighting for operator and precedencegroup declarations. (#2938) [Steven Van Impe][]
 - fix(xml) Support single-character namespaces. (#2957) [Jan Pilzer][]
 - enh(ruby) Support for character literals (#2950) [Vaibhav Chanana][]

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -30,22 +30,23 @@ export default function(hljs) {
     className: 'string',
     variants: [
       {
+        begin: '"""',
+        end: '"""'
+      },
+      {
         begin: '"',
         end: '"',
         illegal: '\\n',
         contains: [ hljs.BACKSLASH_ESCAPE ]
       },
       {
-        begin: '"""',
-        end: '"""',
-        relevance: 10
-      },
-      {
         begin: '[a-z]+"',
         end: '"',
         illegal: '\\n',
-        contains: [ hljs.BACKSLASH_ESCAPE,
-          SUBST ]
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
       },
       {
         className: 'string',

--- a/test/markup/scala/strings.expect.txt
+++ b/test/markup/scala/strings.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-keyword">val</span> s = <span class="hljs-string">&quot;&quot;&quot; this is a string &quot;this is still a string&quot; another quote: &quot; after the quote &quot;&quot;&quot;</span>

--- a/test/markup/scala/strings.txt
+++ b/test/markup/scala/strings.txt
@@ -1,0 +1,1 @@
+val s = """ this is a string "this is still a string" another quote: " after the quote """


### PR DESCRIPTION
Resolves #2986

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

<!--- Describe your changes -->

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors