### PR TITLE
(chore) throttle deprecation messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,11 @@
 - enh(nginx) improving highlighting of some sections [Josh Goebel][]
 - fix(vim) variable names may not be zero length [Josh Goebel][]
 - enh(sqf) Updated keywords to Arma 3 v2.02 (#3084) [R3voA3][]
+- (chore) throttle deprecation messages (#3092) [Mihkel Eidast][]
 
 New Languages:
 
-- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]  
+- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]
 
 Theme Improvements:
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -6,7 +6,7 @@ https://github.com/highlightjs/highlight.js/issues/2880#issuecomment-747275419
 */
 
 /**
- * @type {Object.<string, boolean>}
+ * @type {Record<string, boolean>}
  */
 const seenDeprecations = {};
 
@@ -37,8 +37,8 @@ export const notice = (message) => {
  * @param {string} message
  */
 export const deprecated = (version, message) => {
-  if (!seenDeprecations[`${version}-${message}`]) {
-    console.log(`Deprecated as of ${version}. ${message}`);
-    seenDeprecations[`${version}-${message}`] = true;
-  }
+  if (seenDeprecations[`${version}/${message}`]) return;
+
+  console.log(`Deprecated as of ${version}. ${message}`);
+  seenDeprecations[`${version}/${message}`] = true;
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -6,6 +6,11 @@ https://github.com/highlightjs/highlight.js/issues/2880#issuecomment-747275419
 */
 
 /**
+ * @type {Object.<string, boolean>}
+ */
+const seenDeprecations = {};
+
+/**
  * @param {string} message
  */
 export const error = (message) => {
@@ -32,5 +37,8 @@ export const notice = (message) => {
  * @param {string} message
  */
 export const deprecated = (version, message) => {
-  console.log(`Deprecated as of ${version}. ${message}`);
+  if (!seenDeprecations[`${version}-${message}`]) {
+    console.log(`Deprecated as of ${version}. ${message}`);
+    seenDeprecations[`${version}-${message}`] = true;
+  }
 };


### PR DESCRIPTION
Resolves #3069.

### Changes

I've added a simple object map to keep track of already logged deprecations so they would not be logged multiple times.

I've manually tested that the following code now only logs one deprecation message:
```js
function highlight(code) {
  return hljs.highlight("java", code, false);
}

highlight(code);
highlight(code);
highlight(code);
```

### Checklist
- [x] Added markup tests, or they don't apply here because... does not change markup. could not find any existing logger tests so did not add any either.
- [x] Updated the changelog at `CHANGES.md`
