### PR TITLE
fix(parser) `highlightAll()` now works if the library is lazy loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 10.7.0 (in progress)
 
+Bugs:
+
+- fix(parser) `highlightAll()` now works if the library is lazy loaded [Josh Goebel][]
+
 New Languages:
 
 - Added 3rd party RiScript grammar to SUPPORTED_LANGUAGES (#2988) [John C][]

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -762,30 +762,29 @@ const HLJS = function(hljs) {
   }
 
   let wantsHighlight = false;
-  let domLoaded = false;
 
   /**
    * auto-highlights all pre>code elements on the page
    */
   function highlightAll() {
     // if we are called too early in the loading process
-    if (!domLoaded) { wantsHighlight = true; return; }
+    if (document.readyState === "loading") {
+      wantsHighlight = true;
+      return;
+    }
 
     const blocks = document.querySelectorAll('pre code');
     blocks.forEach(highlightElement);
   }
 
   function boot() {
-    domLoaded = true;
     // if a highlight was requested before DOM was loaded, do now
     if (wantsHighlight) highlightAll();
   }
 
-  const LOADED_STATES = ["interactive", "complete"];
   // make sure we are in the browser environment
   if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('DOMContentLoaded', boot, false);
-    if (LOADED_STATES.includes(document.readyState)) { domLoaded = true; }
   }
 
   /**

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -781,9 +781,11 @@ const HLJS = function(hljs) {
     if (wantsHighlight) highlightAll();
   }
 
+  const LOADED_STATES = ["interactive", "complete"];
   // make sure we are in the browser environment
   if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('DOMContentLoaded', boot, false);
+    if (LOADED_STATES.includes(document.readyState)) { domLoaded = true; }
   }
 
   /**


### PR DESCRIPTION
Previously we hooked `DOMContentLoaded` to keep track of whether the
page had loaded or not, but that does not work if we are lazy loaded
FAR into the future.  In that case we need to check `document.readyState`
and if it's complete then we know that the page has previously been
loaded and we're now good to go.


<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Should resolve #3020.




### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`