### PR TITLE
(typescript) Add "tsx" alias

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -89,7 +89,7 @@ export default function(hljs) {
 
   Object.assign(tsLanguage, {
     name: 'TypeScript',
-    aliases: ['ts']
+    aliases: ['ts', 'tsx']
   });
 
   return tsLanguage;


### PR DESCRIPTION
### Changes
Add "tsx" alias to be on parity with JavaScript as TS also supports JSX syntax.

### Checklist
- [x] ~Added markup tests~, or they don't apply here because no code change
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
