### PR TITLE
chore(parser) Remove redundant aliases: php -> php, etc...

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -317,3 +317,4 @@ Contributors:
 - davidhcefx <davidhu0903ex3@gmail.com>
 - xDGameStudios <xDGameStudios@gmail.com>
 - Ayesh Karunaratne <ayesh@aye.sh>
+- Olcay Usta <https://github.com/olcayusta>

--- a/src/languages/clean.js
+++ b/src/languages/clean.js
@@ -10,7 +10,6 @@ export default function(hljs) {
   return {
     name: 'Clean',
     aliases: [
-      'clean',
       'icl',
       'dcl'
     ],

--- a/src/languages/cos.js
+++ b/src/languages/cos.js
@@ -75,7 +75,6 @@ export default function cos(hljs) {
     name: 'Caché Object Script',
     case_insensitive: true,
     aliases: [
-      "cos",
       "cls"
     ],
     keywords: COS_KEYWORDS,

--- a/src/languages/gml.js
+++ b/src/languages/gml.js
@@ -870,7 +870,6 @@ export default function(hljs) {
   return {
     name: 'GML',
     aliases: [
-      'gml',
       'GML'
     ],
     case_insensitive: false, // language is case-insensitive

--- a/src/languages/isbl.js
+++ b/src/languages/isbl.js
@@ -3189,7 +3189,6 @@ export default function(hljs) {
 
   return {
     name: 'ISBL',
-    aliases: ["isbl"],
     case_insensitive: true,
     keywords: KEYWORDS,
     illegal: "\\$|\\?|%|,|;$|~|#|@|</",

--- a/src/languages/nim.js
+++ b/src/languages/nim.js
@@ -8,7 +8,6 @@ Category: system
 export default function(hljs) {
   return {
     name: 'Nim',
-    aliases: [ 'nim' ],
     keywords: {
       keyword:
         'addr and as asm bind block break case cast const continue converter ' +

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -103,7 +103,7 @@ export default function(hljs) {
     'Directory __PHP_Incomplete_Class parent php_user_filter self static stdClass'
   };
   return {
-    aliases: ['php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8'],
+    aliases: ['php3', 'php4', 'php5', 'php6', 'php7', 'php8'],
     case_insensitive: true,
     keywords: KEYWORDS,
     contains: [

--- a/src/languages/routeros.js
+++ b/src/languages/routeros.js
@@ -73,7 +73,6 @@ export default function(hljs) {
   return {
     name: 'Microtik RouterOS script',
     aliases: [
-      'routeros',
       'mikrotik'
     ],
     case_insensitive: true,

--- a/src/languages/sas.js
+++ b/src/languages/sas.js
@@ -80,7 +80,6 @@ export default function(hljs) {
   return {
     name: 'SAS',
     aliases: [
-      'sas',
       'SAS'
     ],
     case_insensitive: true, // SAS is case-insensitive

--- a/src/languages/smali.js
+++ b/src/languages/smali.js
@@ -71,7 +71,6 @@ export default function(hljs) {
   ];
   return {
     name: 'Smali',
-    aliases: [ 'smali' ],
     contains: [
       {
         className: 'string',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Aliases that match the language name have been removed.
`clean` `cos` `gml` `isbl` `nim` `php` `routeros` `sas` `smali`
Resolves #3023 

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
