### PR TITLE
fix(cpp) constructor support for initializers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ New Languages:
 Language grammar improvements:
 
 - enh(gml) Add additional GML 2.3 keywords (#2984) [xDGameStudios][]
-- fix(cpp) constructor support for initializers () [Josh Goebel][]
+- fix(cpp) constructor support for initializers (#3001) [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [John Cheung]: https://github.com/Real-John-Cheung

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Languages:
 Language grammar improvements:
 
 - enh(gml) Add additional GML 2.3 keywords (#2984) [xDGameStudios][]
+- fix(cpp) constructor support for initializers () [Josh Goebel][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [John Cheung]: https://github.com/Real-John-Cheung

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -192,6 +192,21 @@ export default function(hljs) {
         contains: [ TITLE_MODE ],
         relevance: 0
       },
+      // needed because we do not have look-behind on the below rule
+      // to prevent it from grabbing the final : in a :: pair
+      {
+        begin: /::/,
+        relevance: 0
+      },
+      // initializers
+      {
+        begin: /:/,
+        endsWithParent: true,
+        contains: [
+          STRINGS,
+          NUMBERS
+        ]
+      },
       {
         className: 'params',
         begin: /\(/,

--- a/test/markup/cpp/function-declarations.expect.txt
+++ b/test/markup/cpp/function-declarations.expect.txt
@@ -18,3 +18,6 @@
 <span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(T... args)</span> </span>{}
 
 test();
+
+<span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">A</span><span class="hljs-params">()</span>: a(<span class="hljs-number">10</span>) {</span>}
+<span class="hljs-function"><span class="hljs-keyword">explicit</span> <span class="hljs-title">A</span><span class="hljs-params">()</span>: a(<span class="hljs-number">10</span>) {</span>}

--- a/test/markup/cpp/function-declarations.txt
+++ b/test/markup/cpp/function-declarations.txt
@@ -18,3 +18,6 @@ template<typename T...>
 void foo(T... args) {}
 
 test();
+
+void A(): a(10) {}
+explicit A(): a(10) {}


### PR DESCRIPTION
Resolves #1980.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Detects the `:` for an initializer sequence and highlights strings and
numbers that appear in the sequence.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors