### PR TITLE
enh(swift): add async/await keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Language grammar improvements:
 - enh(css) Add `font-smoothing` to attributes list for CSS (#3027) [AndyKIron][]
 - fix(python) Highlight `print` and `exec` as a builtin (#1468) [Samuel Colvin][]
 - fix(csharp) Fix unit being highlighted instead of uint (#3046) [Spacehamster][]
+- enh(swift) add async/await keywords (#3048) [Bradley Mackey][]
 
 Deprecations:
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -33,6 +33,8 @@ export const keywords = [
   // will result in additional modes being created to scan for those keywords to
   // avoid conflicts with other rules
   'associatedtype',
+  'async',
+  'await',
   /as\?/, // operator
   /as!/, // operator
   'as', // operator

--- a/test/markup/swift/keywords.expect.txt
+++ b/test/markup/swift/keywords.expect.txt
@@ -15,6 +15,7 @@ x <span class="hljs-keyword">is</span> <span class="hljs-type">String</span>
 <span class="hljs-literal">true</span> <span class="hljs-literal">false</span> <span class="hljs-literal">nil</span>
 <span class="hljs-keyword">fileprivate(set)</span> <span class="hljs-keyword">internal(set)</span> <span class="hljs-keyword">open(set)</span> <span class="hljs-keyword">private(set)</span> <span class="hljs-keyword">public(set)</span>
 <span class="hljs-keyword">unowned(safe)</span> <span class="hljs-keyword">unowned(unsafe)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">await</span>
 
 <span class="hljs-keyword">#if</span>
 <span class="hljs-keyword">#error</span>(<span class="hljs-string">&quot;Error&quot;</span>)

--- a/test/markup/swift/keywords.txt
+++ b/test/markup/swift/keywords.txt
@@ -15,6 +15,7 @@ try? try! try
 true false nil
 fileprivate(set) internal(set) open(set) private(set) public(set)
 unowned(safe) unowned(unsafe)
+async await
 
 #if
 #error("Error")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
These new keywords will land in Swift 5.5, which has just been officially announced. Swift CHANGELOG.md available [here](https://github.com/apple/swift/blob/main/CHANGELOG.md), where it's clear GitHub already supports highlighting for these keywords.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Adds Swift language support for `async` and `await` keywords.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
