### PR TITLE
fix(python) allow keywords immediately following numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ New Languages:
 
 Language grammar improvements:
 
+- fix(python) allow keywords immediately following numbers (#2985) [Josh Goebel][]
 - fix(xml) char immediately following tag close mis-highlighted (#3044) [Josh Goebel][]
 - fix(ruby) fix `defined?()` mis-highlighted as `def` (#3025) [Josh Goebel][]
 - fix(c) comments after `#include <str>` blocks (#3041) [Josh Goebel][]

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -144,6 +144,7 @@ export default function(hljs) {
   ];
 
   const KEYWORDS = {
+    $pattern: /[A-Za-z]\w+|__\w+__/,
     keyword: RESERVED_WORDS,
     built_in: BUILT_INS,
     literal: LITERALS,

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -12,3 +12,6 @@ x = Shorty()
     <span class="hljs-built_in">print</span>(_)
 
 <span class="hljs-built_in">exec</span>(<span class="hljs-number">123</span>)
+
+<span class="hljs-comment"># note, numbers still aren&#x27;t highlighted fully</span>
+<span class="hljs-built_in">print</span>(1<span class="hljs-keyword">if</span> <span class="hljs-number">0</span>==0<span class="hljs-keyword">else</span><span class="hljs-string">&quot;b&quot;</span>)

--- a/test/markup/python/keywords.txt
+++ b/test/markup/python/keywords.txt
@@ -12,3 +12,6 @@ for _ in sys.path:
     print(_)
 
 exec(123)
+
+# note, numbers still aren't highlighted fully
+print(1if 0==0else"b")


### PR DESCRIPTION
Progress on #2985.



### Changes

- Adds $pattern for Python keywords

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`