### PR TITLE
fix(c/cpp) comments after #include <> blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ New Languages:
 
 Language grammar improvements:
 
+- fix(c) comments after `#include <str>` blocks (#3041) [Josh Goebel][]
+- fix(cpp) comments after `#include <str>` blocks (#3041) [Josh Goebel][]
 - enh(gml) Add additional GML 2.3 keywords (#2984) [xDGameStudios][]
 - fix(cpp) constructor support for initializers (#3001) [Josh Goebel][]
 - enh(php) Add `trait` to class-like naming patterns (#2997) [Ayesh][]

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -90,8 +90,7 @@ export default function(hljs) {
       }),
       {
         className: 'meta-string',
-        begin: /<.*?>/,
-        illegal: /\n/
+        begin: /<.*?>/
       },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -91,8 +91,7 @@ export default function(hljs) {
       {
         className: 'meta-string',
         begin: /<.*?>/,
-        end: /$/,
-        illegal: '\\n'
+        illegal: /\n/
       },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -90,8 +90,7 @@ export default function(hljs) {
       }),
       {
         className: 'meta-string',
-        begin: /<.*?>/,
-        illegal: /\n/
+        begin: /<.*?>/
       },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -91,8 +91,7 @@ export default function(hljs) {
       {
         className: 'meta-string',
         begin: /<.*?>/,
-        end: /$/,
-        illegal: '\\n'
+        illegal: /\n/
       },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE

--- a/test/markup/cpp/comments.expect.txt
+++ b/test/markup/cpp/comments.expect.txt
@@ -1,0 +1,14 @@
+<span class="hljs-comment">// line comment</span>
+
+<span class="hljs-comment">/* block comment */</span>
+
+<span class="hljs-comment">/* block comment
+  across lines
+*/</span>
+
+<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;sys/wait.h&gt;</span> <span class="hljs-comment">// line comment</span></span>
+<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;sys/wait.h&gt;</span> <span class="hljs-comment">/* block comment */</span></span>
+
+<span class="hljs-comment">/*
+Truncated block comment
+</span>

--- a/test/markup/cpp/comments.txt
+++ b/test/markup/cpp/comments.txt
@@ -1,0 +1,13 @@
+// line comment
+
+/* block comment */
+
+/* block comment
+  across lines
+*/
+
+#include <sys/wait.h> // line comment
+#include <sys/wait.h> /* block comment */
+
+/*
+Truncated block comment

--- a/test/markup/cpp/truncated-block-comment.expect.txt
+++ b/test/markup/cpp/truncated-block-comment.expect.txt
@@ -1,3 +1,0 @@
-<span class="hljs-comment">/*
-Truncated block comment
-</span>

--- a/test/markup/cpp/truncated-block-comment.txt
+++ b/test/markup/cpp/truncated-block-comment.txt
@@ -1,2 +1,0 @@
-/*
-Truncated block comment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Resolves #3040.

### Changes

Fixes the fact that the <blah> string matching mode inside pre-processor
directives such as #include would not terminate until line end -
preventing it from matching comments or other things that might occur
before the end of the line.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`