### PR TITLE
enh(java) support functions with nested template types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Grammars:
 
 - chore(properties) disable auto-detection #3102 [Josh Goebel][]
 - fix(properties) fix incorrect handling of non-alphanumeric keys #3102 [Egor Rogov][]
+- enh(java) support functions with nested template types (#2641) [Josh Goebel][]
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
 - enh(shell) consider one space after prompt as part of prompt [Ryan Mulligan][]
 - fix(nginx) fix bug with $ and @ variables [Josh Goebel][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Grammars:
 - chore(properties) disable auto-detection #3102 [Josh Goebel][]
 - fix(properties) fix incorrect handling of non-alphanumeric keys #3102 [Egor Rogov][]
 - enh(java) support functions with nested template types (#2641) [Josh Goebel][]
+- enh(java) highlight types and literals separate from keywords (#3074) [Josh Goebel][]
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
 - enh(shell) consider one space after prompt as part of prompt [Ryan Mulligan][]
 - fix(nginx) fix bug with $ and @ variables [Josh Goebel][]

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -7,9 +7,29 @@ Website: https://www.java.com/
 
 import { NUMERIC } from "./lib/java.js";
 
+/**
+ * Allows recursive regex expressions to a given depth
+ *
+ * ie: recurRegex("(abc~~~)", /~~~/g, 2) becomes:
+ * (abc(abc(abc)))
+ *
+ * @param {string} re
+ * @param {RegExp} substitution (should be a g mode regex)
+ * @param {number} depth
+ * @returns {string}
+ */
+function recurRegex(re, substitution, depth) {
+  if (depth === -1) return "";
+
+  return re.replace(substitution, _ => {
+    return recurRegex(re, substitution, depth - 1);
+  });
+}
+
 export default function(hljs) {
   var JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';
-  var GENERIC_IDENT_RE = JAVA_IDENT_RE + '(<' + JAVA_IDENT_RE + '(\\s*,\\s*' + JAVA_IDENT_RE + ')*>)?';
+  var GENERIC_IDENT_RE = JAVA_IDENT_RE +
+    recurRegex('(<' + JAVA_IDENT_RE + '~~~(\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?',/~~~/g, 2);
   var KEYWORDS = 'false synchronized int abstract float private char boolean var static null if const ' +
     'for true while long strictfp finally protected import native final void ' +
     'enum else break transient catch instanceof byte super volatile case assert short ' +

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -5,7 +5,9 @@ Category: common, enterprise
 Website: https://www.java.com/
 */
 
-import { NUMERIC } from "./lib/java.js";
+import {
+  NUMERIC as NUMBER
+} from "./lib/java.js";
 
 /**
  * Allows recursive regex expressions to a given depth
@@ -16,7 +18,7 @@ import { NUMERIC } from "./lib/java.js";
  * @param {string} re
  * @param {RegExp} substitution (should be a g mode regex)
  * @param {number} depth
- * @returns {string}
+ * @returns {string}``
  */
 function recurRegex(re, substitution, depth) {
   if (depth === -1) return "";
@@ -26,32 +28,88 @@ function recurRegex(re, substitution, depth) {
   });
 }
 
+/** @type LanguageFn */
 export default function(hljs) {
-  var JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';
-  var GENERIC_IDENT_RE = JAVA_IDENT_RE +
-    recurRegex('(<' + JAVA_IDENT_RE + '~~~(\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?',/~~~/g, 2);
-  var KEYWORDS = 'false synchronized int abstract float private char boolean var static null if const ' +
-    'for true while long strictfp finally protected import native final void ' +
-    'enum else break transient catch instanceof byte super volatile case assert short ' +
-    'package default double public try this switch continue throws protected public private ' +
-    'module requires exports do';
+  const JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';
+  const GENERIC_IDENT_RE = JAVA_IDENT_RE +
+    recurRegex('(<' + JAVA_IDENT_RE + '~~~(\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?', /~~~/g, 2);
+  const MAIN_KEYWORDS = [
+    'false',
+    'synchronized',
+    'int',
+    'abstract',
+    'float',
+    'private',
+    'char',
+    'boolean',
+    'var',
+    'static',
+    'null',
+    'if',
+    'const ',
+    'for',
+    'true',
+    'while',
+    'long',
+    'strictfp',
+    'finally',
+    'protected',
+    'import',
+    'native',
+    'final',
+    'void',
+    'enum',
+    'else',
+    'break',
+    'transient',
+    'catch',
+    'instanceof',
+    'byte',
+    'super',
+    'volatile',
+    'case',
+    'assert',
+    'short',
+    'package',
+    'default',
+    'double',
+    'public',
+    'try',
+    'this',
+    'switch',
+    'continue',
+    'throws',
+    'protected',
+    'public',
+    'private',
+    'module',
+    'requires',
+    'exports',
+    'do'
+  ];
 
-  var ANNOTATION = {
+  const LITERALS = [];
+
+  const KEYWORDS = {
+    keyword: MAIN_KEYWORDS,
+    literal: LITERALS
+  };
+
+  const ANNOTATION = {
     className: 'meta',
     begin: '@' + JAVA_IDENT_RE,
     contains: [
       {
         begin: /\(/,
         end: /\)/,
-        contains: ["self"] // allow nested () inside our annotation
-      },
+        contains: [ "self" ] // allow nested () inside our annotation
+      }
     ]
   };
-  const NUMBER = NUMERIC;
 
   return {
     name: 'Java',
-    aliases: ['jsp'],
+    aliases: [ 'jsp' ],
     keywords: KEYWORDS,
     illegal: /<\/|#/,
     contains: [
@@ -63,7 +121,8 @@ export default function(hljs) {
           contains: [
             {
               // eat up @'s in emails to prevent them to be recognized as doctags
-              begin: /\w+@/, relevance: 0
+              begin: /\w+@/,
+              relevance: 0
             },
             {
               className: 'doctag',
@@ -84,7 +143,9 @@ export default function(hljs) {
       hljs.QUOTE_STRING_MODE,
       {
         className: 'class',
-        beginKeywords: 'class interface enum', end: /[{;=]/, excludeEnd: true,
+        beginKeywords: 'class interface enum',
+        end: /[{;=]/,
+        excludeEnd: true,
         // TODO: can this be removed somehow?
         // an extra boost because Java is more popular than other languages with
         // this same syntax feature (this is just to preserve our tests passing
@@ -93,7 +154,9 @@ export default function(hljs) {
         keywords: 'class interface enum',
         illegal: /[:"\[\]]/,
         contains: [
-          { beginKeywords: 'extends implements' },
+          {
+            beginKeywords: 'extends implements'
+          },
           hljs.UNDERSCORE_TITLE_MODE
         ]
       },
@@ -111,21 +174,22 @@ export default function(hljs) {
         end: /[{;=]/,
         keywords: KEYWORDS,
         contains: [
-          { beginKeywords: "record" },
+          {
+            beginKeywords: "record"
+          },
           {
             begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
             returnBegin: true,
             relevance: 0,
-            contains: [hljs.UNDERSCORE_TITLE_MODE]
+            contains: [ hljs.UNDERSCORE_TITLE_MODE ]
           },
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\(/,
+            end: /\)/,
             keywords: KEYWORDS,
             relevance: 0,
-            contains: [
-              hljs.C_BLOCK_COMMENT_MODE
-            ]
+            contains: [ hljs.C_BLOCK_COMMENT_MODE ]
           },
           hljs.C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE
@@ -133,18 +197,22 @@ export default function(hljs) {
       },
       {
         className: 'function',
-        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
+        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
+        returnBegin: true,
+        end: /[{;=]/,
         excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
           {
-            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(', returnBegin: true,
+            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
+            returnBegin: true,
             relevance: 0,
-            contains: [hljs.UNDERSCORE_TITLE_MODE]
+            contains: [ hljs.UNDERSCORE_TITLE_MODE ]
           },
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\(/,
+            end: /\)/,
             keywords: KEYWORDS,
             relevance: 0,
             contains: [

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -34,23 +34,15 @@ export default function(hljs) {
   const GENERIC_IDENT_RE = JAVA_IDENT_RE +
     recurRegex('(<' + JAVA_IDENT_RE + '~~~(\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?', /~~~/g, 2);
   const MAIN_KEYWORDS = [
-    'false',
     'synchronized',
-    'int',
     'abstract',
-    'float',
     'private',
-    'char',
-    'boolean',
     'var',
     'static',
-    'null',
     'if',
     'const ',
     'for',
-    'true',
     'while',
-    'long',
     'strictfp',
     'finally',
     'protected',
@@ -64,15 +56,12 @@ export default function(hljs) {
     'transient',
     'catch',
     'instanceof',
-    'byte',
     'super',
     'volatile',
     'case',
     'assert',
-    'short',
     'package',
     'default',
-    'double',
     'public',
     'try',
     'this',
@@ -88,11 +77,27 @@ export default function(hljs) {
     'do'
   ];
 
-  const LITERALS = [];
+  const LITERALS = [
+    'false',
+    'true',
+    'null'
+  ];
+
+  const TYPES = [
+    'char',
+    'boolean',
+    'long',
+    'float',
+    'int',
+    'byte',
+    'short',
+    'double'
+  ];
 
   const KEYWORDS = {
     keyword: MAIN_KEYWORDS,
-    literal: LITERALS
+    literal: LITERALS,
+    type: TYPES
   };
 
   const ANNOTATION = {

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -7,7 +7,7 @@ describe('.highlight()', () => {
   it('should support ignoreIllegals (old API)', () => {
     let code = "float # float";
     let result = hljs.highlight("java", code, true);
-    result.value.should.equal(`<span class="hljs-keyword">float</span> # <span class="hljs-keyword">float</span>`);
+    result.value.should.equal(`<span class="hljs-type">float</span> # <span class="hljs-type">float</span>`);
 
     code = "float # float";
     result = hljs.highlight("java", code, false);
@@ -17,7 +17,7 @@ describe('.highlight()', () => {
   it('should support ignoreIllegals (new API)', () => {
     let code = "float # float";
     let result = hljs.highlight(code, { language: "java", ignoreIllegals: true });
-    result.value.should.equal(`<span class="hljs-keyword">float</span> # <span class="hljs-keyword">float</span>`);
+    result.value.should.equal(`<span class="hljs-type">float</span> # <span class="hljs-type">float</span>`);
 
     code = "float # float";
     result = hljs.highlight(code, { language: "java", ignoreIllegals: false });
@@ -37,9 +37,9 @@ describe('.highlight()', () => {
     result.value.should.equal(
       '<span class="hljs-function"><span class="hljs-keyword">public</span> ' +
       '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
-      '<span class="hljs-params">(<span class="hljs-keyword">int</span> x, ' +
-      '<span class="hljs-keyword">int</span> y, ' +
-      '<span class="hljs-keyword">int</span> z)</span></span>;'
+      '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
+      '<span class="hljs-type">int</span> y, ' +
+      '<span class="hljs-type">int</span> z)</span></span>;'
     );
   });
   it('should works without continuation', () => {
@@ -49,9 +49,9 @@ describe('.highlight()', () => {
     result.value.should.equal(
       '<span class="hljs-function"><span class="hljs-keyword">public</span> ' +
       '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
-      '<span class="hljs-params">(<span class="hljs-keyword">int</span> x, ' +
-      '<span class="hljs-keyword">int</span> y, ' +
-      '<span class="hljs-keyword">int</span> z)</span></span>;'
+      '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
+      '<span class="hljs-type">int</span> y, ' +
+      '<span class="hljs-type">int</span> z)</span></span>;'
     );
   });
 });

--- a/test/markup/java/annotations.expect.txt
+++ b/test/markup/java/annotations.expect.txt
@@ -8,5 +8,5 @@
 }
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Example</span> </span>{
-  <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-keyword">int</span> bar)</span> </span>{ }
+  <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> bar)</span> </span>{ }
 }

--- a/test/markup/java/functions.expect.txt
+++ b/test/markup/java/functions.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;A,B,C&gt; <span class="hljs-function">Tuple&lt;A,B,C&gt; <span class="hljs-title">fun</span><span class="hljs-params">(Future&lt;Tuple&lt;A,B,C&gt;&gt; future)</span> <span class="hljs-keyword">throws</span> Exceptions </span>{
+}
+
+<span class="hljs-function"><span class="hljs-keyword">static</span> Optional&lt;List&lt;Token&gt;&gt; <span class="hljs-title">parseAll</span><span class="hljs-params">(String s)</span> </span>{
+}

--- a/test/markup/java/functions.txt
+++ b/test/markup/java/functions.txt
@@ -1,0 +1,5 @@
+public static <A,B,C> Tuple<A,B,C> fun(Future<Tuple<A,B,C>> future) throws Exceptions {
+}
+
+static Optional<List<Token>> parseAll(String s) {
+}

--- a/test/markup/java/numbers.expect.txt
+++ b/test/markup/java/numbers.expect.txt
@@ -1,81 +1,81 @@
-<span class="hljs-keyword">int</span>[] decimalIntegers = {
+<span class="hljs-type">int</span>[] decimalIntegers = {
 	<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">10</span>,  <span class="hljs-number">999</span>,
 	<span class="hljs-number">0</span>, <span class="hljs-number">1</span>, <span class="hljs-number">1_0</span>, <span class="hljs-number">9_9__9</span>,
 };
-<span class="hljs-keyword">long</span>[] longDecimalIntegers = {
+<span class="hljs-type">long</span>[] longDecimalIntegers = {
 	<span class="hljs-number">0l</span>, <span class="hljs-number">1L</span>, <span class="hljs-number">10l</span>,  <span class="hljs-number">999L</span>,
 	<span class="hljs-number">0L</span>, <span class="hljs-number">1l</span>, <span class="hljs-number">1_0L</span>, <span class="hljs-number">9_9__9l</span>,
 };
 
-<span class="hljs-keyword">int</span>[] hexIntegers = {
+<span class="hljs-type">int</span>[] hexIntegers = {
 	<span class="hljs-number">0x0</span>, <span class="hljs-number">0Xa0</span>,  <span class="hljs-number">0X7FF</span>,   <span class="hljs-number">0xd3aD</span>,    <span class="hljs-number">0x00000000ffffffff</span>,
 	<span class="hljs-number">0X0</span>, <span class="hljs-number">0xa_0</span>, <span class="hljs-number">0x7__FF</span>, <span class="hljs-number">0Xd__3_aD</span>, <span class="hljs-number">0X0000_0000__ffff_ffff</span>,
 };
-<span class="hljs-keyword">long</span>[] longHexIntegers = {
+<span class="hljs-type">long</span>[] longHexIntegers = {
 	<span class="hljs-number">0x0L</span>, <span class="hljs-number">0Xa0l</span>,  <span class="hljs-number">0X7FFL</span>,   <span class="hljs-number">0xd3aDl</span>,    <span class="hljs-number">0x7fffffffffffffffL</span>,
 	<span class="hljs-number">0X0l</span>, <span class="hljs-number">0xa_0L</span>, <span class="hljs-number">0x7__FFl</span>, <span class="hljs-number">0Xd__3_aDL</span>, <span class="hljs-number">0X7fff_ffff__ffff_ffffl</span>,
 };
 
-<span class="hljs-keyword">int</span>[] octalIntegers = {
+<span class="hljs-type">int</span>[] octalIntegers = {
 	<span class="hljs-number">00</span>,  <span class="hljs-number">001</span>,   <span class="hljs-number">0777</span>,
 	<span class="hljs-number">0_0</span>, <span class="hljs-number">0__01</span>, <span class="hljs-number">07__77</span>,
 };
-<span class="hljs-keyword">long</span>[] longOctalIntegers = {
+<span class="hljs-type">long</span>[] longOctalIntegers = {
 	<span class="hljs-number">00l</span>,  <span class="hljs-number">001L</span>,   <span class="hljs-number">0777l</span>,
 	<span class="hljs-number">0_0L</span>, <span class="hljs-number">0__01l</span>, <span class="hljs-number">07__77L</span>,
 };
 
-<span class="hljs-keyword">int</span>[] binaryIntegers = {
+<span class="hljs-type">int</span>[] binaryIntegers = {
 	<span class="hljs-number">0b0</span>, <span class="hljs-number">0B11</span>,  <span class="hljs-number">0B000</span>,   <span class="hljs-number">0b01011</span>,
 	<span class="hljs-number">0b0</span>, <span class="hljs-number">0B1_1</span>, <span class="hljs-number">0B00__0</span>, <span class="hljs-number">0b01__0_1__1</span>,
 };
-<span class="hljs-keyword">long</span>[] longBinaryIntegers = {
+<span class="hljs-type">long</span>[] longBinaryIntegers = {
 	<span class="hljs-number">0b0l</span>, <span class="hljs-number">0B11L</span>,  <span class="hljs-number">0B000l</span>,   <span class="hljs-number">0b01011L</span>,
 	<span class="hljs-number">0b0L</span>, <span class="hljs-number">0B1_1l</span>, <span class="hljs-number">0B00__0L</span>, <span class="hljs-number">0b01__0_1__1l</span>,
 };
 
 
-<span class="hljs-keyword">double</span>[] doubleDecimalIntegers = {
+<span class="hljs-type">double</span>[] doubleDecimalIntegers = {
 	<span class="hljs-number">0d</span>, <span class="hljs-number">00D</span>,  <span class="hljs-number">1d</span>, <span class="hljs-number">00800d</span>,
 	<span class="hljs-number">0D</span>, <span class="hljs-number">0_0d</span>, <span class="hljs-number">1D</span>, <span class="hljs-number">0_0__8__0_0D</span>,
 };
-<span class="hljs-keyword">float</span>[] floatDecimalIntegers = {
+<span class="hljs-type">float</span>[] floatDecimalIntegers = {
 	<span class="hljs-number">0f</span>, <span class="hljs-number">00F</span>,  <span class="hljs-number">1f</span>, <span class="hljs-number">00800f</span>,
 	<span class="hljs-number">0F</span>, <span class="hljs-number">0_0f</span>, <span class="hljs-number">1F</span>, <span class="hljs-number">0_0__8__0_0F</span>,
 };
 
-<span class="hljs-keyword">double</span>[] doubleDecimals = {
+<span class="hljs-type">double</span>[] doubleDecimals = {
 	<span class="hljs-number">.0</span>, <span class="hljs-number">.00</span>,   <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">40.010</span>,     <span class="hljs-number">0.</span>, <span class="hljs-number">00.</span>,  <span class="hljs-number">10.</span>,
 	<span class="hljs-number">.0</span>, <span class="hljs-number">.0__0</span>, <span class="hljs-number">.9</span>, <span class="hljs-number">4.2</span>, <span class="hljs-number">4_0.0__1_0</span>, <span class="hljs-number">0.</span>, <span class="hljs-number">0_0.</span>, <span class="hljs-number">1__0.</span>,
 
 	<span class="hljs-number">.0D</span>, <span class="hljs-number">.00d</span>,   <span class="hljs-number">.9D</span>, <span class="hljs-number">4.2d</span>, <span class="hljs-number">40.010D</span>,     <span class="hljs-number">0.d</span>, <span class="hljs-number">00.D</span>,  <span class="hljs-number">10.d</span>,
 	<span class="hljs-number">.0d</span>, <span class="hljs-number">.0__0D</span>, <span class="hljs-number">.9d</span>, <span class="hljs-number">4.2D</span>, <span class="hljs-number">4_0.0__1_0d</span>, <span class="hljs-number">0.D</span>, <span class="hljs-number">0_0.d</span>, <span class="hljs-number">1__0.D</span>,
 };
-<span class="hljs-keyword">float</span>[] floatDecimals = {
+<span class="hljs-type">float</span>[] floatDecimals = {
 	<span class="hljs-number">.0F</span>, <span class="hljs-number">.00f</span>,   <span class="hljs-number">.9F</span>, <span class="hljs-number">4.2f</span>, <span class="hljs-number">40.010F</span>,     <span class="hljs-number">0.f</span>, <span class="hljs-number">00.F</span>,  <span class="hljs-number">10.f</span>,
 	<span class="hljs-number">.0f</span>, <span class="hljs-number">.0__0F</span>, <span class="hljs-number">.9f</span>, <span class="hljs-number">4.2F</span>, <span class="hljs-number">4_0.0__1_0f</span>, <span class="hljs-number">0.F</span>, <span class="hljs-number">0_0.f</span>, <span class="hljs-number">1__0.F</span>,
 };
 
-<span class="hljs-keyword">double</span>[] doubleDecimalExponents = {
+<span class="hljs-type">double</span>[] doubleDecimalExponents = {
 	<span class="hljs-number">.0e10</span>,  <span class="hljs-number">.00e+10</span>,  <span class="hljs-number">.9e-10</span>,  <span class="hljs-number">4.2E10</span>,  <span class="hljs-number">40.010E+08</span>,      <span class="hljs-number">0.E-10</span>,  <span class="hljs-number">00.e100</span>,    <span class="hljs-number">00800e+10</span>,
 	<span class="hljs-number">.0e1_0</span>, <span class="hljs-number">.0_0e+10</span>, <span class="hljs-number">.9e-1_0</span>, <span class="hljs-number">4.2E1_0</span>, <span class="hljs-number">4_0.0__1_0E+0_8</span>, <span class="hljs-number">0.E-1_0</span>, <span class="hljs-number">0_0.e1_0_0</span>, <span class="hljs-number">0_0__8__00e+1___0</span>,
 
 	<span class="hljs-number">.0e10d</span>,  <span class="hljs-number">.00e+10D</span>,  <span class="hljs-number">.9e-10d</span>,  <span class="hljs-number">4.2E10D</span>,  <span class="hljs-number">40.010E+08d</span>,      <span class="hljs-number">0.E-10D</span>,  <span class="hljs-number">00.e100d</span>,    <span class="hljs-number">00800e+10D</span>,
 	<span class="hljs-number">.0e1_0D</span>, <span class="hljs-number">.0_0e+10d</span>, <span class="hljs-number">.9e-1_0D</span>, <span class="hljs-number">4.2E1_0d</span>, <span class="hljs-number">4_0.0__1_0E+0_8D</span>, <span class="hljs-number">0.E-1_0d</span>, <span class="hljs-number">0_0.e1_0_0D</span>, <span class="hljs-number">0_0__8__00e+1___0d</span>,
 };
-<span class="hljs-keyword">float</span>[] floatDecimalExponents = {
+<span class="hljs-type">float</span>[] floatDecimalExponents = {
 	<span class="hljs-number">.0e10f</span>,  <span class="hljs-number">.00e+10F</span>,  <span class="hljs-number">.9e-10f</span>,  <span class="hljs-number">4.2E10F</span>,  <span class="hljs-number">40.010E+08f</span>,      <span class="hljs-number">0.E-10F</span>,  <span class="hljs-number">00.e100f</span>,    <span class="hljs-number">00800e+10F</span>,
 	<span class="hljs-number">.0e1_0F</span>, <span class="hljs-number">.0_0e+10f</span>, <span class="hljs-number">.9e-1_0F</span>, <span class="hljs-number">4.2E1_0f</span>, <span class="hljs-number">4_0.0__1_0E+0_8F</span>, <span class="hljs-number">0.E-1_0f</span>, <span class="hljs-number">0_0.e1_0_0F</span>, <span class="hljs-number">0_0__8__00e+1___0f</span>,
 };
 
-<span class="hljs-keyword">double</span>[] doubleHexExponents = {
+<span class="hljs-type">double</span>[] doubleHexExponents = {
 	<span class="hljs-number">0x0p0</span>, <span class="hljs-number">0x.ep6</span>, <span class="hljs-number">0Xa0.p+01</span>,   <span class="hljs-number">0X.7FFp-18</span>,      <span class="hljs-number">0xd3aD.B00p9</span>,
 	<span class="hljs-number">0X0P0</span>, <span class="hljs-number">0x.Ep6</span>, <span class="hljs-number">0xa_0.p+0_1</span>, <span class="hljs-number">0X.7__F_FP-1__8</span>, <span class="hljs-number">0Xd__3_aD.b00p9</span>,
 
 	<span class="hljs-number">0x0p0D</span>, <span class="hljs-number">0x.ep6D</span>, <span class="hljs-number">0Xa0.p+01d</span>,   <span class="hljs-number">0X.7FFp-18D</span>,      <span class="hljs-number">0xd3aD.B00p9d</span>,
 	<span class="hljs-number">0X0P0d</span>, <span class="hljs-number">0x.eP6d</span>, <span class="hljs-number">0xa_0.p+0_1D</span>, <span class="hljs-number">0X.7__F_FP-1__8d</span>, <span class="hljs-number">0Xd__3_aD.b00p9D</span>,
 };
-<span class="hljs-keyword">float</span>[] floatHexExponents = {
+<span class="hljs-type">float</span>[] floatHexExponents = {
 	<span class="hljs-number">0x0p0F</span>, <span class="hljs-number">0x.ep6F</span>, <span class="hljs-number">0Xa0.p+01f</span>,   <span class="hljs-number">0X.7FFp-18F</span>,      <span class="hljs-number">0xf3aF.B00p9f</span>,
 	<span class="hljs-number">0X0P0f</span>, <span class="hljs-number">0x.eP6f</span>, <span class="hljs-number">0xa_0.p+0_1F</span>, <span class="hljs-number">0X.7__F_FP-1__8f</span>, <span class="hljs-number">0Xf__3_aF.b00p9F</span>,
 };
@@ -89,17 +89,17 @@ fn(<span class="hljs-number">5.</span>);
 fn(x0.d);
 
 <span class="hljs-comment">// invalid pseudo-numeric literals</span>
-<span class="hljs-keyword">int</span>[] badNonDecimalIntegers =      { 08,  0_8,  019,     0x0g,      0B02, };
-<span class="hljs-keyword">long</span>[] longBadNonDecimalIntegers = { 08L, 0_8l, 01_9L,   0x0__GL,   0B0_2l, };
+<span class="hljs-type">int</span>[] badNonDecimalIntegers =      { 08,  0_8,  019,     0x0g,      0B02, };
+<span class="hljs-type">long</span>[] longBadNonDecimalIntegers = { 08L, 0_8l, 01_9L,   0x0__GL,   0B0_2l, };
 
-<span class="hljs-keyword">int</span>[] badUnderscoreIntegers =      { 3_,  0x_0,  0X1_,  0B_0,  0b1_, };
-<span class="hljs-keyword">long</span>[] longBadUnderscoreIntegers = { 3_l, 0X_0L, 0x1_l, 0b_0L, 0B1_l, };
+<span class="hljs-type">int</span>[] badUnderscoreIntegers =      { 3_,  0x_0,  0X1_,  0B_0,  0b1_, };
+<span class="hljs-type">long</span>[] longBadUnderscoreIntegers = { 3_l, 0X_0L, 0x1_l, 0b_0L, 0B1_l, };
 
-<span class="hljs-keyword">double</span>[] doubleBadDecimals = { 0_d, 0_.,  <span class="hljs-number">0.</span>_1,  <span class="hljs-number">0.</span>_D, <span class="hljs-number">0.</span>1_d, };
-<span class="hljs-keyword">float</span>[] floatBadDecimals =   { 0_F, 0_.f, <span class="hljs-number">0.</span>_1F, <span class="hljs-number">0.</span>_f, <span class="hljs-number">0.</span>1_F, };
+<span class="hljs-type">double</span>[] doubleBadDecimals = { 0_d, 0_.,  <span class="hljs-number">0.</span>_1,  <span class="hljs-number">0.</span>_D, <span class="hljs-number">0.</span>1_d, };
+<span class="hljs-type">float</span>[] floatBadDecimals =   { 0_F, 0_.f, <span class="hljs-number">0.</span>_1F, <span class="hljs-number">0.</span>_f, <span class="hljs-number">0.</span>1_F, };
 
-<span class="hljs-keyword">double</span>[] doubleBadDecimalExponents = { 0_e0,  <span class="hljs-number">0.</span>_E1,  1e_2,  2E3_,  3e4_d, };
-<span class="hljs-keyword">float</span>[] floatBadDecimalExponents =   { 0_e0f, <span class="hljs-number">0.</span>_E1F, 1e_2f, 2E3_F, 3e4_f, };
+<span class="hljs-type">double</span>[] doubleBadDecimalExponents = { 0_e0,  <span class="hljs-number">0.</span>_E1,  1e_2,  2E3_,  3e4_d, };
+<span class="hljs-type">float</span>[] floatBadDecimalExponents =   { 0_e0f, <span class="hljs-number">0.</span>_E1F, 1e_2f, 2E3_F, 3e4_f, };
 
-<span class="hljs-keyword">double</span>[] doubleBadHexExponents = { 0x0pA,  0x0_P0,  <span class="hljs-number">0x0</span>._p1,  0x1P_2,  0x2p3_,  0x3P4_D, };
-<span class="hljs-keyword">float</span>[] floatBadHexExponents =   { 0x0pAF, 0x0_P0f, <span class="hljs-number">0x0</span>._p1F, 0x1P_2f, 0x2p3_F, 0x3P4_f, };
+<span class="hljs-type">double</span>[] doubleBadHexExponents = { 0x0pA,  0x0_P0,  <span class="hljs-number">0x0</span>._p1,  0x1P_2,  0x2p3_,  0x3P4_D, };
+<span class="hljs-type">float</span>[] floatBadHexExponents =   { 0x0pAF, 0x0_P0f, <span class="hljs-number">0x0</span>._p1F, 0x1P_2f, 0x2p3_F, 0x3P4_f, };

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">public</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> </span>{
-    <span class="hljs-function"><span class="hljs-keyword">public</span> Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-keyword">int</span> val)</span> </span>{
+    <span class="hljs-function"><span class="hljs-keyword">public</span> Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> </span>{
         <span class="hljs-keyword">new</span> Type();
         <span class="hljs-keyword">if</span> (val) {
             <span class="hljs-keyword">return</span> getType();


### PR DESCRIPTION
Resolves #2641.


<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Allows Java template types for functions to be recursive a single level:

IE (Token within List):

```
static Optional<List<Token>> parseAll(String s) {
}
```

- also lints Java
- also splits out literals and types from keywords

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`