### PR TITLE
fix(parser) Make language alias registration case insensitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ Deprecations:
 API:
 
 - enh(api) add `unregisterLanguage` method (#3009) [Antoine du Hamel][]
-- Make language registration case insensitive [David Ostrovsky][]
+- enh: Make alias registration case insensitive (#3026) [David Ostrovsky][]
 
 [Stef Levesque]: https://github.com/stef-levesque
 [Josh Goebel]: https://github.com/joshgoebel

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Deprecations:
 API:
 
 - enh(api) add `unregisterLanguage` method (#3009) [Antoine du Hamel][]
+- Make language registration case insensitive [David Ostrovsky][]
 
 [Stef Levesque]: https://github.com/stef-levesque
 [Josh Goebel]: https://github.com/joshgoebel
@@ -38,6 +39,7 @@ API:
 [Vyron Vasileiadis]: https://github.com/fedonman
 [Antoine du Hamel]: https://github.com/aduh95
 [Vaibhav Chanana]: https://github.com/il3ven
+[David Ostrovsky]: https://github.com/davido
 
 ## Version 10.6.0
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -875,7 +875,7 @@ const HLJS = function(hljs) {
     if (typeof aliasList === 'string') {
       aliasList = [aliasList];
     }
-    aliasList.forEach(alias => { aliases[alias] = languageName; });
+    aliasList.forEach(alias => { aliases[alias.toLowerCase()] = languageName; });
   }
 
   /**

--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -239,10 +239,7 @@ export default function(hljs) {
 
   return {
     name: 'LaTeX',
-    aliases: [
-      'tex',
-      'TeX',
-    ],
+    aliases: ['TeX'],
     contains: [
       ...VERBATIM,
       ...EVERYTHING_BUT_VERBATIM

--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -239,7 +239,10 @@ export default function(hljs) {
 
   return {
     name: 'LaTeX',
-    aliases: ['TeX'],
+    aliases: [
+      'tex',
+      'TeX',
+    ],
     contains: [
       ...VERBATIM,
       ...EVERYTHING_BUT_VERBATIM


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
- [ ] Added myself to `AUTHORS.txt`, under Contributors
