### PR TITLE
enh(ecmascript): Add built-in types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Language grammar improvements:
 - enh(php) Add `mixed` to list of keywords (#2997) [Ayesh][]
 - enh(php) Add support binary, octal, hex and scientific numerals with underscore separator support (#2997) [Ayesh][]
 - enh(php) Add support for Enums (#3004) [Ayesh][]
+- enh(ecmascript) Add built-in types [Vaibhav Chanana][]
 
 API:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ API:
 [Ayesh]: https://github.com/Ayesh
 [Vyron Vasileiadis]: https://github.com/fedonman
 [Antoine du Hamel]: https://github.com/aduh95
+[Vaibhav Chanana]: https://github.com/il3ven
 
 ## Version 10.6.0
 

--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -82,7 +82,10 @@ const TYPES = [
   "Array",
   "Uint8Array",
   "Uint8ClampedArray",
-  "ArrayBuffer"
+  "ArrayBuffer",
+  "BigInt64Array",
+  "BigUint64Array",
+  "BigInt"
 ];
 
 const ERROR_TYPES = [

--- a/test/markup/javascript/built-in.expect.txt
+++ b/test/markup/javascript/built-in.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-keyword">let</span> bi = <span class="hljs-built_in">BigInt</span>(<span class="hljs-string">&#x27;1&#x27;</span>);
+<span class="hljs-keyword">let</span> inf = <span class="hljs-literal">Infinity</span>
+<span class="hljs-built_in">Number</span>(<span class="hljs-literal">undefined</span>)
+<span class="hljs-keyword">let</span> today = <span class="hljs-keyword">new</span> <span class="hljs-built_in">Date</span>()

--- a/test/markup/javascript/built-in.txt
+++ b/test/markup/javascript/built-in.txt
@@ -1,0 +1,4 @@
+let bi = BigInt('1');
+let inf = Infinity
+Number(undefined)
+let today = new Date()


### PR DESCRIPTION
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #2992 

### Changes
Added these built-in types **BigInt64Array, BigUint64Array, BigInt**
Created a new test file in javascript (built-in.txt)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
