### PR TITLE
enh(c) Update keyword list for C11/C18

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,11 @@
 - enh(nginx) improving highlighting of some sections [Josh Goebel][]
 - fix(vim) variable names may not be zero length [Josh Goebel][]
 - enh(sqf) Updated keywords to Arma 3 v2.02 (#3084) [R3voA3][]
+- enh(c) Update keyword list for C11/C18 (#3010) [Josh Goebel][]
 
 New Languages:
 
-- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]  
+- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]
 
 Theme Improvements:
 

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -27,7 +27,7 @@ export default function(hljs) {
     '[a-zA-Z_]\\w*' + regex.optional(TEMPLATE_ARGUMENT_RE) +
   ')';
   const CPP_PRIMITIVE_TYPES = {
-    className: 'keyword',
+    className: 'type',
     begin: '\\b[a-z\\d_]*_t\\b'
   };
 
@@ -105,19 +105,61 @@ export default function(hljs) {
 
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
 
+  const C_KEYWORDS = [
+    "auto",
+    "break",
+    "case",
+    "const",
+    "continue",
+    "default",
+    "do",
+    "else",
+    "enum",
+    "extern",
+    "for",
+    "goto",
+    "if",
+    "inline",
+    "register",
+    "restrict",
+    "return",
+    "short",
+    "sizeof",
+    "static",
+    "struct",
+    "switch",
+    "typedef",
+    "union",
+    "volatile",
+    "while",
+    "_Alignas",
+    "_Alignof",
+    "_Atomic",
+    "_Bool",
+    "_Complex",
+    "_Generic",
+    "_Imaginary",
+    "_Noreturn",
+    "_Static_assert",
+    "_Thread_local"
+  ];
+
+  const C_TYPES = [
+    "float",
+    "double",
+    "signed",
+    "unsigned",
+    "int",
+    "long",
+    "char",
+    "void"
+  ];
+
   const CPP_KEYWORDS = {
-    keyword: 'int float while private char char8_t char16_t char32_t catch import module export virtual operator sizeof ' +
-      'dynamic_cast|10 typedef const_cast|10 const for static_cast|10 union namespace ' +
-      'unsigned long volatile static protected bool template mutable if public friend ' +
-      'do goto auto void enum else break extern using asm case typeid wchar_t ' +
-      'short reinterpret_cast|10 default double register explicit signed typename try this ' +
-      'switch continue inline delete alignas alignof constexpr consteval constinit decltype ' +
-      'concept co_await co_return co_yield requires ' +
-      'noexcept static_assert thread_local restrict final override ' +
-      'atomic_bool atomic_char atomic_schar ' +
-      'atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong ' +
-      'atomic_ullong new throw return ' +
-      'and and_eq bitand bitor compl not not_eq or or_eq xor xor_eq',
+    keyword: C_KEYWORDS,
+    type: C_TYPES,
+    literal: 'true false nullptr NULL',
+    // TODO: apply hinting work similar to what was done in cpp.js
     built_in: 'std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
       'auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set ' +
       'unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos ' +
@@ -127,7 +169,6 @@ export default function(hljs) {
       'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
       'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
       'vfprintf vprintf vsprintf endl initializer_list unique_ptr _Bool complex _Complex imaginary _Imaginary',
-    literal: 'true false nullptr NULL'
   };
 
   const EXPRESSION_CONTAINS = [

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -134,10 +134,7 @@ export default function(hljs) {
     "_Alignas",
     "_Alignof",
     "_Atomic",
-    "_Bool",
-    "_Complex",
     "_Generic",
-    "_Imaginary",
     "_Noreturn",
     "_Static_assert",
     "_Thread_local"
@@ -152,13 +149,19 @@ export default function(hljs) {
     "short",
     "long",
     "char",
-    "void"
+    "void",
+    "_Bool",
+    "_Complex",
+    "_Imaginary",
+    "_Decimal32",
+    "_Decimal64",
+    "_Decimal128"
   ];
 
   const KEYWORDS = {
     keyword: C_KEYWORDS,
     type: C_TYPES,
-    literal: 'true false nullptr NULL',
+    literal: 'true false NULL',
     // TODO: apply hinting work similar to what was done in cpp.js
     built_in: 'std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream ' +
       'auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set ' +
@@ -283,15 +286,6 @@ export default function(hljs) {
       EXPRESSION_CONTAINS,
       [
         PREPROCESSOR,
-        { // containers: ie, `vector <int> rooms (9);`
-          begin: '\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<',
-          end: '>',
-          keywords: KEYWORDS,
-          contains: [
-            'self',
-            PRIMITIVE_TYPES
-          ]
-        },
         {
           begin: hljs.IDENT_RE + '::',
           keywords: KEYWORDS

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -123,7 +123,6 @@ export default function(hljs) {
     "register",
     "restrict",
     "return",
-    "short",
     "sizeof",
     "static",
     "struct",
@@ -150,6 +149,7 @@ export default function(hljs) {
     "signed",
     "unsigned",
     "int",
+    "short",
     "long",
     "char",
     "void"

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -106,6 +106,7 @@ export default function(hljs) {
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
 
   const C_KEYWORDS = [
+    "asm",
     "auto",
     "break",
     "case",
@@ -117,6 +118,7 @@ export default function(hljs) {
     "enum",
     "extern",
     "for",
+    "fortran",
     "goto",
     "if",
     "inline",
@@ -137,7 +139,15 @@ export default function(hljs) {
     "_Generic",
     "_Noreturn",
     "_Static_assert",
-    "_Thread_local"
+    "_Thread_local",
+    // aliases
+    "alignas",
+    "alignof",
+    "noreturn",
+    "static_assert",
+    "thread_local",
+    // not a C keyword but is, for all intents and purposes, treated exactly like one.
+    "_Pragma"
   ];
 
   const C_TYPES = [
@@ -155,7 +165,11 @@ export default function(hljs) {
     "_Imaginary",
     "_Decimal32",
     "_Decimal64",
-    "_Decimal128"
+    "_Decimal128",
+    // aliases
+    "complex",
+    "bool",
+    "imaginary"
   ];
 
   const KEYWORDS = {
@@ -171,7 +185,7 @@ export default function(hljs) {
       'isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow ' +
       'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
       'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
-      'vfprintf vprintf vsprintf endl initializer_list unique_ptr _Bool complex _Complex imaginary _Imaginary',
+      'vfprintf vprintf vsprintf endl initializer_list unique_ptr',
   };
 
   const EXPRESSION_CONTAINS = [

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -26,7 +26,7 @@ export default function(hljs) {
     regex.optional(NAMESPACE_RE) +
     '[a-zA-Z_]\\w*' + regex.optional(TEMPLATE_ARGUMENT_RE) +
   ')';
-  const CPP_PRIMITIVE_TYPES = {
+  const PRIMITIVE_TYPES = {
     className: 'type',
     begin: '\\b[a-z\\d_]*_t\\b'
   };
@@ -155,7 +155,7 @@ export default function(hljs) {
     "void"
   ];
 
-  const CPP_KEYWORDS = {
+  const KEYWORDS = {
     keyword: C_KEYWORDS,
     type: C_TYPES,
     literal: 'true false nullptr NULL',
@@ -173,7 +173,7 @@ export default function(hljs) {
 
   const EXPRESSION_CONTAINS = [
     PREPROCESSOR,
-    CPP_PRIMITIVE_TYPES,
+    PRIMITIVE_TYPES,
     C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,
     NUMBERS,
@@ -198,12 +198,12 @@ export default function(hljs) {
         end: /;/
       }
     ],
-    keywords: CPP_KEYWORDS,
+    keywords: KEYWORDS,
     contains: EXPRESSION_CONTAINS.concat([
       {
         begin: /\(/,
         end: /\)/,
-        keywords: CPP_KEYWORDS,
+        keywords: KEYWORDS,
         contains: EXPRESSION_CONTAINS.concat([ 'self' ]),
         relevance: 0
       }
@@ -217,12 +217,12 @@ export default function(hljs) {
     returnBegin: true,
     end: /[{;=]/,
     excludeEnd: true,
-    keywords: CPP_KEYWORDS,
+    keywords: KEYWORDS,
     illegal: /[^\w\s\*&:<>.]/,
     contains: [
       { // to prevent it from being confused as the function title
         begin: DECLTYPE_AUTO_RE,
-        keywords: CPP_KEYWORDS,
+        keywords: KEYWORDS,
         relevance: 0
       },
       {
@@ -235,19 +235,19 @@ export default function(hljs) {
         className: 'params',
         begin: /\(/,
         end: /\)/,
-        keywords: CPP_KEYWORDS,
+        keywords: KEYWORDS,
         relevance: 0,
         contains: [
           C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE,
           STRINGS,
           NUMBERS,
-          CPP_PRIMITIVE_TYPES,
+          PRIMITIVE_TYPES,
           // Count matching parentheses.
           {
             begin: /\(/,
             end: /\)/,
-            keywords: CPP_KEYWORDS,
+            keywords: KEYWORDS,
             relevance: 0,
             contains: [
               'self',
@@ -255,12 +255,12 @@ export default function(hljs) {
               hljs.C_BLOCK_COMMENT_MODE,
               STRINGS,
               NUMBERS,
-              CPP_PRIMITIVE_TYPES
+              PRIMITIVE_TYPES
             ]
           }
         ]
       },
-      CPP_PRIMITIVE_TYPES,
+      PRIMITIVE_TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       PREPROCESSOR
@@ -272,7 +272,7 @@ export default function(hljs) {
     aliases: [
       'h'
     ],
-    keywords: CPP_KEYWORDS,
+    keywords: KEYWORDS,
     // Until differentiations are added between `c` and `cpp`, `c` will
     // not be auto-detected to avoid auto-detect conflicts between C and C++
     disableAutodetect: true,
@@ -286,15 +286,15 @@ export default function(hljs) {
         { // containers: ie, `vector <int> rooms (9);`
           begin: '\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<',
           end: '>',
-          keywords: CPP_KEYWORDS,
+          keywords: KEYWORDS,
           contains: [
             'self',
-            CPP_PRIMITIVE_TYPES
+            PRIMITIVE_TYPES
           ]
         },
         {
           begin: hljs.IDENT_RE + '::',
-          keywords: CPP_KEYWORDS
+          keywords: KEYWORDS
         },
         {
           className: 'class',
@@ -311,7 +311,7 @@ export default function(hljs) {
     exports: {
       preprocessor: PREPROCESSOR,
       strings: STRINGS,
-      keywords: CPP_KEYWORDS
+      keywords: KEYWORDS
     }
   };
 }

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -26,9 +26,15 @@ export default function(hljs) {
     regex.optional(NAMESPACE_RE) +
     '[a-zA-Z_]\\w*' + regex.optional(TEMPLATE_ARGUMENT_RE) +
   ')';
-  const PRIMITIVE_TYPES = {
+
+
+  const TYPES = {
     className: 'type',
-    begin: '\\b[a-z\\d_]*_t\\b'
+    variants: [
+      { begin: '\\b[a-z\\d_]*_t\\b' },
+      { match: /\batomic_[a-z]{3,6}\b/}
+    ]
+
   };
 
   // https://en.cppreference.com/w/cpp/language/escape
@@ -190,7 +196,7 @@ export default function(hljs) {
 
   const EXPRESSION_CONTAINS = [
     PREPROCESSOR,
-    PRIMITIVE_TYPES,
+    TYPES,
     C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,
     NUMBERS,
@@ -259,7 +265,7 @@ export default function(hljs) {
           hljs.C_BLOCK_COMMENT_MODE,
           STRINGS,
           NUMBERS,
-          PRIMITIVE_TYPES,
+          TYPES,
           // Count matching parentheses.
           {
             begin: /\(/,
@@ -272,12 +278,12 @@ export default function(hljs) {
               hljs.C_BLOCK_COMMENT_MODE,
               STRINGS,
               NUMBERS,
-              PRIMITIVE_TYPES
+              TYPES
             ]
           }
         ]
       },
-      PRIMITIVE_TYPES,
+      TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       PREPROCESSOR


### PR DESCRIPTION
Resolves #3010.



### Changes

- Applies the keyword list found in #3010
- Splits out `type` keywords

### Checklist
- [x] Added markup tests, or they don't apply here because we're still
reworking the whole grammar
- [x] Updated the changelog at `CHANGES.md`