### PR TITLE
enh(shell) consider one space after prompt as part of prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Version next
 
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
+- enh(shell) consider one space after prompt as part of prompt [Ryan Mulligan][]
 
 [Ryan Mulligan]: https://github.com/ryantm
 
@@ -69,7 +70,6 @@ Deprecations:
 [David Ostrovsky]: https://github.com/davido
 [AndyKIron]: https://github.com/AndyKIron
 [Samuel Colvin]: https://github.com/samuelcolvin
-[Ryan Mulligan]: https://github.com/ryantm
 
 ## Version 10.6.0
 

--- a/src/languages/shell.js
+++ b/src/languages/shell.js
@@ -17,7 +17,7 @@ export default function(hljs) {
         // We cannot add \s (spaces) in the regular expression otherwise it will be too broad and produce unexpected result.
         // For instance, in the following example, it would match "echo /path/to/home >" as a prompt:
         // echo /path/to/home > t.exe
-        begin: /^\s{0,3}[/~\w\d[\]()@-]*[>%$#]/,
+        begin: /^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,
         starts: {
           end: /[^\\](?=\s*$)/,
           subLanguage: 'bash'

--- a/test/markup/shell/command-continuation.expect.txt
+++ b/test/markup/shell/command-continuation.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-meta">$</span><span class="bash"> docker run \
+<span class="hljs-meta">$ </span><span class="bash">docker run \
       --publish=7474:7474 --publish=7687:7687 \
       --volume=/neo4j/data:/data \
       --volume=/neo4j/plugins:/plugins \
@@ -7,8 +7,8 @@
       --user=<span class="hljs-string">&quot;<span class="hljs-subst">$(id -u neo4j)</span>:<span class="hljs-subst">$(id -g neo4j)</span>&quot;</span> \
       --group-add=<span class="hljs-variable">$groups</span> \
       neo4j:3.4</span>
-<span class="hljs-meta">&gt;</span><span class="bash"> /bin/cat \.travis.yml\
+<span class="hljs-meta">&gt; </span><span class="bash">/bin/cat \.travis.yml\
  -b | head -n1</span>
      1	language: node_js
-<span class="hljs-meta">&gt;</span><span class="bash"> <span class="hljs-built_in">echo</span> <span class="hljs-string">&#x27;hello&#x27;</span></span>
+<span class="hljs-meta">&gt; </span><span class="bash"><span class="hljs-built_in">echo</span> <span class="hljs-string">&#x27;hello&#x27;</span></span>
 hello

--- a/test/markup/shell/plain-prompt.expect.txt
+++ b/test/markup/shell/plain-prompt.expect.txt
@@ -1,2 +1,2 @@
-<span class="hljs-meta">&gt;</span><span class="bash"> foo</span>
-<span class="hljs-meta">&gt;</span><span class="bash"> /bin/sh</span>
+<span class="hljs-meta">&gt; </span><span class="bash">foo</span>
+<span class="hljs-meta">&gt; </span><span class="bash">/bin/sh</span>

--- a/test/markup/shell/prompt-with-slash.expect.txt
+++ b/test/markup/shell/prompt-with-slash.expect.txt
@@ -1,6 +1,6 @@
-<span class="hljs-meta">pao-sw-a04-40(config)#</span><span class="bash"> interface range ethernet 1/1/1-1/1/9</span>
-<span class="hljs-meta">pao-sw-a04-42(conf-range-eth1/1/1-1/1/9)#</span><span class="bash"> switchport trunk allowed vlan 1102</span>
-<span class="hljs-meta">pao-sw-a04-42(conf-range-eth1/1/1-1/1/9)#</span><span class="bash"> show configuration</span>
+<span class="hljs-meta">pao-sw-a04-40(config)# </span><span class="bash">interface range ethernet 1/1/1-1/1/9</span>
+<span class="hljs-meta">pao-sw-a04-42(conf-range-eth1/1/1-1/1/9)# </span><span class="bash">switchport trunk allowed vlan 1102</span>
+<span class="hljs-meta">pao-sw-a04-42(conf-range-eth1/1/1-1/1/9)# </span><span class="bash">show configuration</span>
 !
 interface ethernet1/1/1
  description pao-sw-a03-09_port56

--- a/test/markup/shell/prompt-with-tilde.expected.txt
+++ b/test/markup/shell/prompt-with-tilde.expected.txt
@@ -1,4 +1,4 @@
-<span class="hljs-meta">~/docs&gt;</span><span class="bash"> cat readme.adoc</span>
+<span class="hljs-meta">~/docs&gt; </span><span class="bash">cat readme.adoc</span>
 = Highlight.js
 
 Highlight.js is a syntax highlighter written in JavaScript.

--- a/test/markup/shell/simple.expect.txt
+++ b/test/markup/shell/simple.expect.txt
@@ -1,1 +1,1 @@
-<span class="hljs-meta">&gt;</span><span class="bash"> /bin/sh</span>
+<span class="hljs-meta">&gt; </span><span class="bash">/bin/sh</span>

--- a/test/markup/shell/single.expect.txt
+++ b/test/markup/shell/single.expect.txt
@@ -1,1 +1,1 @@
-<span class="hljs-meta">$</span><span class="bash"> <span class="hljs-built_in">echo</span> <span class="hljs-string">&quot;<span class="hljs-variable">$HOME</span>&quot;</span> -n</span>
+<span class="hljs-meta">$ </span><span class="bash"><span class="hljs-built_in">echo</span> <span class="hljs-string">&quot;<span class="hljs-variable">$HOME</span>&quot;</span> -n</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
By having the space after the prompt be part of the prompt, you can
have css like

```
code.language-ShellSession .hljs-meta,
code.language-shellsession .hljs-meta,
code.language-Shell .hljs-meta,
code.language-shell .hljs-meta,
code.language-Console .hljs-meta,
code.language-console .hljs-meta {
  user-select: none;
}
```

which allows you to avoid selecting the prompt, where the selection
does not include the space after the prompt.

### Checklist
- [X] Added markup tests, or they don't apply here because... tests updated.
- [X] Updated the changelog at `CHANGES.md`
