### PR TITLE
enh(parser) Detect comments based on english like text, rather than specific list of keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 ## Version next
 
+- enh(parser) Detect comments based on english like text, rather than keyword list [Josh Goebel][]
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
 
+[Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ New Languages:
 
 Language grammar improvements:
 
+- enh(parser) smarter detection of comments (#2827) [Josh Goebel][]
 - fix(python) allow keywords immediately following numbers (#2985) [Josh Goebel][]
 - fix(xml) char immediately following tag close mis-highlighted (#3044) [Josh Goebel][]
 - fix(ruby) fix `defined?()` mis-highlighted as `def` (#3025) [Josh Goebel][]

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -73,7 +73,6 @@ export const COMMENT = function(begin, end, modeOptions = {}) {
     },
     modeOptions
   );
-  // mode.contains.push(PHRASAL_WORDS_MODE);
   mode.contains.push({
     className: 'doctag',
     // hack to avoid the space from being included. the space is necessary to

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -73,18 +73,25 @@ export const COMMENT = function(begin, end, modeOptions = {}) {
     },
     modeOptions
   );
-  mode.contains.push(
-    {
-      className: "hint",
-      begin: /([()"]?([A-Za-z'-]{3,}|is|a|I|so|us|[tT][oO]|at|if|in|it|on)[.]?[()":]?([.][ ]|[ ]|\))){3}/
-    }
-  );
   // mode.contains.push(PHRASAL_WORDS_MODE);
   mode.contains.push({
     className: 'doctag',
-    begin: '(?:TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):',
+    // hack to avoid the space from being included. the space is necessary to
+    // match here to prevent the plain text rule below from gobbling up doctags
+    begin: '[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)',
+    end: /(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,
+    excludeBegin: true,
     relevance: 0
   });
+  // looking like plain text, more likely to be a comment
+  mode.contains.push(
+    {
+      // TODO: how to include ", (, ) without breaking grammars that use these for
+      // comment delimiters?
+      // begin: /[ ]+([()"]?([A-Za-z'-]{3,}|is|a|I|so|us|[tT][oO]|at|if|in|it|on)[.]?[()":]?([.][ ]|[ ]|\))){3}/
+      begin: /[ ]+(([A-Za-z'-]{3,}|is|a|I|so|us|[tT][oO]|at|if|in|it|on)[.]?[:]?([.][ ]|[ ]|\))){3}/
+    }
+  );
   return mode;
 };
 export const C_LINE_COMMENT_MODE = COMMENT('//', '$');

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -73,7 +73,13 @@ export const COMMENT = function(begin, end, modeOptions = {}) {
     },
     modeOptions
   );
-  mode.contains.push(PHRASAL_WORDS_MODE);
+  mode.contains.push(
+    {
+      className: "hint",
+      begin: /([()"]?([A-Za-z'-]{3,}|is|a|I|so|us|[tT][oO]|at|if|in|it|on)[.]?[()":]?([.][ ]|[ ]|\))){3}/
+    }
+  );
+  // mode.contains.push(PHRASAL_WORDS_MODE);
   mode.contains.push({
     className: 'doctag',
     begin: '(?:TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):',


### PR DESCRIPTION
Resolves #2827.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Before we boosted comments relevance by:

```
begin: /\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
```

Now we look for "english like phrases" instead:

```
begin: /[ ]+(([A-Za-z'-]{3,}|is|a|I|so|us|[tT][oO]|at|if|in|it|on)[.]?[:]?([.][ ]|[ ]|\))){3}/
```


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`