### PR TITLE
enh(http) support headers without preamble

### DIFF
--- a/src/languages/http.js
+++ b/src/languages/http.js
@@ -11,24 +11,25 @@ import * as regex from '../lib/regex.js';
 export default function(hljs) {
   const VERSION = 'HTTP/(2|1\\.[01])';
   const HEADER_NAME = /[A-Za-z][A-Za-z0-9-]*/;
-  const HEADERS_AND_BODY = [
-    {
-      className: 'attribute',
-      begin: regex.concat('^', HEADER_NAME, '(?=\\:\\s)'),
-      starts: {
-        contains: [
-          {
-            className: "punctuation",
-            begin: /: /,
-            relevance: 0,
-            starts: {
-              end: '$',
-              relevance: 0
-            }
+  const HEADER = {
+    className: 'attribute',
+    begin: regex.concat('^', HEADER_NAME, '(?=\\:\\s)'),
+    starts: {
+      contains: [
+        {
+          className: "punctuation",
+          begin: /: /,
+          relevance: 0,
+          starts: {
+            end: '$',
+            relevance: 0
           }
-        ]
-      }
-    },
+        }
+      ]
+    }
+  };
+  const HEADERS_AND_BODY = [
+    HEADER,
     {
       begin: '\\n\\n',
       starts: { subLanguage: [], endsWithParent: true }
@@ -85,7 +86,11 @@ export default function(hljs) {
           illegal: /\S/,
           contains: HEADERS_AND_BODY
         }
-      }
+      },
+      // to allow headers to work even without a preamble
+      hljs.inherit(HEADER, {
+        relevance: 0
+      })
     ]
   };
 }

--- a/test/markup/cpp/function-declarations.expect.txt
+++ b/test/markup/cpp/function-declarations.expect.txt
@@ -21,4 +21,3 @@
 
 <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">A</span><span class="hljs-params">()</span>: a(<span class="hljs-number">10</span>) {</span>}
 <span class="hljs-function"><span class="hljs-keyword">explicit</span> <span class="hljs-title">A</span><span class="hljs-params">()</span>: a(<span class="hljs-number">10</span>) {</span>}
-

--- a/test/markup/http/just_headers.expect.txt
+++ b/test/markup/http/just_headers.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-attribute">Host</span><span class="hljs-punctuation">: </span>example.org
+<span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json; charset=utf-8
+<span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>19

--- a/test/markup/http/just_headers.txt
+++ b/test/markup/http/just_headers.txt
@@ -1,0 +1,3 @@
+Host: example.org
+Content-Type: application/json; charset=utf-8
+Content-Length: 19


### PR DESCRIPTION
Resolves #3019.


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`