### PR TITLE
(python) highlight print and exec as builtins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@ API:
 [Vaibhav Chanana]: https://github.com/il3ven
 [David Ostrovsky]: https://github.com/davido
 [AndyKIron]: https://github.com/AndyKIron
+[Samuel Colvin]: https://github.com/samuelcolvin
 
 ## Version 10.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Language grammar improvements:
 - enh(ecmascript) Add built-in types [Vaibhav Chanana][]
 - enh(kotlin) Add `kts` as an alias for Kotlin (#3021) [Vaibhav Chanana][]
 - enh(css) Add `font-smoothing` to attributes list for CSS (#3027) [AndyKIron][]
+- fix(python) Highlight `print` and `exec` as a builtin (#1468) [Samuel Colvin][]
 
 Deprecations:
 

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -406,10 +406,6 @@ export default function(hljs) {
           PARAMS,
           STRING
         ]
-      },
-      // don’t highlight keywords-turned-functions in Python 3
-      {
-        begin: /\b(print|exec)\(/
       }
     ]
   };

--- a/test/markup/python-repl/sample.expect.txt
+++ b/test/markup/python-repl/sample.expect.txt
@@ -1,11 +1,11 @@
 <span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python">v = <span class="hljs-string">&quot;foo = 42&quot;</span></span>
 <span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python">v</span>
 &quot;foo = 42&quot;
-<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python">print(v)</span>
+<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-built_in">print</span>(v)</span>
 foo = 42
-<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python">print(<span class="hljs-built_in">repr</span>(v).rstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).rstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 &quot;foo = 42
-<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python">print(<span class="hljs-built_in">repr</span>(v).lstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).lstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 foo = 42&quot;
 
 <span class="hljs-meta">&gt;&gt;&gt;</span> <span class="python"><span class="hljs-string">&quot;&quot;&quot;</span></span>

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -9,4 +9,6 @@ x = Shorty()
     sys = <span class="hljs-built_in">__import__</span>(<span class="hljs-string">&#x27;sys&#x27;</span>)
 
 <span class="hljs-keyword">for</span> _ <span class="hljs-keyword">in</span> sys.path:
-    print(_)
+    <span class="hljs-built_in">print</span>(_)
+
+<span class="hljs-built_in">exec</span>(<span class="hljs-number">123</span>)

--- a/test/markup/python/keywords.txt
+++ b/test/markup/python/keywords.txt
@@ -10,3 +10,5 @@ if __debug__:
 
 for _ in sys.path:
     print(_)
+
+exec(123)


### PR DESCRIPTION
fix #1468 

### Changes

Highlight `print` and `exec` as a builtin in python.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
