### PR TITLE
ehn(api): add unregisterLanguage method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,9 @@ module.exports = {
     },
     {
       files: ["test/**/*.js"],
+      globals: {
+        should: "readonly"
+      },
       env: {
         mocha: true
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,12 +14,17 @@ Language grammar improvements:
 - enh(php) Add `mixed` to list of keywords (#2997) [Ayesh][]
 - enh(php) Add support binary, octal, hex and scientific numerals with underscore separator support (#2997) [Ayesh][]
 
+API:
+
+- enh(api) add `unregisterLanguage` method (#3009) [Antoine du Hamel][]
+
 [Stef Levesque]: https://github.com/stef-levesque
 [Josh Goebel]: https://github.com/joshgoebel
 [John Cheung]: https://github.com/Real-John-Cheung
 [xDGameStudios]: https://github.com/xDGameStudios
 [Ayesh]: https://github.com/Ayesh
 [Vyron Vasileiadis]: https://github.com/fedonman
+[Antoine du Hamel]: https://github.com/aduh95
 
 ## Version 10.6.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -125,6 +125,14 @@ Adds new language to the library under the specified name. Used mostly internall
   to use common regular expressions defined within it.
 
 
+``unregisterLanguage(languageName)``
+------------------------------------
+
+Removes a language and its aliases from the library. Used mostly internally.
+
+* ``languageName``: a string with the name of the language being removed.
+
+
 ``registerAliases(alias|aliases, {languageName})``
 --------------------------------------------------
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -821,6 +821,11 @@ const HLJS = function(hljs) {
    */
   function unregisterLanguage(languageName) {
     delete languages[languageName];
+    for(const alias of Object.keys(aliases)) {
+      if(aliases[alias] === languageName) {
+        delete aliases[alias];
+      }
+    }
   }
 
   /**

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -815,6 +815,15 @@ const HLJS = function(hljs) {
   }
 
   /**
+   * Remove a language grammar module
+   *
+   * @param {string} languageName
+   */
+  function unregisterLanguage(languageName) {
+    delete languages[languageName];
+  }
+
+  /**
    * @returns {string[]} List of language internal names
    */
   function listLanguages() {
@@ -916,6 +925,7 @@ const HLJS = function(hljs) {
     initHighlighting,
     initHighlightingOnLoad,
     registerLanguage,
+    unregisterLanguage,
     listLanguages,
     getLanguage,
     registerAliases,

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -821,8 +821,8 @@ const HLJS = function(hljs) {
    */
   function unregisterLanguage(languageName) {
     delete languages[languageName];
-    for(const alias of Object.keys(aliases)) {
-      if(aliases[alias] === languageName) {
+    for (const alias of Object.keys(aliases)) {
+      if (aliases[alias] === languageName) {
         delete aliases[alias];
       }
     }

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -12,6 +12,7 @@ describe('hljs', function() {
   require('./keywords');
   require('./number');
   require('./registerAlias');
+  require('./unregisterLanguage');
   require('./starters');
   require('./underscoreIdent');
 });

--- a/test/api/unregisterLanguage.js
+++ b/test/api/unregisterLanguage.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const hljs = require("../../build");
+
+let grammar = function () {
+  return {
+    contains: [{ beginKeywords: "class" }],
+  };
+};
+
+describe(".unregisterLanguage()", () => {
+  beforeEach(() => {
+    hljs.registerLanguage("test", grammar);
+  });
+
+  it("should remove an existing language", () => {
+    hljs.unregisterLanguage("test");
+    const result = hljs.getLanguage("test");
+
+    (result == null).should.be.true();
+  });
+
+  it("should remove an existing language and its aliases", () => {
+    hljs.registerAliases(["jquery", "jqueryui"], {
+      languageName: "test",
+    });
+
+    {
+        const result = hljs.getLanguage("jquery");
+        (result == null).should.be.false();
+    }
+    hljs.unregisterLanguage("test");
+    {
+        const result = hljs.getLanguage("jquery");
+        (result == null).should.be.true();
+    }
+  });
+});

--- a/test/api/unregisterLanguage.js
+++ b/test/api/unregisterLanguage.js
@@ -2,37 +2,38 @@
 
 const hljs = require("../../build");
 
-let grammar = function () {
+const jQuery = function() {
   return {
-    contains: [{ beginKeywords: "class" }],
+    name: "jQuery",
+    contains: [{ beginKeywords: "class" }]
   };
 };
 
 describe(".unregisterLanguage()", () => {
   beforeEach(() => {
-    hljs.registerLanguage("test", grammar);
+    hljs.registerLanguage("test", jQuery);
   });
 
   it("should remove an existing language", () => {
     hljs.unregisterLanguage("test");
     const result = hljs.getLanguage("test");
 
-    (result == null).should.be.true();
+    should(result).be.undefined();
   });
 
   it("should remove an existing language and its aliases", () => {
     hljs.registerAliases(["jquery", "jqueryui"], {
-      languageName: "test",
+      languageName: "test"
     });
 
     {
-        const result = hljs.getLanguage("jquery");
-        (result == null).should.be.false();
+      const result = hljs.getLanguage("jquery");
+      should(result.name).equal("jQuery");
     }
     hljs.unregisterLanguage("test");
     {
-        const result = hljs.getLanguage("jquery");
-        (result == null).should.be.true();
+      const result = hljs.getLanguage("jquery");
+      should(result).be.undefined();
     }
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,7 @@ interface PublicApi {
     initHighlightingOnLoad: () => void
     highlightAll: () => void
     registerLanguage: (languageName: string, language: LanguageFn) => void
+    unregisterLanguage: (languageName: string) => void
     listLanguages: () => string[]
     registerAliases: (aliasList: string | string[], { languageName } : {languageName: string}) => void
     getLanguage: (languageName: string) => Language | undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Currently, there is no way of un-do a `registerLanguage` operation except re-loading the whole library. Adds a `unregisterLanguage` method to the public API.

### Checklist
- [x] No markup tests, this shouldn't change anything to the markup
- [x] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
