### PR TITLE
enh(parser) add highlightElement, deprecate highlightBlock

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,9 @@ module.exports = {
     },
     {
       files: ["test/**/*.js"],
+      globals: {
+        should: "readonly"
+      },
       env: {
         mocha: true
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Language grammar improvements:
 
 - enh(gml) Add additional GML 2.3 keywords (#2984) [xDGameStudios][]
 
+Deprecations:
+
+- `highlightBlock(el)` deprecated as of 10.7.
+  - Please use `highlightElement(el)` instead.
+  - Plugin callbacks renamed `before/after:highlightBlock` => `before/after:highlightElement`
+  - Plugin callback now takes `el` vs `block` attribute
+  - The old API and callbacks will be supported until v12.
+
 [Josh Goebel]: https://github.com/joshgoebel
 [John Cheung]: https://github.com/Real-John-Cheung
 [xDGameStudios]: https://github.com/xDGameStudios

--- a/docs/plugin-api.rst
+++ b/docs/plugin-api.rst
@@ -101,14 +101,24 @@ Note: This callback does not fire from highlighting resulting from auto-language
 
 It returns nothing.
 
-
 ``after:highlightBlock({block, result, text})``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deprecated as of 10.7.  Please use ``after:highlightElement``.
+
+``before:highlightBlock({block, language})``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deprecated as of 10.7.  Please use ``before:highlightElement``.
+
+
+``after:highlightElement({el, result, text})``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed an object with two keys:
 
-block
-  The HTML element of the block that's been highlighted.
+el
+  The HTML element that's been highlighted.
 
 result
   The result object returned by `highlight` or `highlightAuto`.
@@ -119,13 +129,13 @@ text
 It returns nothing.
 
 
-``before:highlightBlock({block, language})``
+``before:highlightElement({el, language})``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This callback function is passed an object with two keys:
 
-block
-  The HTML element of the block that will be highlighted.
+el
+  The HTML element that will be highlighted.
 
 language
   The language determined from the class attribute (or undefined).

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -697,8 +697,6 @@ const HLJS = function(hljs) {
     if (shouldNotHighlight(language)) return;
 
     // support for v10 API
-    fire("before:highlightBlock",
-      { block: element, language: language });
     fire("before:highlightElement",
       { el: element, language: language });
 
@@ -707,7 +705,6 @@ const HLJS = function(hljs) {
     const result = language ? highlight(language, text, true) : highlightAuto(text);
 
     // support for v10 API
-    fire("after:highlightBlock", { block: element, result, text });
     fire("after:highlightElement", { el: element, result, text });
 
     element.innerHTML = result.value;
@@ -877,9 +874,33 @@ const HLJS = function(hljs) {
   }
 
   /**
+   * Upgrades the old highlightBlock plugins to the new
+   * highlightElement API
+   * @param {HLJSPlugin} plugin
+   */
+  function upgradePluginAPI(plugin) {
+    // TODO: remove with v12
+    if (plugin["before:highlightBlock"] && !plugin["before:highlightElement"]) {
+      plugin["before:highlightElement"] = (data) => {
+        plugin["before:highlightBlock"](
+          Object.assign({ block: data.el }, data)
+        );
+      };
+    }
+    if (plugin["after:highlightBlock"] && !plugin["after:highlightElement"]) {
+      plugin["after:highlightElement"] = (data) => {
+        plugin["after:highlightBlock"](
+          Object.assign({ block: data.el }, data)
+        );
+      };
+    }
+  }
+
+  /**
    * @param {HLJSPlugin} plugin
    */
   function addPlugin(plugin) {
+    upgradePluginAPI(plugin);
     plugins.push(plugin);
   }
 

--- a/src/plugins/merge_html.js
+++ b/src/plugins/merge_html.js
@@ -4,8 +4,8 @@ import { escapeHTML } from "../lib/utils.js";
 
 /** @type {HLJSPlugin} */
 export const mergeHTMLPlugin = {
-  "after:highlightBlock": ({ block, result, text }) => {
-    const originalStream = nodeStream(block);
+  "after:highlightElement": ({ el, result, text }) => {
+    const originalStream = nodeStream(el);
     if (!originalStream.length) return;
 
     const resultNode = document.createElement('div');

--- a/test/browser/highlight_block_callbacks.js
+++ b/test/browser/highlight_block_callbacks.js
@@ -29,8 +29,8 @@ describe('old highlightBlock plugin', function() {
     should(old["after:highlightElement"]).be.undefined();
     should(old["before:highlightElement"]).be.undefined();
     this.hljs.addPlugin(old);
-    should(old["after:highlightElement"]).not.be.null();
-    should(old["before:highlightElement"]).not.be.null();
+    should(old["after:highlightElement"]).not.be.undefined();
+    should(old["before:highlightElement"]).not.be.undefined();
   });
 }
 );

--- a/test/browser/highlight_block_callbacks.js
+++ b/test/browser/highlight_block_callbacks.js
@@ -6,12 +6,34 @@ const {newTestCase, defaultCase, buildFakeDOM } = require('./test_case')
 
 class ContentAdder {
   constructor(params) {
-    this.content = params.content
+    this.content = params.content;
   }
-  'before:highlightBlock'({block,language}) {
-    block.innerHTML += this.content;
+
+  'before:highlightElement'({ el, language}) {
+    el.innerHTML += this.content;
   }
 }
+
+class OldPlugin {
+  'before:highlightBlock'({ block, language }) {}
+  'after:highlightBlock'({ block, result, text }) {}
+}
+
+describe('old highlightBlock plugin', function() {
+  it("is upgraded to new API automatically", async function() {
+    // we need a stub testcase juts for buildFakeDOM to work
+    const testCase = newTestCase({ html: "" });
+    await buildFakeDOM.bind(this)(testCase);
+
+    const old = new OldPlugin();
+    should(old["after:highlightElement"]).be.undefined();
+    should(old["before:highlightElement"]).be.undefined();
+    this.hljs.addPlugin(old);
+    should(old["after:highlightElement"]).not.be.null();
+    should(old["before:highlightElement"]).not.be.null();
+  });
+}
+);
 
 describe('callback system', function() {
   it("supports class based plugins", async function() {
@@ -30,12 +52,12 @@ describe('callback system', function() {
   })
 })
 
-describe('before:highlightBlock', function() {
+describe('before:highlightElement', function() {
   it('is called', async function() {
     await buildFakeDOM.bind(this)(defaultCase);
     var called = false;
     this.hljs.addPlugin({
-      'before:highlightBlock': ({block, result}) => {
+      'before:highlightElement': ({el, result}) => {
         called = true;
       }
     });
@@ -50,9 +72,9 @@ describe('before:highlightBlock', function() {
     await buildFakeDOM.bind(this)(testCase);
 
     this.hljs.addPlugin({
-      'before:highlightBlock': ({block, language}) => {
+      'before:highlightElement': ({el, language}) => {
         language.should.equal("javascript")
-        block.innerHTML = "var a;"
+        el.innerHTML = "var a;"
       }
     });
 
@@ -64,12 +86,12 @@ describe('before:highlightBlock', function() {
 
 })
 
-describe('after:highlightBlock', function() {
+describe('after:highlightElement', function() {
   it('is called', async function() {
     await buildFakeDOM.bind(this)(defaultCase);
     var called = false;
     this.hljs.addPlugin({
-      'after:highlightBlock': ({block, result}) => {
+      'after:highlightElement': ({el, result}) => {
         called = true;
       }
     });
@@ -80,7 +102,7 @@ describe('after:highlightBlock', function() {
     await buildFakeDOM.bind(this)(defaultCase);
 
     this.hljs.addPlugin({
-      'after:highlightBlock': ({block, result}) => {
+      'after:highlightElement': ({el, result}) => {
         result.language.should.equal("javascript")
         result.relevance.should.above(0)
       }
@@ -95,7 +117,7 @@ describe('after:highlightBlock', function() {
     });
     await buildFakeDOM.bind(this)(test);
     this.hljs.addPlugin({
-      'after:highlightBlock': ({block, result}) => {
+      'after:highlightElement': ({el, result}) => {
         result.language="basic";
       }
     });
@@ -111,7 +133,7 @@ describe('after:highlightBlock', function() {
     })
     await buildFakeDOM.bind(this)(test);
     this.hljs.addPlugin({
-      'after:highlightBlock': ({block, result}) => {
+      'after:highlightElement': ({el, result}) => {
         result.value="redacted";
       }
     });

--- a/test/browser/highlight_block_callbacks.js
+++ b/test/browser/highlight_block_callbacks.js
@@ -23,7 +23,7 @@ describe('callback system', function() {
     await buildFakeDOM.bind(this)(testCase);
 
     this.hljs.addPlugin(new ContentAdder({content:" = 5;"}))
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     const actual = this.block.innerHTML;
     actual.should.equal(testCase.expect);
 
@@ -39,7 +39,7 @@ describe('before:highlightBlock', function() {
         called = true;
       }
     });
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     called.should.equal(true);
   })
   it('can modify block content before highlight', async function() {
@@ -56,7 +56,7 @@ describe('before:highlightBlock', function() {
       }
     });
 
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     const actual = this.block.innerHTML;
     actual.should.equal(
       `<span class="hljs-keyword">var</span> a;`);
@@ -73,7 +73,7 @@ describe('after:highlightBlock', function() {
         called = true;
       }
     });
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     called.should.equal(true);
   })
   it('receives result data', async function() {
@@ -86,7 +86,7 @@ describe('after:highlightBlock', function() {
       }
     });
 
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
   });
   it('can override language if not originally provided (in class)', async function() {
     var test = newTestCase({
@@ -100,7 +100,7 @@ describe('after:highlightBlock', function() {
       }
     });
 
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     should(this.block.outerHTML.includes(`class="hljs basic"`)).equal(true);
 
   })
@@ -116,7 +116,7 @@ describe('after:highlightBlock', function() {
       }
     });
 
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     this.block.outerHTML.should.equal(`<code class="javascript hljs">redacted</code>`);
   })
 })

--- a/test/browser/test_case.js
+++ b/test/browser/test_case.js
@@ -28,7 +28,7 @@ function newTestCase(opts) {
   test.html = test.html || `<pre><code class='${test.language}'>${test.code}</code></pre>`;
   test.runner = async function() {
     await buildFakeDOM.bind(this, test)();
-    this.hljs.highlightBlock(this.block);
+    this.hljs.highlightElement(this.block);
     const actual = this.block.innerHTML;
     actual.should.equal(test.expect);
   }

--- a/test/special/index.js
+++ b/test/special/index.js
@@ -22,13 +22,13 @@ describe('special cases tests', () => {
     // Setup hljs environment
     hljs.configure({ tabReplace: '    ' });
     let blocks = document.querySelectorAll('pre code');
-    blocks.forEach(hljs.highlightBlock);
+    blocks.forEach(hljs.highlightElement);
 
     // Setup hljs for non-`<pre><code>` tests
     hljs.configure({ useBR: true });
 
     blocks = document.querySelectorAll('.code');
-    blocks.forEach(hljs.highlightBlock);
+    blocks.forEach(hljs.highlightElement);
   });
 
   require('./explicitLanguage');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,6 +100,9 @@ type PluginEvent = keyof HLJSPlugin;
 type HLJSPlugin = {
     'after:highlight'?: (result: HighlightResult) => void,
     'before:highlight'?: (context: BeforeHighlightContext) => void,
+    'after:highlightElement'?: (data: { block: Element, result: HighlightResult, text: string}) => void,
+    'before:highlightElement'?: (data: { block: Element, language: string}) => void,
+    // TODO: Old API, remove with v12
     'after:highlightBlock'?: (data: { block: Element, result: HighlightResult, text: string}) => void,
     'before:highlightBlock'?: (data: { block: Element, language: string}) => void,
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -100,8 +100,8 @@ type PluginEvent = keyof HLJSPlugin;
 type HLJSPlugin = {
     'after:highlight'?: (result: HighlightResult) => void,
     'before:highlight'?: (context: BeforeHighlightContext) => void,
-    'after:highlightElement'?: (data: { block: Element, result: HighlightResult, text: string}) => void,
-    'before:highlightElement'?: (data: { block: Element, language: string}) => void,
+    'after:highlightElement'?: (data: { el: Element, result: HighlightResult, text: string}) => void,
+    'before:highlightElement'?: (data: { el: Element, language: string}) => void,
     // TODO: Old API, remove with v12
     'after:highlightBlock'?: (data: { block: Element, result: HighlightResult, text: string}) => void,
     'before:highlightBlock'?: (data: { block: Element, language: string}) => void,


### PR DESCRIPTION
More work towards #2277.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- adds `highlightElement(el)` API and new plugin callbacks
- deprecates old `highlightBlock(el)` API and old callbacks
- both sets of plugin callbacks will be supported until v12 

Supporting both sets of plugin callbacks should allow plugins to be written that easily work with both v10 and v11 (for a smooth transition for all).

Old API will continue to be supported until v12.

- [x] Make sure API isn't double called if a plugin defines both for compatibility

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors