### PR TITLE
Add Q# to supported languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ New Languages:
 
 - Added 3rd party RiScript grammar to SUPPORTED_LANGUAGES (#2988) [John C][]
 - Added 3rd party HLSL grammar to SUPPORTED_LANGUAGES (#3002) [Stef Levesque][]
+- Added 3rd party Q# grammar to SUPPORTED_LANGUAGES(#3006) [Vyron Vasileiadis][]
 
 Language grammar improvements:
 
@@ -18,6 +19,7 @@ Language grammar improvements:
 [John Cheung]: https://github.com/Real-John-Cheung
 [xDGameStudios]: https://github.com/xDGameStudios
 [Ayesh]: https://github.com/Ayesh
+[Vyron Vasileiadis]: https://github.com/fedonman
 
 ## Version 10.6.0
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -152,6 +152,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Python                  | python, py, gyp        |         |
 | Python profiler results | profile                |         |
 | Python REPL             | python-repl, pycon     |         |
+| Q#                      | qsharp                 | [highlightjs-qsharp](https://github.com/fedonman.com/highlightjs-qsharp) |
 | Q                       | k, kdb                 |         |
 | QML                     | qml                    |         |
 | R                       | r                      |         |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -152,7 +152,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Python                  | python, py, gyp        |         |
 | Python profiler results | profile                |         |
 | Python REPL             | python-repl, pycon     |         |
-| Q#                      | qsharp                 | [highlightjs-qsharp](https://github.com/fedonman.com/highlightjs-qsharp) |
+| Q#                      | qsharp                 | [highlightjs-qsharp](https://github.com/fedonman/highlightjs-qsharp) |
 | Q                       | k, kdb                 |         |
 | QML                     | qml                    |         |
 | R                       | r                      |         |


### PR DESCRIPTION
Created [highlighjs-qsharp](https://github.com/fedonman/highlightjs-qsharp) repository, which contains syntax definitions for Q# language. 

The syntax is not perfect, although this first version provides satisfactory results.
