### PR TITLE
(chore) Fix Authors format

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -317,4 +317,4 @@ Contributors:
 - davidhcefx <davidhu0903ex3@gmail.com>
 - xDGameStudios <xDGameStudios@gmail.com>
 - Ayesh Karunaratne <ayesh@aye.sh>
-- Olcay Usta <https://github.com/olcayusta>
+- Olcay Usta (https://github.com/olcayusta)


### PR DESCRIPTION
Follow up from #3024, fyi @olcayusta 

### Changes
The entries in the AUTHORS.txt should follow the npm people field short-format as they get included in the package.json.
![image](https://user-images.githubusercontent.com/2564094/109584191-f7ccde80-7ab5-11eb-9c6a-596ee72e4d4c.png)

See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#people-fields-author-contributors

### Checklist
- [x] ~Added markup tests~
- [x] ~Updated the changelog at `CHANGES.md`~
- [x] Added myself to `AUTHORS.txt`, under Contributors
