### PR TITLE
enh(shell) add alias ShellSession

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
+## Version next
+
+- enh(shell) add alias ShellSession [Ryan Mulligan][]
+
+[Ryan Mulligan]: https://github.com/ryantm
+
+
 ## Version 10.7.1
 
 - fix(parser) Resolves issues with TypeScript types [Josh Goebel][]
-- enh(shell) add alias ShellSession [Ryan Mulligan][]
 
 ### Version 10.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Version 10.7.1
 
 - fix(parser) Resolves issues with TypeScript types [Josh Goebel][]
+- enh(shell) add alias ShellSession [Ryan Mulligan][]
 
 ### Version 10.7.0
 
@@ -62,6 +63,7 @@ Deprecations:
 [David Ostrovsky]: https://github.com/davido
 [AndyKIron]: https://github.com/AndyKIron
 [Samuel Colvin]: https://github.com/samuelcolvin
+[Ryan Mulligan]: https://github.com/ryantm
 
 ## Version 10.6.0
 

--- a/src/languages/shell.js
+++ b/src/languages/shell.js
@@ -10,7 +10,7 @@ Audit: 2020
 export default function(hljs) {
   return {
     name: 'Shell Session',
-    aliases: [ 'console' ],
+    aliases: [ 'console', 'shellsession' ],
     contains: [
       {
         className: 'meta',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
ShellSession is the canonical name for this "language" used by Linguist which is used by
GitHub.

https://github.com/github/linguist/blob/2a6f9e29e198afbaa721164680bbc3b292dad260/lib/linguist/languages.yml#L5340

### Checklist
- [x] Added markup tests, or they don't apply here because... this just adds a language alias
- [x] Updated the changelog at `CHANGES.md`
