### PR TITLE
[PHP] Add support for Enum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Language grammar improvements:
 - enh(php) Add `Stringable`, `UnhandledMatchError`, and `WeakMap` classes/interfaces (#2997) [Ayesh][]
 - enh(php) Add `mixed` to list of keywords (#2997) [Ayesh][]
 - enh(php) Add support binary, octal, hex and scientific numerals with underscore separator support (#2997) [Ayesh][]
+- enh(php) Add support for Enums (#3004) [Ayesh][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [John Cheung]: https://github.com/Real-John-Cheung

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -85,7 +85,7 @@ export default function(hljs) {
     // <https://www.php.net/manual/en/reserved.php>
     // <https://www.php.net/manual/en/language.types.type-juggling.php>
     'array abstract and as binary bool boolean break callable case catch class clone const continue declare ' +
-    'default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends ' +
+    'default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile enum eval extends ' +
     'final finally float for foreach from global goto if implements instanceof insteadof int integer interface ' +
     'isset iterable list match|0 mixed new object or private protected public real return string switch throw trait ' +
     'try unset use var void while xor yield',
@@ -170,11 +170,11 @@ export default function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'class interface trait',
+        beginKeywords: 'class interface trait enum',
         relevance: 0,
         end: /\{/,
         excludeEnd: true,
-        illegal: /[:($"]/,
+        illegal: /[($"]/,
         contains: [
           {beginKeywords: 'extends implements'},
           hljs.UNDERSCORE_TITLE_MODE

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -170,11 +170,13 @@ export default function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'class interface trait enum',
+        variants: [
+          { beginKeywords: "enum", illegal: /[($"]/ },
+          { beginKeywords: "class interface trait", illegal: /[:($"]/ }
+        ],
         relevance: 0,
         end: /\{/,
         excludeEnd: true,
-        illegal: /[($"]/,
         contains: [
           {beginKeywords: 'extends implements'},
           hljs.UNDERSCORE_TITLE_MODE

--- a/test/detect/php/default.txt
+++ b/test/detect/php/default.txt
@@ -52,6 +52,10 @@ match ($key) {
     [1] => 'Array [1]',
 };
 
+enum Foo: string {
+    case Test = 'test';
+}
+
 echo URI::ME . URI::$st1;
 
 __halt_compiler () ; datahere

--- a/test/detect/php/default.txt
+++ b/test/detect/php/default.txt
@@ -56,6 +56,14 @@ enum Foo: string {
     case Test = 'test';
 }
 
+match ($key) {
+    1 => 'Integer 1',
+    '1' => 'String 1',
+    true => 'Bool true',
+    [] => 'Empty array',
+    [1] => 'Array [1]',
+};
+
 echo URI::ME . URI::$st1;
 
 __halt_compiler () ; datahere

--- a/test/markup/php/php80.expect.txt
+++ b/test/markup/php/php80.expect.txt
@@ -8,3 +8,6 @@
     [<span class="hljs-number">1</span>] =&gt; <span class="hljs-string">&#x27;Array [1]&#x27;</span>,
 };
 
+<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-title">Foo</span>: <span class="hljs-title">string</span> </span>{
+    <span class="hljs-keyword">case</span> Test = <span class="hljs-string">&#x27;test&#x27;</span>;
+}

--- a/test/markup/php/php80.txt
+++ b/test/markup/php/php80.txt
@@ -7,3 +7,7 @@ match ($key) {
     [] => 'Empty array',
     [1] => 'Array [1]',
 };
+
+enum Foo: string {
+    case Test = 'test';
+}


### PR DESCRIPTION
Related to #2997.

PHP 8.1 will add [support for Enums with a syntax](https://php.watch/versions/8.1/enums#enum-syntax) similar to this:
```php
enum Foo: string {}
```

At the moment, the [vote](https://wiki.php.net/rfc/enumerations) has two more days to end, but it already has the 2/3 majority it requires to pass. This PR includes changes that did not make it to #2997 because the vote has yet to end. Once the vote is concluded, I will mark mark this PR ready for review, although early reviews are received with so much gratitude!

### Changes
 - Add Enum syntax support as a class-name variant.
 - Update CHANGES.md file.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
