### PR TITLE
enh(cpp) simpler struct matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,20 @@ Parser:
 
 - enh(parser) support multi-class matchers (#3081) [Josh Goebel][]
 - enh(parser) Detect comments based on english like text, rather than keyword list [Josh Goebel][]
+- adds `title.class` sub-scope support (#3078) [Josh Goebel][]
+- adds `title.function` sub-scope support (#3078) [Josh Goebel][]
+- adds `beforeMatch` compiler extension (#3078) [Josh Goebel][]
 
 Grammars:
 
+- enh(java) Simplified class-like matcher (#3078) [Josh Goebel][]
+- enh(cpp) Simplified class-like matcher (#3078) [Josh Goebel][]
+- enh(rust) Simplified class-like matcher (#3078) [Josh Goebel][]
+- enh(actionscript) Simplified class-like matcher (#3078) [Josh Goebel][]
+- enh(arcade) `function.title` => `title.function` (#3078) [Josh Goebel][]
+- enh(autoit) `function.title` => `title.function` (#3078) [Josh Goebel][]
+- enh(c) `function.title` => `title.function` (#3078) [Josh Goebel][]
+- enh(rust) support function invoke and `impl` (#3078) [Josh Goebel][]
 - chore(properties) disable auto-detection #3102 [Josh Goebel][]
 - fix(properties) fix incorrect handling of non-alphanumeric keys #3102 [Egor Rogov][]
 - enh(java) support functions with nested template types (#2641) [Josh Goebel][]

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -14,145 +14,147 @@ if you had a general purpose language that allowed inline URLs:
   var GOOGLE = https://www.google.com/
 
 
-It would be wholly reasonable to use the ``link`` class for this, even though
-your language is not considered a "Markup" language.
+It would be reasonable to use the ``link`` class for this, even if your language
+is not a markup language.  However, many themes might not be designed with this
+in mind so a better choice might be ``string`` or perhaps ``string.link``.
 
-+------------------------------------------------------------------------------+
-| **General purpose**                                                          |
-+--------------------------+---------------------------------------------------+
-| keyword                  | keyword in a regular Algol-style language         |
-+--------------------------+---------------------------------------------------+
-| built_in                 | built-in or library object (constant, class,      |
-|                          | function)                                         |
-+--------------------------+---------------------------------------------------+
-| type                     | data type (in a language with syntactically       |
-|                          | significant types) (``string``, ``int``,          |
-|                          | ``array``, etc.)                                  |
-+--------------------------+---------------------------------------------------+
-| literal                  | special identifier for a built-in value           |
-|                          | (``true``, ``false``, ``null``, etc.)             |
-+--------------------------+---------------------------------------------------+
-| number                   | number, including units and modifiers, if any.    |
-+--------------------------+---------------------------------------------------+
-| operator                 | operators: ``+``, ``-``, ``>>``, ``|``, ``==``    |
-+--------------------------+---------------------------------------------------+
-| punctuation              | aux. punctuation that should be subtly highlighted|
-|                          | (parentheses, brackets, etc.)                     |
-+--------------------------+---------------------------------------------------+
-| property                 | object property ``obj.prop1.prop2.value``         |
-+--------------------------+---------------------------------------------------+
-| regexp                   | literal regular expression                        |
-+--------------------------+---------------------------------------------------+
-| string                   | literal string, character                         |
-+--------------------------+---------------------------------------------------+
-| subst                    | parsed section inside a literal string            |
-+--------------------------+---------------------------------------------------+
-| symbol                   | symbolic constant, interned string, goto label    |
-+--------------------------+---------------------------------------------------+
-| class                    | class or class-level declaration (interfaces,     |
-|                          | traits, modules, etc), typically includes a       |
-|                          | ``title`` submode                                 |
-+--------------------------+---------------------------------------------------+
-| function                 | function or method declaration                    |
-+--------------------------+---------------------------------------------------+
-| variable                 | variables                                         |
-+--------------------------+---------------------------------------------------+
-| title                    | name of a class or a function at the place of     |
-|                          | declaration                                       |
-+--------------------------+---------------------------------------------------+
-| title.class              | name of a class                                   |
-+--------------------------+---------------------------------------------------+
-| params                   | block of function arguments (parameters) at the   |
-|                          | place of declaration                              |
-+--------------------------+---------------------------------------------------+
-| comment                  | comments                                          |
-+--------------------------+---------------------------------------------------+
-| doctag                   | documentation markup within comments              |
-+--------------------------+---------------------------------------------------+
-| **Meta**                                                                     |
-+--------------------------+---------------------------------------------------+
-| meta                     | flags, modifiers, annotations, processing         |
-|                          | instructions, preprocessor directives, etc        |
-+--------------------------+---------------------------------------------------+
-| meta-keyword             | keyword or built-in within meta construct         |
-+--------------------------+---------------------------------------------------+
-| meta-string              | string within meta construct                      |
-+--------------------------+---------------------------------------------------+
-| **Tags, attributes, configs**                                                |
-+--------------------------+---------------------------------------------------+
-| section                  | heading of a section in a config file, heading in |
-|                          | text markup                                       |
-+--------------------------+---------------------------------------------------+
-| tag                      | XML/HTML tag                                      |
-+--------------------------+---------------------------------------------------+
-| name                     | name of an XML tag, the first word in an          |
-|                          | s-expression                                      |
-+--------------------------+---------------------------------------------------+
-| attr                     | name of an attribute with no language defined     |
-|                          | semantics (keys in JSON, setting names in .ini),  |
-|                          | also sub-attribute within another highlighted     |
-|                          | object, like XML tag                              |
-+--------------------------+---------------------------------------------------+
-| attribute                | name of an attribute followed by a structured     |
-|                          | value part, like CSS properties                   |
-+--------------------------+---------------------------------------------------+
-| **Text Markup**                                                              |
-+--------------------------+---------------------------------------------------+
-| bullet                   | list item bullet                                  |
-+--------------------------+---------------------------------------------------+
-| code                     | code block                                        |
-+--------------------------+---------------------------------------------------+
-| emphasis                 | emphasis                                          |
-+--------------------------+---------------------------------------------------+
-| strong                   | strong emphasis                                   |
-+--------------------------+---------------------------------------------------+
-| formula                  | mathematical formula                              |
-+--------------------------+---------------------------------------------------+
-| link                     | hyperlink                                         |
-+--------------------------+---------------------------------------------------+
-| quote                    | quotation or blockquote                           |
-+--------------------------+---------------------------------------------------+
-| **CSS**                                                                      |
-+--------------------------+---------------------------------------------------+
-| selector-tag             | tag selector                                      |
-+--------------------------+---------------------------------------------------+
-| selector-id              | #id selector                                      |
-+--------------------------+---------------------------------------------------+
-| selector-class           | .class selector                                   |
-+--------------------------+---------------------------------------------------+
-| selector-attr            | [attr] selector                                   |
-+--------------------------+---------------------------------------------------+
-| selector-pseudo          | :pseudo selector                                  |
-+--------------------------+---------------------------------------------------+
-| **Templates**                                                                |
-+--------------------------+---------------------------------------------------+
-| template-tag             | tag of a template language                        |
-+--------------------------+---------------------------------------------------+
-| template-variable        | variable in a template language                   |
-+--------------------------+---------------------------------------------------+
-| **diff**                                                                     |
-+--------------------------+---------------------------------------------------+
-| addition                 | added or changed line                             |
-+--------------------------+---------------------------------------------------+
-| deletion                 | deleted line                                      |
-+--------------------------+---------------------------------------------------+
++----------------------------------------------------------------------------------------+
+| **General purpose**                                                                    |
++--------------------------+-------------------------------------------------------------+
+| keyword                  | keyword in a regular Algol-style language                   |
++--------------------------+-------------------------------------------------------------+
+| built_in                 | built-in or library object (constant, class,                |
+|                          | function)                                                   |
++--------------------------+-------------------------------------------------------------+
+| type                     | data type (in a language with syntactically                 |
+|                          | significant types) (``string``, ``int``,                    |
+|                          | ``array``, etc.)                                            |
++--------------------------+-------------------------------------------------------------+
+| literal                  | special identifier for a built-in value                     |
+|                          | (``true``, ``false``, ``null``, etc.)                       |
++--------------------------+-------------------------------------------------------------+
+| number                   | number, including units and modifiers, if any.              |
++--------------------------+-------------------------------------------------------------+
+| operator                 | operators: ``+``, ``-``, ``>>``, ``|``, ``==``              |
++--------------------------+-------------------------------------------------------------+
+| punctuation              | aux. punctuation that should be subtly highlighted          |
+|                          | (parentheses, brackets, etc.)                               |
++--------------------------+-------------------------------------------------------------+
+| property                 | object property ``obj.prop1.prop2.value``                   |
++--------------------------+-------------------------------------------------------------+
+| regexp                   | literal regular expression                                  |
++--------------------------+-------------------------------------------------------------+
+| string                   | literal string, character                                   |
++--------------------------+-------------------------------------------------------------+
+| subst                    | parsed section inside a literal string                      |
++--------------------------+-------------------------------------------------------------+
+| symbol                   | symbolic constant, interned string, goto label              |
++--------------------------+-------------------------------------------------------------+
+| class                    | relating to a class, typically paired with                  |
+|                          | another scope such as ``title.class``                             |
++--------------------------+-------------------------------------------------------------+
+| function                 | relating to a function, typically paired with               |
+|                          | another scope such as ``title.function``                             |
++--------------------------+-------------------------------------------------------------+
+| variable                 | variables                                                   |
++--------------------------+-------------------------------------------------------------+
+| title                    | name of a class or a function                               |
++--------------------------+-------------------------------------------------------------+
+| title.class              | name of a class (interface, trait, module, etc)             |
++--------------------------+-------------------------------------------------------------+
+| title.function           | name of a function                                          |
++--------------------------+-------------------------------------------------------------+
+| params                   | block of function arguments (parameters) at the             |
+|                          | place of declaration                                        |
++--------------------------+-------------------------------------------------------------+
+| comment                  | comments                                                    |
++--------------------------+-------------------------------------------------------------+
+| doctag                   | documentation markup within comments                        |
++--------------------------+-------------------------------------------------------------+
+| **Meta**                                                                               |
++--------------------------+-------------------------------------------------------------+
+| meta                     | flags, modifiers, annotations, processing                   |
+|                          | instructions, preprocessor directives, etc                  |
++--------------------------+-------------------------------------------------------------+
+| meta-keyword             | keyword or built-in within meta construct                   |
++--------------------------+-------------------------------------------------------------+
+| meta-string              | string within meta construct                                |
++--------------------------+-------------------------------------------------------------+
+| **Tags, attributes, configs**                                                          |
++--------------------------+-------------------------------------------------------------+
+| section                  | heading of a section in a config file, heading in           |
+|                          | text markup                                                 |
++--------------------------+-------------------------------------------------------------+
+| tag                      | XML/HTML tag                                                |
++--------------------------+-------------------------------------------------------------+
+| name                     | name of an XML tag, the first word in an                    |
+|                          | s-expression                                                |
++--------------------------+-------------------------------------------------------------+
+| attr                     | name of an attribute with no language defined               |
+|                          | semantics (keys in JSON, setting names in .ini),            |
+|                          | also sub-attribute within another highlighted               |
+|                          | object, like XML tag                                        |
++--------------------------+-------------------------------------------------------------+
+| attribute                | name of an attribute followed by a structured               |
+|                          | value part, like CSS properties                             |
++--------------------------+-------------------------------------------------------------+
+| **Text Markup**                                                                        |
++--------------------------+-------------------------------------------------------------+
+| bullet                   | list item bullet                                            |
++--------------------------+-------------------------------------------------------------+
+| code                     | code block                                                  |
++--------------------------+-------------------------------------------------------------+
+| emphasis                 | emphasis                                                    |
++--------------------------+-------------------------------------------------------------+
+| strong                   | strong emphasis                                             |
++--------------------------+-------------------------------------------------------------+
+| formula                  | mathematical formula                                        |
++--------------------------+-------------------------------------------------------------+
+| link                     | hyperlink                                                   |
++--------------------------+-------------------------------------------------------------+
+| quote                    | quotation or blockquote                                     |
++--------------------------+-------------------------------------------------------------+
+| **CSS**                                                                                |
++--------------------------+-------------------------------------------------------------+
+| selector-tag             | tag selector                                                |
++--------------------------+-------------------------------------------------------------+
+| selector-id              | #id selector                                                |
++--------------------------+-------------------------------------------------------------+
+| selector-class           | .class selector                                             |
++--------------------------+-------------------------------------------------------------+
+| selector-attr            | [attr] selector                                             |
++--------------------------+-------------------------------------------------------------+
+| selector-pseudo          | :pseudo selector                                            |
++--------------------------+-------------------------------------------------------------+
+| **Templates**                                                                          |
++--------------------------+-------------------------------------------------------------+
+| template-tag             | tag of a template language                                  |
++--------------------------+-------------------------------------------------------------+
+| template-variable        | variable in a template language                             |
++--------------------------+-------------------------------------------------------------+
+| **diff**                                                                               |
++--------------------------+-------------------------------------------------------------+
+| addition                 | added or changed line                                       |
++--------------------------+-------------------------------------------------------------+
+| deletion                 | deleted line                                                |
++--------------------------+-------------------------------------------------------------+
 
-A note on namespaced classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A note on multi-scope classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some class names above have a ``.`` in them - which is not a valid character in
-a CSS class name.  We use this notation to specify nested scopes.  In the
-generated HTML this will output two different classes.  An example.  Lets say
-the class name is ``title.class``.  The generated HTML would be:
+Some scope names above have a ``.`` in them.  We use this notation to specify
+multiple scopes.  In the generated HTML this will output two separate classes.
+For example, Lets say the scope name is ``title.class``.  The generated HTML
+would be:
 
 ::
 
-  class <span class="hljs-title hljs-title-class">Render</span>
+  class <span class="hljs-title hljs-class">Render</span>
 
-Render is a ``title``, but it is also the title of a class in particular. Some
-definitions still use nested rules/tags to do this, but the preferred way is now
-to handle this with the new namespaced classes and simplify the language
-defintions when possible.
+Render is a ``title``, the title of a ``class`` in particular. Some definitions
+still use nested rules/tags to do this, but the preferred way is now to handle
+this with the new multi-scope classes and simplify the language definitions when
+possible.
 
 
 A note on newer classes
@@ -167,6 +169,7 @@ A list of these classes:
 
 - operator
 - punctuation
+- property
 
 
 Reserved classes

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -60,6 +60,8 @@ your language is not considered a "Markup" language.
 | title                    | name of a class or a function at the place of     |
 |                          | declaration                                       |
 +--------------------------+---------------------------------------------------+
+| title.class              | name of a class                                   |
++--------------------------+---------------------------------------------------+
 | params                   | block of function arguments (parameters) at the   |
 |                          | place of declaration                              |
 +--------------------------+---------------------------------------------------+
@@ -134,6 +136,24 @@ your language is not considered a "Markup" language.
 +--------------------------+---------------------------------------------------+
 | deletion                 | deleted line                                      |
 +--------------------------+---------------------------------------------------+
+
+A note on namespaced classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some class names above have a ``.`` in them - which is not a valid character in
+a CSS class name.  We use this notation to specify nested scopes.  In the
+generated HTML this will output two different classes.  An example.  Lets say
+the class name is ``title.class``.  The generated HTML would be:
+
+::
+
+  class <span class="hljs-title hljs-title-class">Render</span>
+
+Render is a ``title``, but it is also the title of a class in particular. Some
+definitions still use nested rules/tags to do this, but the preferred way is now
+to handle this with the new namespaced classes and simplify the language
+defintions when possible.
+
 
 A note on newer classes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/mode-reference.rst
+++ b/docs/mode-reference.rst
@@ -250,6 +250,29 @@ This callback is triggered the moment an end match is detected. ``matchData`` in
 For an example of usage see ``END_SAME_AS_BEGIN`` in ``modes.js``.
 
 
+beforeMatch
+^^^^^^^^^^^
+
+- **type**: string
+
+Used to qualify a match by the content that immediately precedes it.  This is syntactic sugar that generates a much more complex mode that first matches the entire sequence (using look-ahead), then glosses over the ``beforeMatch`` portion and ``starts`` a new rule to handle the actual match.
+
+Notes:
+
+- Any ``keywords`` specified are applied to the ``beforeMatch`` text as well (as shown in the example below)
+- Do not get this confused with any type of look-behind.  We are always looking forward.
+- This is incompatible with ``starts``.
+
+::
+
+  {
+    beforeMatch: /\b(enum|class|struct|union)\s+/,
+    keywords: "enum class struct union",
+    begin: /\w+/,
+    className: "title.class"
+  }
+
+
 beginKeywords
 ^^^^^^^^^^^^^
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -452,7 +452,7 @@ const HLJS = function(hljs) {
         modeBuffer += codeToHighlight.slice(match.index, match.index + 1);
         if (!SAFE_MODE) {
           /** @type {AnnotatedError} */
-          const err = new Error('0 width match regex');
+          const err = new Error(`0 width match regex (${languageName})`);
           err.languageName = languageName;
           err.badRule = lastMatch.rule;
           throw err;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -252,7 +252,8 @@ const HLJS = function(hljs) {
      */
     function emitMultiClass(mode, match) {
       let i = 1;
-      while (match[i]) {
+      // eslint-disable-next-line no-undefined
+      while (match[i] !== undefined) {
         const klass = language.classNameAliases[mode.className[i]] || mode.className[i];
         const text = match[i];
         if (klass) { emitter.addKeyword(text, klass); } else {

--- a/src/languages/actionscript.js
+++ b/src/languages/actionscript.js
@@ -10,6 +10,10 @@ import * as regex from '../lib/regex.js';
 /** @type LanguageFn */
 export default function(hljs) {
   const IDENT_RE = /[a-zA-Z_$][a-zA-Z0-9_$]*/;
+  const PKG_NAME_RE = regex.concat(
+    IDENT_RE,
+    regex.concat("(\\.", IDENT_RE, ")*")
+  );
   const IDENT_FUNC_RETURN_TYPE_RE = /([*]|[a-zA-Z_$][a-zA-Z0-9_$]*)/;
 
   const AS3_REST_ARG_MODE = {
@@ -92,20 +96,16 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE,
       hljs.C_NUMBER_MODE,
       {
-        className: 'class',
-        beginKeywords: 'package',
-        end: /\{/,
-        contains: [ hljs.TITLE_MODE ]
+        beforeMatch: /\b(package)\s+/,
+        keywords: "package",
+        match: PKG_NAME_RE,
+        className: "title.class"
       },
       {
-        className: 'class',
-        beginKeywords: 'class interface',
-        end: /\{/,
-        excludeEnd: true,
-        contains: [
-          { beginKeywords: 'extends implements' },
-          hljs.TITLE_MODE
-        ]
+        beforeMatch: /\b(class|interface|extends|implements)\s+/,
+        keywords: "class interface extends implements",
+        match: IDENT_RE,
+        className: "title.class"
       },
       {
         className: 'meta',

--- a/src/languages/actionscript.js
+++ b/src/languages/actionscript.js
@@ -114,13 +114,12 @@ export default function(hljs) {
         keywords: { 'meta-keyword': 'import include' }
       },
       {
-        className: 'function',
         beginKeywords: 'function',
         end: /[{;]/,
         excludeEnd: true,
         illegal: /\S/,
         contains: [
-          hljs.TITLE_MODE,
+          hljs.inherit(hljs.TITLE_MODE, { className: "title.function" }),
           {
             className: 'params',
             begin: /\(/,

--- a/src/languages/arcade.js
+++ b/src/languages/arcade.js
@@ -135,12 +135,12 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'function',
         beginKeywords: 'function',
         end: /\{/,
         excludeEnd: true,
         contains: [
           hljs.inherit(hljs.TITLE_MODE, {
+            className: "title.function",
             begin: IDENT_RE
           }),
           {

--- a/src/languages/autoit.js
+++ b/src/languages/autoit.js
@@ -29,7 +29,7 @@ export default function(hljs) {
     "Tidy_On",
     "Tidy_Parameters"
   ]
-  
+
   const LITERAL = 'True False And Null Not Or Default';
 
   const BUILT_IN
@@ -140,12 +140,11 @@ export default function(hljs) {
   };
 
   const FUNCTION = {
-    className: 'function',
     beginKeywords: 'Func',
     end: '$',
     illegal: '\\$|\\[|%',
     contains: [
-      hljs.UNDERSCORE_TITLE_MODE,
+      hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, { className: "title.function" }),
       {
         className: 'params',
         begin: '\\(',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -235,7 +235,6 @@ export default function(hljs) {
   };
 
   const FUNCTION_DECLARATION = {
-    className: 'function',
     begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
     returnBegin: true,
     end: /[{;=]/,
@@ -251,7 +250,9 @@ export default function(hljs) {
       {
         begin: FUNCTION_TITLE,
         returnBegin: true,
-        contains: [ TITLE_MODE ],
+        contains: [
+          hljs.inherit(TITLE_MODE, { className: "title.function" })
+        ],
         relevance: 0
       },
       {

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -406,7 +406,7 @@ export default function(hljs) {
           beforeMatch: /\b(enum|class|struct|union)\s+/,
           keywords: "enum class struct union",
           match: /\w+/,
-          className: "title"
+          className: "title.class"
         }
       ])
   };

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -21,7 +21,7 @@ export default function(hljs) {
   const DECLTYPE_AUTO_RE = 'decltype\\(auto\\)';
   const NAMESPACE_RE = '[a-zA-Z_]\\w*::';
   const TEMPLATE_ARGUMENT_RE = '<[^<>]+>';
-  const FUNCTION_TYPE_RE = '(' +
+  const FUNCTION_TYPE_RE = '(?!struct)(' +
     DECLTYPE_AUTO_RE + '|' +
     regex.optional(NAMESPACE_RE) +
     '[a-zA-Z_]\\w*' + regex.optional(TEMPLATE_ARGUMENT_RE) +
@@ -233,7 +233,7 @@ export default function(hljs) {
       'atomic_bool atomic_char atomic_schar ' +
       'atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong ' +
       'atomic_ullong new throw return ' +
-      'and and_eq bitand bitor compl not not_eq or or_eq xor xor_eq',
+      'and and_eq bitand bitor compl not not_eq or or_eq xor xor_eq struct',
     built_in: '_Bool _Complex _Imaginary',
     _relevance_hints: COMMON_CPP_HINTS,
     literal: 'true false nullptr NULL'
@@ -403,15 +403,10 @@ export default function(hljs) {
           keywords: CPP_KEYWORDS
         },
         {
-          className: 'class',
-          beginKeywords: 'enum class struct union',
-          end: /[{;:<>=]/,
-          contains: [
-            {
-              beginKeywords: "final class struct"
-            },
-            hljs.TITLE_MODE
-          ]
+          beforeMatch: /\b(enum|class|struct|union)\s+/,
+          keywords: "enum class struct union",
+          match: /\w+/,
+          className: "title"
         }
       ])
   };

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -8,6 +8,7 @@ Website: https://www.java.com/
 import {
   NUMERIC as NUMBER
 } from "./lib/java.js";
+import * as regex from '../lib/regex.js';
 
 /**
  * Allows recursive regex expressions to a given depth
@@ -111,6 +112,17 @@ export default function(hljs) {
       }
     ]
   };
+  const PARAMS = {
+    className: 'params',
+    begin: /\(/,
+    end: /\)/,
+    keywords: KEYWORDS,
+    relevance: 0,
+    contains: [
+      hljs.C_BLOCK_COMMENT_MODE
+    ],
+    endsParent: true
+  };
 
   return {
     name: 'Java',
@@ -147,10 +159,26 @@ export default function(hljs) {
       hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
       {
-        beforeMatch: /\b(class|interface|enum|extends|implements)\s+/,
-        keywords: "class interface enum extends implements",
+        beforeMatch: /\b(class|interface|enum|extends|implements|new)\s+/,
+        keywords: "class interface enum extends implements new",
         match: JAVA_IDENT_RE,
         className: "title.class"
+      },
+      {
+        begin: [
+          /record/,
+          /\s+/,
+          JAVA_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        },
+        contains: [
+          PARAMS,
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
       },
       {
         // Expression keywords prevent 'keyword Name(...)' from being
@@ -159,37 +187,8 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'class',
-        begin: 'record\\s+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
-        returnBegin: true,
-        excludeEnd: true,
-        end: /[{;=]/,
-        keywords: KEYWORDS,
-        contains: [
-          {
-            beginKeywords: "record"
-          },
-          {
-            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
-            returnBegin: true,
-            relevance: 0,
-            contains: [ hljs.UNDERSCORE_TITLE_MODE ]
-          },
-          {
-            className: 'params',
-            begin: /\(/,
-            end: /\)/,
-            keywords: KEYWORDS,
-            relevance: 0,
-            contains: [ hljs.C_BLOCK_COMMENT_MODE ]
-          },
-          hljs.C_LINE_COMMENT_MODE,
-          hljs.C_BLOCK_COMMENT_MODE
-        ]
-      },
-      {
         className: 'function',
-        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
+        begin: '(' + GENERIC_IDENT_RE + '\\s+)' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
         returnBegin: true,
         end: /[{;=]/,
         excludeEnd: true,

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -147,23 +147,10 @@ export default function(hljs) {
       hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
       {
-        className: 'class',
-        beginKeywords: 'class interface enum',
-        end: /[{;=]/,
-        excludeEnd: true,
-        // TODO: can this be removed somehow?
-        // an extra boost because Java is more popular than other languages with
-        // this same syntax feature (this is just to preserve our tests passing
-        // for now)
-        relevance: 1,
-        keywords: 'class interface enum',
-        illegal: /[:"\[\]]/,
-        contains: [
-          {
-            beginKeywords: 'extends implements'
-          },
-          hljs.UNDERSCORE_TITLE_MODE
-        ]
+        beforeMatch: /\b(class|interface|enum|extends|implements)\s+/,
+        keywords: "class interface enum extends implements",
+        match: JAVA_IDENT_RE,
+        className: "title.class"
       },
       {
         // Expression keywords prevent 'keyword Name(...)' from being

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -33,7 +33,7 @@ function recurRegex(re, substitution, depth) {
 export default function(hljs) {
   const JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';
   const GENERIC_IDENT_RE = JAVA_IDENT_RE +
-    recurRegex('(<' + JAVA_IDENT_RE + '~~~(\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?', /~~~/g, 2);
+    recurRegex('(?:<' + JAVA_IDENT_RE + '~~~(?:\\s*,\\s*' + JAVA_IDENT_RE + '~~~)*>)?', /~~~/g, 2);
   const MAIN_KEYWORDS = [
     'synchronized',
     'abstract',
@@ -57,7 +57,6 @@ export default function(hljs) {
     'transient',
     'catch',
     'instanceof',
-    'super',
     'volatile',
     'case',
     'assert',
@@ -65,7 +64,6 @@ export default function(hljs) {
     'default',
     'public',
     'try',
-    'this',
     'switch',
     'continue',
     'throws',
@@ -76,6 +74,11 @@ export default function(hljs) {
     'requires',
     'exports',
     'do'
+  ];
+
+  const BUILT_INS = [
+    'super',
+    'this'
   ];
 
   const LITERALS = [
@@ -98,7 +101,8 @@ export default function(hljs) {
   const KEYWORDS = {
     keyword: MAIN_KEYWORDS,
     literal: LITERALS,
-    type: TYPES
+    type: TYPES,
+    built_in: BUILT_INS
   };
 
   const ANNOTATION = {
@@ -166,6 +170,20 @@ export default function(hljs) {
       },
       {
         begin: [
+          JAVA_IDENT_RE,
+          /\s+/,
+          JAVA_IDENT_RE,
+          /\s+/,
+          /=/
+        ],
+        className: {
+          1: "type",
+          3: "variable",
+          5: "operator"
+        }
+      },
+      {
+        begin: [
           /record/,
           /\s+/,
           JAVA_IDENT_RE
@@ -187,19 +205,16 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'function',
-        begin: '(' + GENERIC_IDENT_RE + '\\s+)' + hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
-        returnBegin: true,
-        end: /[{;=]/,
-        excludeEnd: true,
+        begin: [
+          '(?:' + GENERIC_IDENT_RE + '\\s+)',
+          hljs.UNDERSCORE_IDENT_RE,
+          /\s*(?=\()/
+        ],
+        className: {
+          2: "title.function"
+        },
         keywords: KEYWORDS,
         contains: [
-          {
-            begin: hljs.UNDERSCORE_IDENT_RE + '\\s*\\(',
-            returnBegin: true,
-            relevance: 0,
-            contains: [ hljs.UNDERSCORE_TITLE_MODE ]
-          },
           {
             className: 'params',
             begin: /\(/,

--- a/src/languages/r.js
+++ b/src/languages/r.js
@@ -56,30 +56,6 @@ export default function(hljs) {
         'standardGeneric substitute sum switch tan tanh tanpi tracemem ' +
         'trigamma trunc unclass untracemem UseMethod xtfrm',
     },
-    compilerExtensions: [
-      // allow beforeMatch to act as a "qualifier" for the match
-      // the full match begin must be [beforeMatch][begin]
-      (mode, parent) => {
-        if (!mode.beforeMatch) return;
-        // starts conflicts with endsParent which we need to make sure the child
-        // rule is not matched multiple times
-        if (mode.starts) throw new Error("beforeMatch cannot be used with starts");
-
-        const originalMode = Object.assign({}, mode);
-        Object.keys(mode).forEach((key) => { delete mode[key]; });
-
-        mode.begin = regex.concat(originalMode.beforeMatch, regex.lookahead(originalMode.begin));
-        mode.starts = {
-          relevance: 0,
-          contains: [
-            Object.assign(originalMode, { endsParent: true })
-          ]
-        };
-        mode.relevance = 0;
-
-        delete originalMode.beforeMatch;
-      }
-    ],
     contains: [
       // Roxygen comments
       hljs.COMMENT(

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -6,8 +6,19 @@ Website: https://www.rust-lang.org
 Category: common, system
 */
 
+import * as regex from '../lib/regex.js';
+
 /** @type LanguageFn */
 export default function(hljs) {
+  const FUNCTION_INVOKE = {
+    className: "title.function.invoke",
+    relevance: 0,
+    begin: regex.concat(
+      /\b/,
+      /(?!let\b)/,
+      hljs.IDENT_RE,
+      regex.lookahead(/\s*\(/))
+  };
   const NUMBER_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
   const KEYWORDS = [
     "abstract",
@@ -240,13 +251,14 @@ export default function(hljs) {
       },
       {
         begin: [
-          /let/,
-          /\s+/,
+          /let/, /\s+/,
+          /(?:mut\s+)?/,
           hljs.UNDERSCORE_IDENT_RE
         ],
         className: {
           1: "keyword",
-          3: "variable"
+          3: "keyword",
+          4: "variable"
         }
       },
       // must come before impl/for rule later
@@ -296,7 +308,8 @@ export default function(hljs) {
       {
         className: "punctuation",
         begin: '->'
-      }
+      },
+      FUNCTION_INVOKE
     ]
   };
 }

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -6,44 +6,170 @@ Website: https://www.rust-lang.org
 Category: common, system
 */
 
+/** @type LanguageFn */
 export default function(hljs) {
-  const NUM_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
-  const KEYWORDS =
-    'abstract as async await become box break const continue crate do dyn ' +
-    'else enum extern false final fn for if impl in let loop macro match mod ' +
-    'move mut override priv pub ref return self Self static struct super ' +
-    'trait true try type typeof unsafe unsized use virtual where while yield';
-  const BUILTINS =
+  const NUMBER_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
+  const KEYWORDS = [
+    "abstract",
+    "as",
+    "async",
+    "await",
+    "become",
+    "box",
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "do",
+    "dyn",
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "final",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "macro",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "override",
+    "priv",
+    "pub",
+    "ref",
+    "return",
+    "self",
+    "Self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "try",
+    "type",
+    "typeof",
+    "unsafe",
+    "unsized",
+    "use",
+    "virtual",
+    "where",
+    "while",
+    "yield"
+  ];
+  const LITERALS = [
+    "true",
+    "false",
+    "Some",
+    "None",
+    "Ok",
+    "Err"
+  ];
+  const BUILTINS = [
     // functions
-    'drop ' +
-    // types
-    'i8 i16 i32 i64 i128 isize ' +
-    'u8 u16 u32 u64 u128 usize ' +
-    'f32 f64 ' +
-    'str char bool ' +
-    'Box Option Result String Vec ' +
+    'drop ',
     // traits
-    'Copy Send Sized Sync Drop Fn FnMut FnOnce ToOwned Clone Debug ' +
-    'PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator ' +
-    'Extend IntoIterator DoubleEndedIterator ExactSizeIterator ' +
-    'SliceConcatExt ToString ' +
+    "Copy",
+    "Send",
+    "Sized",
+    "Sync",
+    "Drop",
+    "Fn",
+    "FnMut",
+    "FnOnce",
+    "ToOwned",
+    "Clone",
+    "Debug",
+    "PartialEq",
+    "PartialOrd",
+    "Eq",
+    "Ord",
+    "AsRef",
+    "AsMut",
+    "Into",
+    "From",
+    "Default",
+    "Iterator",
+    "Extend",
+    "IntoIterator",
+    "DoubleEndedIterator",
+    "ExactSizeIterator",
+    "SliceConcatExt",
+    "ToString",
     // macros
-    'assert! assert_eq! bitflags! bytes! cfg! col! concat! concat_idents! ' +
-    'debug_assert! debug_assert_eq! env! panic! file! format! format_args! ' +
-    'include_bin! include_str! line! local_data_key! module_path! ' +
-    'option_env! print! println! select! stringify! try! unimplemented! ' +
-    'unreachable! vec! write! writeln! macro_rules! assert_ne! debug_assert_ne!';
+    "assert!",
+    "assert_eq!",
+    "bitflags!",
+    "bytes!",
+    "cfg!",
+    "col!",
+    "concat!",
+    "concat_idents!",
+    "debug_assert!",
+    "debug_assert_eq!",
+    "env!",
+    "panic!",
+    "file!",
+    "format!",
+    "format_args!",
+    "include_bin!",
+    "include_str!",
+    "line!",
+    "local_data_key!",
+    "module_path!",
+    "option_env!",
+    "print!",
+    "println!",
+    "select!",
+    "stringify!",
+    "try!",
+    "unimplemented!",
+    "unreachable!",
+    "vec!",
+    "write!",
+    "writeln!",
+    "macro_rules!",
+    "assert_ne!",
+    "debug_assert_ne!"
+  ];
+  const TYPES = [
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "isize",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "usize",
+    "f32",
+    "f64",
+    "str",
+    "char",
+    "bool",
+    "Box",
+    "Option",
+    "Result",
+    "String",
+    "Vec"
+  ];
   return {
     name: 'Rust',
     aliases: [ 'rs' ],
     keywords: {
       $pattern: hljs.IDENT_RE + '!?',
-      keyword:
-        KEYWORDS,
-      literal:
-        'true false Some None Ok Err',
-      built_in:
-        BUILTINS
+      type: TYPES,
+      keyword: KEYWORDS,
+      literal: LITERALS,
+      built_in: BUILTINS
     },
     illegal: '</',
     contains: [
@@ -74,27 +200,31 @@ export default function(hljs) {
         className: 'number',
         variants: [
           {
-            begin: '\\b0b([01_]+)' + NUM_SUFFIX
+            begin: '\\b0b([01_]+)' + NUMBER_SUFFIX
           },
           {
-            begin: '\\b0o([0-7_]+)' + NUM_SUFFIX
+            begin: '\\b0o([0-7_]+)' + NUMBER_SUFFIX
           },
           {
-            begin: '\\b0x([A-Fa-f0-9_]+)' + NUM_SUFFIX
+            begin: '\\b0x([A-Fa-f0-9_]+)' + NUMBER_SUFFIX
           },
           {
             begin: '\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)' +
-                   NUM_SUFFIX
+                   NUMBER_SUFFIX
           }
         ],
         relevance: 0
       },
       {
-        className: 'function',
-        beginKeywords: 'fn',
-        end: '(\\(|<)',
-        excludeEnd: true,
-        contains: [ hljs.UNDERSCORE_TITLE_MODE ]
+        begin: [
+          /fn/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.function"
+        }
       },
       {
         className: 'meta',
@@ -109,34 +239,62 @@ export default function(hljs) {
         ]
       },
       {
-        className: 'class',
-        beginKeywords: 'type',
-        end: ';',
-        contains: [
-          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {
-            endsParent: true
-          })
+        begin: [
+          /let/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
         ],
-        illegal: '\\S'
+        className: {
+          1: "keyword",
+          3: "variable"
+        }
+      },
+      // must come before impl/for rule later
+      {
+        begin: [
+          /for/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE,
+          /\s+/,
+          /in/
+        ],
+        className: {
+          1: "keyword",
+          3: "variable",
+          5: "keyword"
+        }
       },
       {
-        className: 'class',
-        beginKeywords: 'trait enum struct union',
-        end: /\{/,
-        contains: [
-          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {
-            endsParent: true
-          })
+        begin: [
+          /type/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
         ],
-        illegal: '[\\w\\d]'
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
+      },
+      {
+        begin: [
+          /(?:trait|enum|struct|union|impl|for)/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
       },
       {
         begin: hljs.IDENT_RE + '::',
         keywords: {
+          keyword: "Self",
           built_in: BUILTINS
         }
       },
       {
+        className: "punctuation",
         begin: '->'
       }
     ]

--- a/src/lib/exts/before_match.js
+++ b/src/lib/exts/before_match.js
@@ -1,0 +1,25 @@
+import * as regex from "../regex.js";
+
+// allow beforeMatch to act as a "qualifier" for the match
+// the full match begin must be [beforeMatch][begin]
+export const beforeMatchExt = (mode, parent) => {
+  if (!mode.beforeMatch) return;
+  // starts conflicts with endsParent which we need to make sure the child
+  // rule is not matched multiple times
+  if (mode.starts) throw new Error("beforeMatch cannot be used with starts");
+
+  const originalMode = Object.assign({}, mode);
+  Object.keys(mode).forEach((key) => { delete mode[key]; });
+
+  mode.keywords = originalMode.keywords;
+  mode.begin = regex.concat(originalMode.beforeMatch, regex.lookahead(originalMode.begin));
+  mode.starts = {
+    relevance: 0,
+    contains: [
+      Object.assign(originalMode, { endsParent: true })
+    ]
+  };
+  mode.relevance = 0;
+
+  delete originalMode.beforeMatch;
+};

--- a/src/lib/html_renderer.js
+++ b/src/lib/html_renderer.js
@@ -22,6 +22,21 @@ const emitsWrappingTags = (node) => {
   return !!node.kind;
 };
 
+/**
+ *
+ * @param {string} name
+ * @param {{prefix:string}} options
+ */
+const expandClassName = (name, { prefix }) => {
+  if (name.includes(".")) {
+    const pieces = name.split(".");
+    const first = pieces[0];
+    const full = name.replace(".", "-");
+    return `${prefix}${first} ${prefix}${full}`;
+  }
+  return `${prefix}${name}`;
+};
+
 /** @type {Renderer} */
 export default class HTMLRenderer {
   /**
@@ -53,7 +68,7 @@ export default class HTMLRenderer {
 
     let className = node.kind;
     if (!node.sublanguage) {
-      className = `${this.classPrefix}${className}`;
+      className = expandClassName(className, { prefix: this.classPrefix });
     }
     this.span(className);
   }

--- a/src/lib/html_renderer.js
+++ b/src/lib/html_renderer.js
@@ -30,9 +30,7 @@ const emitsWrappingTags = (node) => {
 const expandClassName = (name, { prefix }) => {
   if (name.includes(".")) {
     const pieces = name.split(".");
-    const first = pieces[0];
-    const full = name.replace(".", "-");
-    return `${prefix}${first} ${prefix}${full}`;
+    return pieces.map(x => `${prefix}${x}`).join(" ");
   }
   return `${prefix}${name}`;
 };

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -1,6 +1,7 @@
 import * as regex from './regex.js';
 import { inherit } from './utils.js';
 import * as EXT from "./compiler_extensions.js";
+import { beforeMatchExt } from "./exts/before_match.js";
 import { compileKeywords } from "./compile_keywords.js";
 import { MultiClass } from "./ext/multi_class.js";
 
@@ -286,7 +287,8 @@ export function compileLanguage(language, { plugins }) {
       // do this early so compiler extensions generally don't have to worry about
       // the distinction between match/begin
       EXT.compileMatch,
-      MultiClass
+      MultiClass,
+      beforeMatchExt
     ].forEach(ext => ext(mode, parent));
 
     language.compilerExtensions.forEach(ext => ext(mode, parent));

--- a/src/styles/arduino-light.css
+++ b/src/styles/arduino-light.css
@@ -52,12 +52,6 @@ Arduino® Light Theme - Stefania Mellai <s.mellai@arduino.cc>
   color: #005C5F;
 }
 
-.hljs-title,
-.hljs-section {
-  color: #880000;
-  font-weight: bold;
-}
-
 .hljs-comment {
   color: rgba(149,165,166,.8);
 }
@@ -82,6 +76,12 @@ Arduino® Light Theme - Stefania Mellai <s.mellai@arduino.cc>
   color: #728E00;
 }
 
+.hljs-title,
+.hljs-section {
+  color: #880000;
+  font-weight: bold;
+}
+
 .hljs-number {
-  color: #8A7B52;  
+  color: #8A7B52;
 }

--- a/src/styles/atom-one-dark-reasonable.css
+++ b/src/styles/atom-one-dark-reasonable.css
@@ -55,7 +55,9 @@ Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
 .hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute, .hljs-meta-string {
   color: #98c379;
 }
-.hljs-built_in, .hljs-class .hljs-title {
+.hljs-built_in,
+.hljs-title-class,
+.hljs-class .hljs-title {
   color: #e6c07b;
 }
 .hljs-attr, .hljs-variable, .hljs-template-variable, .hljs-type, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo, .hljs-number {

--- a/src/styles/atom-one-dark-reasonable.css
+++ b/src/styles/atom-one-dark-reasonable.css
@@ -56,7 +56,7 @@ Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
   color: #98c379;
 }
 .hljs-built_in,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #e6c07b;
 }

--- a/src/styles/atom-one-dark.css
+++ b/src/styles/atom-one-dark.css
@@ -58,11 +58,6 @@ hue-6-2: #e6c07b
   color: #98c379;
 }
 
-.hljs-built_in,
-.hljs-class .hljs-title {
-  color: #e6c07b;
-}
-
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
@@ -81,6 +76,12 @@ hue-6-2: #e6c07b
 .hljs-selector-id,
 .hljs-title {
   color: #61aeee;
+}
+
+.hljs-built_in,
+.hljs-title-class,
+.hljs-class .hljs-title {
+  color: #e6c07b;
 }
 
 .hljs-emphasis {

--- a/src/styles/atom-one-dark.css
+++ b/src/styles/atom-one-dark.css
@@ -79,7 +79,7 @@ hue-6-2: #e6c07b
 }
 
 .hljs-built_in,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #e6c07b;
 }

--- a/src/styles/atom-one-light.css
+++ b/src/styles/atom-one-light.css
@@ -58,11 +58,6 @@ hue-6-2: #c18401
   color: #50a14f;
 }
 
-.hljs-built_in,
-.hljs-class .hljs-title {
-  color: #c18401;
-}
-
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
@@ -81,6 +76,12 @@ hue-6-2: #c18401
 .hljs-selector-id,
 .hljs-title {
   color: #4078f2;
+}
+
+.hljs-built_in,
+.hljs-title-class,
+.hljs-class .hljs-title {
+  color: #c18401;
 }
 
 .hljs-emphasis {

--- a/src/styles/atom-one-light.css
+++ b/src/styles/atom-one-light.css
@@ -79,7 +79,7 @@ hue-6-2: #c18401
 }
 
 .hljs-built_in,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #c18401;
 }

--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -48,7 +48,7 @@ Date: 2013-04-02
 
 
 .hljs-class .hljs-title,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-type {
   color: #458;
 }

--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -46,7 +46,9 @@ Date: 2013-04-02
   color: #900;
 }
 
+
 .hljs-class .hljs-title,
+.hljs-title-class,
 .hljs-type {
   color: #458;
 }

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -50,7 +50,7 @@
 
 .hljs-built_in,
 .hljs-symbol,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   /* prettylights-syntax-variable */
   color: #e36209;

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -50,6 +50,7 @@
 
 .hljs-built_in,
 .hljs-symbol,
+.hljs-title-class,
 .hljs-class .hljs-title {
   /* prettylights-syntax-variable */
   color: #e36209;

--- a/src/styles/grayscale.css
+++ b/src/styles/grayscale.css
@@ -48,7 +48,7 @@ grayscale style (c) MY Sun <simonmysun@gmail.com>
   font-weight: normal;
 }
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-name {

--- a/src/styles/grayscale.css
+++ b/src/styles/grayscale.css
@@ -48,6 +48,7 @@ grayscale style (c) MY Sun <simonmysun@gmail.com>
   font-weight: normal;
 }
 
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-name {

--- a/src/styles/gruvbox-dark.css
+++ b/src/styles/gruvbox-dark.css
@@ -25,17 +25,6 @@ Gruvbox style (dark) (c) Pavel Pertsev (original style at https://github.com/mor
   color: #fb4934;
 }
 
-/* Gruvbox Blue */
-.hljs-built_in,
-.hljs-emphasis,
-.hljs-name,
-.hljs-quote,
-.hljs-strong,
-.hljs-title,
-.hljs-variable {
-  color: #83a598;
-}
-
 /* Gruvbox Yellow */
 .hljs-attr,
 .hljs-params,
@@ -81,6 +70,17 @@ Gruvbox style (dark) (c) Pavel Pertsev (original style at https://github.com/mor
 .hljs-selector-pseudo,
 .hljs-tag {
   color: #8ec07c;
+}
+
+/* Gruvbox Blue */
+.hljs-built_in,
+.hljs-emphasis,
+.hljs-name,
+.hljs-quote,
+.hljs-strong,
+.hljs-title,
+.hljs-variable {
+  color: #83a598;
 }
 
 /* Gruvbox Gray */

--- a/src/styles/gruvbox-light.css
+++ b/src/styles/gruvbox-light.css
@@ -25,17 +25,6 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
   color: #9d0006;
 }
 
-/* Gruvbox Blue */
-.hljs-built_in,
-.hljs-emphasis,
-.hljs-name,
-.hljs-quote,
-.hljs-strong,
-.hljs-title,
-.hljs-variable {
-  color: #076678;
-}
-
 /* Gruvbox Yellow */
 .hljs-attr,
 .hljs-params,
@@ -81,6 +70,17 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-selector-pseudo,
 .hljs-tag {
   color: #427b58;
+}
+
+/* Gruvbox Blue */
+.hljs-built_in,
+.hljs-emphasis,
+.hljs-name,
+.hljs-quote,
+.hljs-strong,
+.hljs-title,
+.hljs-variable {
+  color: #076678;
 }
 
 /* Gruvbox Gray */

--- a/src/styles/hopscotch.css
+++ b/src/styles/hopscotch.css
@@ -35,11 +35,6 @@
   color: #fd8b19;
 }
 
-/* Yellow */
-.hljs-class .hljs-title {
-  color: #fdcc59;
-}
-
 /* Green */
 .hljs-string,
 .hljs-symbol,
@@ -58,6 +53,12 @@
 .hljs-section,
 .hljs-title {
   color: #1290bf;
+}
+
+/* Yellow */
+.hljs-title-class,
+.hljs-class .hljs-title {
+  color: #fdcc59;
 }
 
 /* Purple */

--- a/src/styles/hopscotch.css
+++ b/src/styles/hopscotch.css
@@ -56,7 +56,7 @@
 }
 
 /* Yellow */
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #fdcc59;
 }

--- a/src/styles/isbl-editor-dark.css
+++ b/src/styles/isbl-editor-dark.css
@@ -51,16 +51,6 @@ ISBL Editor style dark color scheme (c) Dmitriy Tarasov <dimatar@gmail.com>
   color: #f0f0f0;
 }
 
-.hljs-title,
-.hljs-section {
-  color: #df471e;
-}
-
-.hljs-title>.hljs-built_in {
-  color: #81bce9;
-  font-weight: normal;
-}
-
 .hljs-regexp,
 .hljs-symbol,
 .hljs-variable,
@@ -88,6 +78,16 @@ ISBL Editor style dark color scheme (c) Dmitriy Tarasov <dimatar@gmail.com>
 .hljs-class  {
   color: #ce9d4d;
   font-weight: bold;
+}
+
+.hljs-title,
+.hljs-section {
+  color: #df471e;
+}
+
+.hljs-title>.hljs-built_in {
+  color: #81bce9;
+  font-weight: normal;
 }
 
 /* Meta color: hue: 200 */

--- a/src/styles/isbl-editor-light.css
+++ b/src/styles/isbl-editor-light.css
@@ -50,16 +50,6 @@ ISBL Editor style light color schemec (c) Dmitriy Tarasov <dimatar@gmail.com>
   color: #000000;
 }
 
-.hljs-title,
-.hljs-section {
-  color: #fb2c00;
-}
-
-.hljs-title>.hljs-built_in {
-  color: #008080;
-  font-weight: normal;
-}
-
 .hljs-regexp,
 .hljs-symbol,
 .hljs-variable,
@@ -87,6 +77,16 @@ ISBL Editor style light color schemec (c) Dmitriy Tarasov <dimatar@gmail.com>
 .hljs-class  {
   color: #6f1C00;
   font-weight: bold;
+}
+
+.hljs-title,
+.hljs-section {
+  color: #fb2c00;
+}
+
+.hljs-title>.hljs-built_in {
+  color: #008080;
+  font-weight: normal;
 }
 
 /* Meta color: hue: 200 */

--- a/src/styles/kimbie.dark.css
+++ b/src/styles/kimbie.dark.css
@@ -34,13 +34,6 @@
   color: #f79a32;
 }
 
-/* Kimbie Yellow */
-.hljs-title,
-.hljs-section,
-.hljs-attribute {
-  color: #f06431;
-}
-
 /* Kimbie Green */
 .hljs-string,
 .hljs-symbol,
@@ -54,6 +47,13 @@
 .hljs-selector-tag,
 .hljs-function {
   color: #98676a;
+}
+
+/* Kimbie Yellow */
+.hljs-title,
+.hljs-section,
+.hljs-attribute {
+  color: #f06431;
 }
 
 .hljs {

--- a/src/styles/kimbie.light.css
+++ b/src/styles/kimbie.light.css
@@ -34,13 +34,6 @@
   color: #f79a32;
 }
 
-/* Kimbie Yellow */
-.hljs-title,
-.hljs-section,
-.hljs-attribute {
-  color: #f06431;
-}
-
 /* Kimbie Green */
 .hljs-string,
 .hljs-symbol,
@@ -54,6 +47,13 @@
 .hljs-selector-tag,
 .hljs-function {
   color: #98676a;
+}
+
+/* Kimbie Yellow */
+.hljs-title,
+.hljs-section,
+.hljs-attribute {
+  color: #f06431;
 }
 
 .hljs {

--- a/src/styles/lioshi.css
+++ b/src/styles/lioshi.css
@@ -46,19 +46,19 @@
   color: #b5bd68;
 }
 
-/* Blue */
-.hljs-title,
-.hljs-meta,
-.hljs-section {
-  color: #81a2be;
-}
-
 /* Purple */
 .hljs-selector-tag,
 .hljs-keyword,
 .hljs-function,
 .hljs-class {
   color: #be94bb;
+}
+
+/* Blue */
+.hljs-title,
+.hljs-meta,
+.hljs-section {
+  color: #81a2be;
 }
 
 /* Purple light */

--- a/src/styles/monokai-sublime.css
+++ b/src/styles/monokai-sublime.css
@@ -59,6 +59,7 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 }
 
 .hljs-params,
+.hljs-title-class,
 .hljs-class .hljs-title {
   color: #f8f8f2;
 }

--- a/src/styles/monokai-sublime.css
+++ b/src/styles/monokai-sublime.css
@@ -59,7 +59,7 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 }
 
 .hljs-params,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #f8f8f2;
 }

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -47,7 +47,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
   color: #a6e22e;
 }
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: white;
 }

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -23,10 +23,6 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
   color: #66d9ef;
 }
 
-.hljs-class .hljs-title {
-  color: white;
-}
-
 .hljs-attribute,
 .hljs-symbol,
 .hljs-regexp,
@@ -49,6 +45,11 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-template-tag,
 .hljs-template-variable {
   color: #a6e22e;
+}
+
+.hljs-title-class,
+.hljs-class .hljs-title {
+  color: white;
 }
 
 .hljs-comment,

--- a/src/styles/nnfx-dark.css
+++ b/src/styles/nnfx-dark.css
@@ -66,6 +66,7 @@
   color: #a85;
 }
 
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #96c;

--- a/src/styles/nnfx-dark.css
+++ b/src/styles/nnfx-dark.css
@@ -72,6 +72,7 @@
   color: #96c;
 }
 
+.hljs-function.hljs-title,
 .hljs-function .hljs-title,
 .hljs-attr,
 .hljs-subst {

--- a/src/styles/nnfx-dark.css
+++ b/src/styles/nnfx-dark.css
@@ -66,7 +66,7 @@
   color: #a85;
 }
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #96c;

--- a/src/styles/nnfx.css
+++ b/src/styles/nnfx.css
@@ -66,6 +66,7 @@
   color: #642;
 }
 
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #639;

--- a/src/styles/nnfx.css
+++ b/src/styles/nnfx.css
@@ -66,12 +66,13 @@
   color: #642;
 }
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #639;
 }
 
+.hljs-function.hljs-title,
 .hljs-function .hljs-title,
 .hljs-attr,
 .hljs-subst {

--- a/src/styles/nord.css
+++ b/src/styles/nord.css
@@ -100,6 +100,7 @@ Aurora
   color: #88C0D0;
 }
 
+.hljs-title.hljs-function,
 .hljs-function > .hljs-title {
   color: #88C0D0;
 }

--- a/src/styles/obsidian.css
+++ b/src/styles/obsidian.css
@@ -29,12 +29,6 @@
   color: #668bb0;
 }
 
-.hljs-code,
-.hljs-class .hljs-title,
-.hljs-section {
-  color: white;
-}
-
 .hljs-regexp,
 .hljs-link {
   color: #d39745;
@@ -85,4 +79,11 @@
 .hljs-name,
 .hljs-strong {
   font-weight: bold;
+}
+
+.hljs-code,
+.hljs-title-class,
+.hljs-class .hljs-title,
+.hljs-section {
+  color: white;
 }

--- a/src/styles/obsidian.css
+++ b/src/styles/obsidian.css
@@ -82,7 +82,7 @@
 }
 
 .hljs-code,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-section {
   color: white;

--- a/src/styles/pojoaque.css
+++ b/src/styles/pojoaque.css
@@ -43,7 +43,7 @@ Based on Solarized Style from http://ethanschoonover.com/solarized
 
 .hljs-variable,
 .hljs-template-variable,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-tag {

--- a/src/styles/pojoaque.css
+++ b/src/styles/pojoaque.css
@@ -43,6 +43,7 @@ Based on Solarized Style from http://ethanschoonover.com/solarized
 
 .hljs-variable,
 .hljs-template-variable,
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-tag {

--- a/src/styles/purebasic.css
+++ b/src/styles/purebasic.css
@@ -50,13 +50,6 @@ NOTE_2:	Color names provided in comments were derived using "Name that Color" on
 	color: #00AAAA; /* Persian Green (approx.) */
 }
 
-.hljs-title, /* --- used for PureBASIC Procedures Names --- */
-.hljs-tag,
-.hljs-variable,
-.hljs-code  {
-	color: #006666; /* Blue Stone (approx.) */
-}
-
 .hljs-keyword, /* --- used for PureBASIC Keywords --- */
 .hljs-class,
 .hljs-meta-keyword,
@@ -64,6 +57,13 @@ NOTE_2:	Color names provided in comments were derived using "Name that Color" on
 .hljs-built_in {
 	color: #006666; /* Blue Stone (approx.) */
 	font-weight: bold;
+}
+
+.hljs-title, /* --- used for PureBASIC Procedures Names --- */
+.hljs-tag,
+.hljs-variable,
+.hljs-code  {
+	color: #006666; /* Blue Stone (approx.) */
 }
 
 .hljs-string, /* --- used for PureBASIC Strings --- */

--- a/src/styles/qtcreator_dark.css
+++ b/src/styles/qtcreator_dark.css
@@ -61,7 +61,7 @@ Qt Creator dark color scheme
 
 .hljs-variable,
 .hljs-params,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #8888ff;
 }

--- a/src/styles/qtcreator_dark.css
+++ b/src/styles/qtcreator_dark.css
@@ -12,10 +12,7 @@ Qt Creator dark color scheme
   background: #000000;
 }
 
-.hljs,
-.hljs-subst,
-.hljs-tag,
-.hljs-title {
+.hljs {
   color: #aaaaaa;
 }
 
@@ -50,6 +47,12 @@ Qt Creator dark color scheme
 .hljs-symbol,
 .hljs-name {
   color: #ffff55;
+}
+
+.hljs-subst,
+.hljs-tag,
+.hljs-title {
+  color: #aaaaaa;
 }
 
 .hljs-attribute {

--- a/src/styles/qtcreator_dark.css
+++ b/src/styles/qtcreator_dark.css
@@ -58,6 +58,7 @@ Qt Creator dark color scheme
 
 .hljs-variable,
 .hljs-params,
+.hljs-title-class,
 .hljs-class .hljs-title {
   color: #8888ff;
 }

--- a/src/styles/qtcreator_light.css
+++ b/src/styles/qtcreator_light.css
@@ -61,7 +61,7 @@ Qt Creator light color scheme
 
 .hljs-variable,
 .hljs-params,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
   color: #0055AF;
 }

--- a/src/styles/qtcreator_light.css
+++ b/src/styles/qtcreator_light.css
@@ -12,10 +12,7 @@ Qt Creator light color scheme
   background: #ffffff;
 }
 
-.hljs,
-.hljs-subst,
-.hljs-tag,
-.hljs-title {
+.hljs {
   color: #000000;
 }
 
@@ -50,6 +47,12 @@ Qt Creator light color scheme
 .hljs-symbol,
 .hljs-name {
   color: #808000;
+}
+
+.hljs-subst,
+.hljs-tag,
+.hljs-title {
+  color: #000000;
 }
 
 .hljs-attribute {

--- a/src/styles/qtcreator_light.css
+++ b/src/styles/qtcreator_light.css
@@ -58,6 +58,7 @@ Qt Creator light color scheme
 
 .hljs-variable,
 .hljs-params,
+.hljs-title-class,
 .hljs-class .hljs-title {
   color: #0055AF;
 }

--- a/src/styles/rainbow.css
+++ b/src/styles/rainbow.css
@@ -49,7 +49,7 @@ Style with support for rainbow parens
 .hljs-variable,
 .hljs-template-variable,
 .hljs-selector-id,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title {
    color: #ffcc66;
 }

--- a/src/styles/rainbow.css
+++ b/src/styles/rainbow.css
@@ -49,6 +49,7 @@ Style with support for rainbow parens
 .hljs-variable,
 .hljs-template-variable,
 .hljs-selector-id,
+.hljs-title-class,
 .hljs-class .hljs-title {
    color: #ffcc66;
 }

--- a/src/styles/solarized-dark.css
+++ b/src/styles/solarized-dark.css
@@ -48,7 +48,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #b58900;

--- a/src/styles/solarized-dark.css
+++ b/src/styles/solarized-dark.css
@@ -48,6 +48,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #b58900;

--- a/src/styles/solarized-light.css
+++ b/src/styles/solarized-light.css
@@ -48,7 +48,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #b58900;

--- a/src/styles/solarized-light.css
+++ b/src/styles/solarized-light.css
@@ -48,6 +48,7 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 .hljs-attr,
 .hljs-variable,
 .hljs-template-variable,
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type {
   color: #b58900;

--- a/src/styles/sunburst.css
+++ b/src/styles/sunburst.css
@@ -44,6 +44,7 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
   color: #89bdff;
 }
 
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-doctag {
   text-decoration: underline;

--- a/src/styles/sunburst.css
+++ b/src/styles/sunburst.css
@@ -44,7 +44,7 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
   color: #89bdff;
 }
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-doctag {
   text-decoration: underline;

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -60,7 +60,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 }
 
 
-.hljs-title-class,
+.hljs-title.hljs-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-built_in,

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -60,6 +60,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 }
 
 
+.hljs-title-class,
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-built_in,

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -35,11 +35,11 @@ describe('.highlight()', () => {
     const result = hljs.highlight(code, { language: "java" });
 
     result.value.should.equal(
-      '<span class="hljs-keyword">public</span> <span class="hljs-function">' +
-      '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
+      '<span class="hljs-keyword">public</span> ' +
+      '<span class="hljs-keyword">void</span> <span class="hljs-title hljs-function">moveTo</span>' +
       '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
       '<span class="hljs-type">int</span> y, ' +
-      '<span class="hljs-type">int</span> z)</span></span>;'
+      '<span class="hljs-type">int</span> z)</span>;'
     );
   });
   it('should works without continuation', () => {
@@ -47,11 +47,11 @@ describe('.highlight()', () => {
     const result = hljs.highlight(code, { language: 'java' });
 
     result.value.should.equal(
-      '<span class="hljs-keyword">public</span> <span class="hljs-function">' +
-      '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
+      '<span class="hljs-keyword">public</span> ' +
+      '<span class="hljs-keyword">void</span> <span class="hljs-title hljs-function">moveTo</span>' +
       '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
       '<span class="hljs-type">int</span> y, ' +
-      '<span class="hljs-type">int</span> z)</span></span>;'
+      '<span class="hljs-type">int</span> z)</span>;'
     );
   });
 });

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -35,7 +35,7 @@ describe('.highlight()', () => {
     const result = hljs.highlight(code, { language: "java" });
 
     result.value.should.equal(
-      '<span class="hljs-function"><span class="hljs-keyword">public</span> ' +
+      '<span class="hljs-keyword">public</span> <span class="hljs-function">' +
       '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
       '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
       '<span class="hljs-type">int</span> y, ' +
@@ -47,7 +47,7 @@ describe('.highlight()', () => {
     const result = hljs.highlight(code, { language: 'java' });
 
     result.value.should.equal(
-      '<span class="hljs-function"><span class="hljs-keyword">public</span> ' +
+      '<span class="hljs-keyword">public</span> <span class="hljs-function">' +
       '<span class="hljs-keyword">void</span> <span class="hljs-title">moveTo</span>' +
       '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
       '<span class="hljs-type">int</span> y, ' +

--- a/test/markup/arcade/profile.expect.txt
+++ b/test/markup/arcade/profile.expect.txt
@@ -1,7 +1,7 @@
 <span class="hljs-comment">/*
   Isolated test for the most recent version
 */</span>
-<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">offsetPopulation</span>(<span class="hljs-params">offset</span>)</span>{
+<span class="hljs-keyword">function</span> <span class="hljs-title hljs-function">offsetPopulation</span>(<span class="hljs-params">offset</span>){
    <span class="hljs-keyword">var</span> popDensity = <span class="hljs-built_in">Round</span>( <span class="hljs-symbol">$feature</span>.POPULATION / <span class="hljs-built_in">AreaGeodetic</span>(<span class="hljs-built_in">Geometry</span>(<span class="hljs-symbol">$feature</span>), <span class="hljs-string">&quot;square-kilometers&quot;</span>) );
    <span class="hljs-keyword">var</span> geom = <span class="hljs-built_in">Geometry</span>({ <span class="hljs-string">&#x27;x&#x27;</span>: offset.x, <span class="hljs-string">&#x27;y&#x27;</span>: offset.y, <span class="hljs-string">&#x27;spatialReference&#x27;</span>:{<span class="hljs-string">&#x27;wkid&#x27;</span>:<span class="hljs-number">102100</span>} });
    <span class="hljs-keyword">var</span> myLayer = <span class="hljs-built_in">FeatureSet</span>(<span class="hljs-symbol">$map</span>, [<span class="hljs-string">&quot;POPULATION&quot;</span>, <span class="hljs-string">&quot;ELECTION-DATA&quot;</span>]);

--- a/test/markup/autoit/default.expect.txt
+++ b/test/markup/autoit/default.expect.txt
@@ -5,7 +5,7 @@
 _Singleton(<span class="hljs-symbol">@ScriptName</span>) <span class="hljs-comment">; Allow only one instance</span>
 example(<span class="hljs-number">0</span>, <span class="hljs-number">10</span>)
 
-<span class="hljs-function"><span class="hljs-keyword">Func</span> <span class="hljs-title">example</span><span class="hljs-params">($min, $max)</span></span>
+<span class="hljs-keyword">Func</span> <span class="hljs-title hljs-function">example</span><span class="hljs-params">($min, $max)</span>
 	<span class="hljs-keyword">For</span> $i = $min <span class="hljs-keyword">To</span> $max
 		<span class="hljs-keyword">If</span> <span class="hljs-built_in">Mod</span>($i, <span class="hljs-number">2</span>) == <span class="hljs-number">0</span> <span class="hljs-keyword">Then</span>
 			<span class="hljs-built_in">MsgBox</span>(<span class="hljs-number">64</span>, <span class="hljs-string">&quot;Message&quot;</span>, $i &amp; <span class="hljs-string">&#x27; is even number!&#x27;</span>)

--- a/test/markup/cpp/primitive-types.expect.txt
+++ b/test/markup/cpp/primitive-types.expect.txt
@@ -1,3 +1,3 @@
 <span class="hljs-keyword">const</span> <span class="hljs-keyword">uint64_t</span> MAX_INT_64;
 
-<span class="hljs-keyword">struct</span> <span class="hljs-title hljs-title-class">position_tag</span>;
+<span class="hljs-keyword">struct</span> <span class="hljs-title hljs-class">position_tag</span>;

--- a/test/markup/cpp/primitive-types.expect.txt
+++ b/test/markup/cpp/primitive-types.expect.txt
@@ -1,3 +1,3 @@
 <span class="hljs-keyword">const</span> <span class="hljs-keyword">uint64_t</span> MAX_INT_64;
 
-<span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">position_tag</span>;</span>
+<span class="hljs-keyword">struct</span> <span class="hljs-title hljs-title-class">position_tag</span>;

--- a/test/markup/cpp/template_complexity.expect.txt
+++ b/test/markup/cpp/template_complexity.expect.txt
@@ -1,24 +1,24 @@
-<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">T</span>&gt; <span class="hljs-comment">// comment</span>
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">T</span>&gt; <span class="hljs-comment">// comment</span>
 <span class="hljs-function"><span class="hljs-keyword">auto</span> <span class="hljs-title">foo</span><span class="hljs-params">(T x)</span> </span>{ ... };
 
 <span class="hljs-keyword">namespace</span> impl {
     <span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt;
-    <span class="hljs-keyword">struct</span> <span class="hljs-title hljs-title-class">is_streamable</span>&lt;T, std::<span class="hljs-keyword">void_t</span>&lt;<span class="hljs-keyword">decltype</span>(std::declval&lt;std::wostream &amp;&gt;() &lt;&lt; std::declval&lt;T&gt;())&gt;&gt; : std::true_type { };
+    <span class="hljs-keyword">struct</span> <span class="hljs-title hljs-class">is_streamable</span>&lt;T, std::<span class="hljs-keyword">void_t</span>&lt;<span class="hljs-keyword">decltype</span>(std::declval&lt;std::wostream &amp;&gt;() &lt;&lt; std::declval&lt;T&gt;())&gt;&gt; : std::true_type { };
 }
 
 <span class="hljs-comment">// Disable overload for already valid operands.</span>
-<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">T</span>, class = std::<span class="hljs-keyword">enable_if_t</span>&lt;!impl::is_streamable_v&lt;<span class="hljs-keyword">const</span> T &amp;&gt; &amp;&amp; std::is_convertible_v&lt;<span class="hljs-keyword">const</span> T &amp;, std::wstring_view&gt;&gt;&gt;
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">T</span>, class = std::<span class="hljs-keyword">enable_if_t</span>&lt;!impl::is_streamable_v&lt;<span class="hljs-keyword">const</span> T &amp;&gt; &amp;&amp; std::is_convertible_v&lt;<span class="hljs-keyword">const</span> T &amp;, std::wstring_view&gt;&gt;&gt;
 std::wostream &amp;<span class="hljs-keyword">operator</span> &lt;&lt;(std::wostream &amp;stream, <span class="hljs-keyword">const</span> T &amp;thing)
 {
     <span class="hljs-keyword">return</span> stream &lt;&lt; <span class="hljs-keyword">static_cast</span>&lt;std::wstring_view&gt;(thing);
 }
 
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">struct</span></span> DataHolder { };
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">class</span></span> DataThingy { };
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">class</span></span> Boolean : <span class="hljs-keyword">char</span> {
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">struct</span></span> DataHolder { };
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">class</span></span> DataThingy { };
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">class</span></span> Boolean : <span class="hljs-keyword">char</span> {
     True, False, FileNotFound
 };
 
-<span class="hljs-keyword">union</span> <span class="hljs-title hljs-title-class">Soy</span>
+<span class="hljs-keyword">union</span> <span class="hljs-title hljs-class">Soy</span>
 {
 };

--- a/test/markup/cpp/template_complexity.expect.txt
+++ b/test/markup/cpp/template_complexity.expect.txt
@@ -1,24 +1,24 @@
-<span class="hljs-keyword">template</span> &lt;<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">T</span>&gt;</span> <span class="hljs-comment">// comment</span>
+<span class="hljs-keyword">template</span> &lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">T</span>&gt; <span class="hljs-comment">// comment</span>
 <span class="hljs-function"><span class="hljs-keyword">auto</span> <span class="hljs-title">foo</span><span class="hljs-params">(T x)</span> </span>{ ... };
 
 <span class="hljs-keyword">namespace</span> impl {
     <span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">typename</span> T&gt;
-    <span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">is_streamable</span>&lt;</span>T, std::<span class="hljs-keyword">void_t</span>&lt;<span class="hljs-keyword">decltype</span>(std::declval&lt;std::wostream &amp;&gt;() &lt;&lt; std::declval&lt;T&gt;())&gt;&gt; : std::true_type { };
+    <span class="hljs-keyword">struct</span> <span class="hljs-title hljs-title-class">is_streamable</span>&lt;T, std::<span class="hljs-keyword">void_t</span>&lt;<span class="hljs-keyword">decltype</span>(std::declval&lt;std::wostream &amp;&gt;() &lt;&lt; std::declval&lt;T&gt;())&gt;&gt; : std::true_type { };
 }
 
 <span class="hljs-comment">// Disable overload for already valid operands.</span>
-<span class="hljs-keyword">template</span>&lt;<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">T</span>, <span class="hljs-keyword">class</span> =</span> std::<span class="hljs-keyword">enable_if_t</span>&lt;!impl::is_streamable_v&lt;<span class="hljs-keyword">const</span> T &amp;&gt; &amp;&amp; std::is_convertible_v&lt;<span class="hljs-keyword">const</span> T &amp;, std::wstring_view&gt;&gt;&gt;
+<span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">T</span>, class = std::<span class="hljs-keyword">enable_if_t</span>&lt;!impl::is_streamable_v&lt;<span class="hljs-keyword">const</span> T &amp;&gt; &amp;&amp; std::is_convertible_v&lt;<span class="hljs-keyword">const</span> T &amp;, std::wstring_view&gt;&gt;&gt;
 std::wostream &amp;<span class="hljs-keyword">operator</span> &lt;&lt;(std::wostream &amp;stream, <span class="hljs-keyword">const</span> T &amp;thing)
 {
     <span class="hljs-keyword">return</span> stream &lt;&lt; <span class="hljs-keyword">static_cast</span>&lt;std::wstring_view&gt;(thing);
 }
 
-<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-keyword">struct</span> <span class="hljs-title">DataHolder</span> {</span> };
-<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-keyword">class</span> <span class="hljs-title">DataThingy</span> {</span> };
-<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Boolean</span> :</span> <span class="hljs-keyword">char</span> {
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">struct</span></span> DataHolder { };
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">class</span></span> DataThingy { };
+<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-title-class"><span class="hljs-keyword">class</span></span> Boolean : <span class="hljs-keyword">char</span> {
     True, False, FileNotFound
 };
 
-<span class="hljs-class"><span class="hljs-keyword">union</span> <span class="hljs-title">Soy</span>
-{</span>
+<span class="hljs-keyword">union</span> <span class="hljs-title hljs-title-class">Soy</span>
+{
 };

--- a/test/markup/index.js
+++ b/test/markup/index.js
@@ -31,7 +31,7 @@ function testLanguage(language, {testDir}) {
 
           // Uncomment this for major changes that rewrite the test expectations
           // which will then need to be manually compared by hand of course
-          require('fs').writeFileSync(filename, actual);
+          // require('fs').writeFileSync(filename, actual);
 
           actual.trim().should.equal(expected.trim());
           done();

--- a/test/markup/index.js
+++ b/test/markup/index.js
@@ -31,7 +31,7 @@ function testLanguage(language, {testDir}) {
 
           // Uncomment this for major changes that rewrite the test expectations
           // which will then need to be manually compared by hand of course
-          // require('fs').writeFileSync(filename, actual);
+          require('fs').writeFileSync(filename, actual);
 
           actual.trim().should.equal(expected.trim());
           done();

--- a/test/markup/java/annotations.expect.txt
+++ b/test/markup/java/annotations.expect.txt
@@ -4,9 +4,9 @@
 <span class="hljs-meta">@Slf4j</span>
 <span class="hljs-meta">@RunWith(SpringRunner.class)</span>
 <span class="hljs-meta">@Something(1+(3+4))</span>
-<span class="hljs-keyword">public</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">BoardControllerTest</span> </span>{
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">BoardControllerTest</span> {
 }
 
-<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Example</span> </span>{
+<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">Example</span> {
   <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> bar)</span> </span>{ }
 }

--- a/test/markup/java/annotations.expect.txt
+++ b/test/markup/java/annotations.expect.txt
@@ -4,9 +4,9 @@
 <span class="hljs-meta">@Slf4j</span>
 <span class="hljs-meta">@RunWith(SpringRunner.class)</span>
 <span class="hljs-meta">@Something(1+(3+4))</span>
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">BoardControllerTest</span> {
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">BoardControllerTest</span> {
 }
 
-<span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">Example</span> {
-  <span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> bar)</span> </span>{ }
+<span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">Example</span> {
+  <span class="hljs-keyword">void</span> <span class="hljs-title hljs-function">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> bar)</span> { }
 }

--- a/test/markup/java/functions.expect.txt
+++ b/test/markup/java/functions.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;A,B,C&gt; <span class="hljs-function">Tuple&lt;A,B,C&gt; <span class="hljs-title">fun</span><span class="hljs-params">(Future&lt;Tuple&lt;A,B,C&gt;&gt; future)</span> <span class="hljs-keyword">throws</span> Exceptions </span>{
 }
 
-<span class="hljs-function"><span class="hljs-keyword">static</span> Optional&lt;List&lt;Token&gt;&gt; <span class="hljs-title">parseAll</span><span class="hljs-params">(String s)</span> </span>{
+<span class="hljs-keyword">static</span> <span class="hljs-function">Optional&lt;List&lt;Token&gt;&gt; <span class="hljs-title">parseAll</span><span class="hljs-params">(String s)</span> </span>{
 }

--- a/test/markup/java/functions.expect.txt
+++ b/test/markup/java/functions.expect.txt
@@ -1,5 +1,5 @@
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;A,B,C&gt; <span class="hljs-function">Tuple&lt;A,B,C&gt; <span class="hljs-title">fun</span><span class="hljs-params">(Future&lt;Tuple&lt;A,B,C&gt;&gt; future)</span> <span class="hljs-keyword">throws</span> Exceptions </span>{
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;A,B,C&gt; Tuple&lt;A,B,C&gt; <span class="hljs-title hljs-function">fun</span><span class="hljs-params">(Future&lt;Tuple&lt;A,B,C&gt;&gt; future)</span> <span class="hljs-keyword">throws</span> Exceptions {
 }
 
-<span class="hljs-keyword">static</span> <span class="hljs-function">Optional&lt;List&lt;Token&gt;&gt; <span class="hljs-title">parseAll</span><span class="hljs-params">(String s)</span> </span>{
+<span class="hljs-keyword">static</span> Optional&lt;List&lt;Token&gt;&gt; <span class="hljs-title hljs-function">parseAll</span><span class="hljs-params">(String s)</span> {
 }

--- a/test/markup/java/gh1031.expect.txt
+++ b/test/markup/java/gh1031.expect.txt
@@ -1,7 +1,7 @@
-<span class="hljs-keyword">public</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">DefaultDataDaoImpl</span> </span>{
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">DefaultDataDaoImpl</span> {
   <span class="hljs-keyword">private</span> List&lt;AbstractCmrDataProcessor&gt; cmrDataProcessors;
 }
 
-<span class="hljs-keyword">public</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">DefaultDataDaoImpl</span> </span>{
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">DefaultDataDaoImpl</span> {
   <span class="hljs-keyword">private</span> List&lt;AbstractCmrDataProcessor, AbstractCmrDataProcessor&gt; cmrDataProcessors;
 }

--- a/test/markup/java/gh1031.expect.txt
+++ b/test/markup/java/gh1031.expect.txt
@@ -1,7 +1,7 @@
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">DefaultDataDaoImpl</span> {
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">DefaultDataDaoImpl</span> {
   <span class="hljs-keyword">private</span> List&lt;AbstractCmrDataProcessor&gt; cmrDataProcessors;
 }
 
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">DefaultDataDaoImpl</span> {
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">DefaultDataDaoImpl</span> {
   <span class="hljs-keyword">private</span> List&lt;AbstractCmrDataProcessor, AbstractCmrDataProcessor&gt; cmrDataProcessors;
 }

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-keyword">public</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> </span>{
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">Greet</span> {
     <span class="hljs-function"><span class="hljs-keyword">public</span> Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> </span>{
         <span class="hljs-keyword">new</span> Type();
         <span class="hljs-keyword">if</span> (val) {

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -1,6 +1,6 @@
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">Greet</span> {
-    <span class="hljs-keyword">public</span> <span class="hljs-function">Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> </span>{
-        <span class="hljs-keyword">new</span> <span class="hljs-title hljs-title-class">Type</span>();
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-class">Greet</span> {
+    <span class="hljs-keyword">public</span> Either&lt;Integer, String&gt; <span class="hljs-title hljs-function">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> {
+        <span class="hljs-keyword">new</span> <span class="hljs-title hljs-class">Type</span>();
         <span class="hljs-keyword">if</span> (val) {
             <span class="hljs-keyword">return</span> getType();
         } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (!val) {

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title hljs-title-class">Greet</span> {
-    <span class="hljs-function"><span class="hljs-keyword">public</span> Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> </span>{
-        <span class="hljs-keyword">new</span> Type();
+    <span class="hljs-keyword">public</span> <span class="hljs-function">Either&lt;Integer, String&gt; <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> </span>{
+        <span class="hljs-keyword">new</span> <span class="hljs-title hljs-title-class">Type</span>();
         <span class="hljs-keyword">if</span> (val) {
             <span class="hljs-keyword">return</span> getType();
         } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (!val) {

--- a/test/markup/rust/traits.expect.txt
+++ b/test/markup/rust/traits.expect.txt
@@ -1,3 +1,3 @@
-<span class="hljs-function"><span class="hljs-keyword">fn</span> <span class="hljs-title">sqr</span></span>(i: <span class="hljs-built_in">i32</span>) { i * i }
-<span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">Minimum</span></span> : <span class="hljs-built_in">Copy</span> {}
-<span class="hljs-keyword">pub</span> <span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">Builder</span></span> <span class="hljs-keyword">where</span> <span class="hljs-keyword">Self</span>: <span class="hljs-built_in">Sized</span> + <span class="hljs-built_in">Iterator</span>&lt;Item=Event&gt; {}
+<span class="hljs-keyword">fn</span> <span class="hljs-title hljs-function">sqr</span>(i: <span class="hljs-type">i32</span>) { i * i }
+<span class="hljs-keyword">trait</span> <span class="hljs-title hljs-class">Minimum</span> : <span class="hljs-built_in">Copy</span> {}
+<span class="hljs-keyword">pub</span> <span class="hljs-keyword">trait</span> <span class="hljs-title hljs-class">Builder</span> <span class="hljs-keyword">where</span> <span class="hljs-keyword">Self</span>: <span class="hljs-built_in">Sized</span> + <span class="hljs-built_in">Iterator</span>&lt;Item=Event&gt; {}

--- a/test/markup/rust/types.expect.txt
+++ b/test/markup/rust/types.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-title">A</span></span>: Trait;
-<span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-title">A</span></span>;
-<span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-title">A</span></span> = B;
-<span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-title">R</span></span>&lt;T&gt; = m::R&lt;T, ConcreteError&gt;
+<span class="hljs-keyword">type</span> <span class="hljs-title hljs-class">A</span>: Trait;
+<span class="hljs-keyword">type</span> <span class="hljs-title hljs-class">A</span>;
+<span class="hljs-keyword">type</span> <span class="hljs-title hljs-class">A</span> = B;
+<span class="hljs-keyword">type</span> <span class="hljs-title hljs-class">R</span>&lt;T&gt; = m::R&lt;T, ConcreteError&gt;

--- a/test/markup/rust/variables.expect.txt
+++ b/test/markup/rust/variables.expect.txt
@@ -1,3 +1,3 @@
-<span class="hljs-keyword">let</span> foo;
-<span class="hljs-keyword">let</span> <span class="hljs-keyword">mut</span> bar;
-<span class="hljs-keyword">let</span> _foo_bar;
+<span class="hljs-keyword">let</span> <span class="hljs-variable">foo</span>;
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">mut </span><span class="hljs-variable">bar</span>;
+<span class="hljs-keyword">let</span> <span class="hljs-variable">_foo_bar</span>;

--- a/test/markup/sas/default.expect.txt
+++ b/test/markup/sas/default.expect.txt
@@ -28,11 +28,11 @@ data </span>testing;
     <span class="hljs-keyword">end</span>;
 <span class="hljs-keyword">run;</span>
 
-<span class="hljs-built_in">%macro</span> <span class="hljs-title.function">testMacro</span>(positional, named = value);
+<span class="hljs-built_in">%macro</span> <span class="hljs-title hljs-function">testMacro</span>(positional, named = value);
     <span class="hljs-built_in">%put</span> positional = <span class="hljs-variable">&amp;positional.</span>;
     <span class="hljs-built_in">%put</span> named      = <span class="hljs-variable">&amp;named.</span>;
-<span class="hljs-built_in">%mend</span> <span class="hljs-title.function">testMacro</span>;
-<span class="hljs-title.function">%testMacro</span>(positional, named = value);
+<span class="hljs-built_in">%mend</span> <span class="hljs-title hljs-function">testMacro</span>;
+<span class="hljs-title hljs-function">%testMacro</span>(positional, named = value);
 
 <span class="hljs-keyword">dm</span> <span class="hljs-string">&#x27;clear log output odsresults&#x27;</span>;
 <span class="hljs-keyword">

--- a/test/parser/should-not-destroyData.js
+++ b/test/parser/should-not-destroyData.js
@@ -33,7 +33,7 @@ describe("parser/should not destroy data", function () {
       should(() => {
         hljs.highlight('The number is 123_longint yes.', {language: 'test-language'}).value
        }).throw(Error, {
-         message: "0 width match regex",
+         message: /0 width match regex/,
          languageName: "test-language"})
     })
   })

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -299,7 +299,7 @@
           // update data-klass post-render for cool class previews
           this.$nextTick(() => {
             $(".hljs span").each((_,el) => {
-              $(el).attr("data-klass", el.className.replace("hljs-",""))
+              $(el).attr("data-klass", el.className.replace(/hljs-/g,""))
             })
           })
         }


### PR DESCRIPTION
Resolves #2736.   Resolves #2520. Resolves #3112.

### Changes

- Adds new `beforeMatch` compiler extension
- (cpp) Simplified struct/class/enum/union matcher
- (java) Simplified class interface enum matcher
- adds `title.class` sub-scope support. Related #2521.

Seems to do about as well as GitHub now.

<img width="664" alt="Screen Shot 2021-03-26 at 12 39 58 PM" src="https://user-images.githubusercontent.com/6473/112664511-6b050e80-8e30-11eb-853d-b5a89cad0c71.png">


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] docs for `beforeMatch`
- [x] Updated the changelog at `CHANGES.md`