### PR TITLE
fix(kotlin): Add kts as an alias for Kotlin (#3021)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Language grammar improvements:
 - enh(php) Add support binary, octal, hex and scientific numerals with underscore separator support (#2997) [Ayesh][]
 - enh(php) Add support for Enums (#3004) [Ayesh][]
 - enh(ecmascript) Add built-in types [Vaibhav Chanana][]
+- fix(kotlin) Add kts as an alias for Kotlin (#3021) [Vaibhav Chanana][]
 
 Deprecations:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Language grammar improvements:
 - enh(php) Add support binary, octal, hex and scientific numerals with underscore separator support (#2997) [Ayesh][]
 - enh(php) Add support for Enums (#3004) [Ayesh][]
 - enh(ecmascript) Add built-in types [Vaibhav Chanana][]
-- fix(kotlin) Add kts as an alias for Kotlin (#3021) [Vaibhav Chanana][]
+- enh(kotlin) Add `kts` as an alias for Kotlin (#3021) [Vaibhav Chanana][]
 
 Deprecations:
 

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -132,7 +132,7 @@ export default function(hljs) {
 
   return {
     name: 'Kotlin',
-    aliases: [ 'kt' ],
+    aliases: [ 'kt', 'kts' ],
     keywords: KEYWORDS,
     contains: [
       hljs.COMMENT(


### PR DESCRIPTION
Simple PR. Resolves #3021 

### Changes
Added `kts` as an alias for Kotlin in `languages/kotlin.js`

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
