### PR TITLE
fix(csharp) fix typo (unit -> uint).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Language grammar improvements:
 - enh(kotlin) Add `kts` as an alias for Kotlin (#3021) [Vaibhav Chanana][]
 - enh(css) Add `font-smoothing` to attributes list for CSS (#3027) [AndyKIron][]
 - fix(python) Highlight `print` and `exec` as a builtin (#1468) [Samuel Colvin][]
+- fix(csharp) Fix unit being highlighted instead of uint (#3046) [Spacehamster][]
 
 Deprecations:
 

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -27,7 +27,7 @@ export default function(hljs) {
       'short',
       'string',
       'ulong',
-      'unit',
+      'uint',
       'ushort'
   ];
   var FUNCTION_MODIFIERS = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Resolves #3046

### Changes
Fixes typo that highlighted incorrect keyword

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
