### PR TITLE
(scheme) Add 'racket' alias

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -318,3 +318,4 @@ Contributors:
 - xDGameStudios <xDGameStudios@gmail.com>
 - Ayesh Karunaratne <ayesh@aye.sh>
 - Olcay Usta <https://github.com/olcayusta>
+- Eli W. Hunter <elihunter173@gmail.com>

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -172,7 +172,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | SQL                     | sql                    |         |
 | STEP Part 21            | p21, step, stp         |         |
 | Scala                   | scala                  |         |
-| Scheme                  | scheme                 |         |
+| Scheme                  | scheme, racket         |         |
 | Scilab                  | scilab, sci            |         |
 | Shape Expressions       | shexc                  | [highlightjs-shexc](https://github.com/highlightjs/highlightjs-shexc) |
 | Shell                   | shell, console         |         |

--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -198,6 +198,7 @@ export default function(hljs) {
 
   return {
     name: 'Scheme',
+    aliases: [ 'racket' ],
     illegal: /\S/,
     contains: [
       hljs.SHEBANG(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Add `racket` alias to the scheme language since scheme highlighting is also used for racket. https://github.com/highlightjs/highlight.js/issues/2890

### Checklist
- [x] Added markup tests, or they don't apply here because... Single alias added
- [ ] Updated the changelog at `CHANGES.md`
- [x] Added myself to `AUTHORS.txt`, under Contributors
