### PR TITLE
[DT] Sample showing one of possible rewrites

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,7 +144,7 @@ type AnnotatedError = Error & {mode?: Mode | Language, languageName?: string, ba
 type ModeCallback = (match: RegExpMatchArray, response: CallbackResponse) => void
 type HighlightedHTMLElement = HTMLElement & {result?: object, second_best?: object, parentNode: HTMLElement}
 type EnhancedMatch = RegExpMatchArray & {rule: CompiledMode, type: MatchType}
-type MatchType = "begin" | "end" | "illegal"
+export type MatchType = "begin" | "end" | "illegal"
 
  interface Emitter {
     addKeyword(text: string, kind: string): void
@@ -243,17 +243,9 @@ interface ModeDetails {
 // deprecated API since v10
 // declare module 'highlight.js/lib/highlight.js';
 
-declare module 'highlight.js' {
-    export = hljs;
-}
+export as namespace hljs;
+export = hljs;
 
-declare module 'highlight.js/lib/core' {
-    export = hljs;
-}
-
-declare module 'highlight.js/lib/core.js' {
-    export = hljs;
-}
 
 declare module 'highlight.js/lib/languages/*' {
     export default function(hljs?: HLJSApi): LanguageDetail;

--- a/types/lib/core.d.ts
+++ b/types/lib/core.d.ts
@@ -1,0 +1,3 @@
+import hljs = require('../')
+
+export = hljs;

--- a/types/lib/core/index.d.ts
+++ b/types/lib/core/index.d.ts
@@ -1,0 +1,3 @@
+import hljs = require('../../')
+
+export = hljs;


### PR DESCRIPTION
@joshgoebel 
As discussed

Thanks!

Imagine you're a first time user that found the project and followed the 'Usage' link. The usage is for non-module usage:

```ts
/// <reference types="highlight.js" />
/// <reference types="vue" />
document.addEventListener("DOMContentLoaded", (event) => {
  document.querySelectorAll<HTMLElement>("pre code").forEach((block) => {
    hljs.highlightBlock(block);
  });
});

const matchType: hljs.MatchType = "end";

Vue.use(hljs.vuePlugin);
```
Try the same code with your current types, to see the difference.
This one is just sample for global script, ESM should be based on same code base really.
