### PR TITLE
Markdown: don't allow inlines to break out of their containing block

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -159,8 +159,8 @@ export default function(hljs) {
         ]
       },
       {
-        begin: '(^|[^a-zA-Z_])__',
-        end: '__(?=[^a-zA-Z])',
+        begin: '(^|\\s)__',
+        end: '__(?=\\s)',
         returnBegin: true,
         contains: [
           {
@@ -190,8 +190,8 @@ export default function(hljs) {
         ]
       },
       {
-        begin: '(^|[^a-zA-Z_])_(?!_)',
-        end: '_(?=[^a-zA-Z])',
+        begin: '(^|\\s)_(?!_)',
+        end: '_(?=\\s)',
         returnBegin: true,
         contains: [
           {
@@ -214,8 +214,8 @@ export default function(hljs) {
         end: '\\*\\*'
       },
       {
-        begin: '(^|[^a-zA-Z])__',
-        end: '__(?=[^a-zA-Z])',
+        begin: '(^|\\s)__',
+        end: '__(?=\\s)',
         returnBegin: true,
         contains: [
           {
@@ -238,8 +238,8 @@ export default function(hljs) {
         end: '\\*',
       },
       {
-        begin: '(^|[^a-zA-Z])_(?!_)',
-        end: '_(?=[^a-zA-Z])',
+        begin: '(^|\\s)_(?!_)',
+        end: '_(?=\\s)',
         returnBegin: true,
         contains: [
           {

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -6,7 +6,7 @@
 <span class="hljs-strong">__Bold <span class="hljs-emphasis">*then italic*</span>__</span>
 <span class="hljs-strong">**Bold <span class="hljs-emphasis">_then italic_</span>**</span>
 <span class="hljs-strong">**Bold and <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">br</span>/&gt;</span></span>**</span>
-<span class="hljs-strong">**<span class="hljs-emphasis">_[<span class="hljs-string">this</span>](<span class="hljs-link">https://google.com</span>)_</span>**</span>
+<span class="hljs-strong">** <span class="hljs-emphasis">_[<span class="hljs-string">this</span>](<span class="hljs-link">https://google.com</span>)_</span> **</span>
 
 <span class="hljs-quote">&gt; quoted <span class="hljs-strong">**Bold <span class="hljs-emphasis">_then italic_</span>**</span></span>
 <span class="hljs-quote">&gt; <span class="hljs-emphasis">_[<span class="hljs-string">this</span>](<span class="hljs-link">https://google.com</span>)_</span></span>
@@ -16,3 +16,17 @@
 
 <span class="hljs-bullet">*</span> list with a <span class="hljs-emphasis">*italic item*</span>
 <span class="hljs-bullet">*</span> list with a <span class="hljs-strong">**bold item**</span>
+
+Unclosed <span class="hljs-emphasis">_italic
+in paragraph</span>
+
+Unclosed <span class="hljs-strong">__bold
+in paragraph</span>
+
+<span class="hljs-bullet">*</span> Unclosed <span class="hljs-emphasis">_italic
+in list</span>
+<span class="hljs-bullet">*</span> Unclosed <span class="hljs-emphasis">_bold
+in list</span>
+
+underscore_in_word
+italic<span class="hljs-emphasis">*in*</span>word

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -29,4 +29,13 @@ in list</span>
 in list</span>
 
 underscore_in_word
+
+underscore <span class="hljs-emphasis">_in_word</span>
+
+underscore_in_ word
+
 italic<span class="hljs-emphasis">*in*</span>word
+
+italic <span class="hljs-emphasis">*in*</span>word
+
+italic<span class="hljs-emphasis">*in*</span> word

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -29,4 +29,13 @@ in list
 in list
 
 underscore_in_word
+
+underscore _in_word
+
+underscore_in_ word
+
 italic*in*word
+
+italic *in*word
+
+italic*in* word

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -6,7 +6,7 @@ __Bold__
 __Bold *then italic*__
 **Bold _then italic_**
 **Bold and <br/>**
-**_[this](https://google.com)_**
+** _[this](https://google.com)_ **
 
 > quoted **Bold _then italic_**
 > _[this](https://google.com)_
@@ -16,3 +16,17 @@ __Bold *then italic*__
 
 * list with a *italic item*
 * list with a **bold item**
+
+Unclosed _italic
+in paragraph
+
+Unclosed __bold
+in paragraph
+
+* Unclosed _italic
+in list
+* Unclosed _bold
+in list
+
+underscore_in_word
+italic*in*word

--- a/test/markup/markdown/code.expect.txt
+++ b/test/markup/markdown/code.expect.txt
@@ -7,9 +7,7 @@ var code = true;
 ```</span>
 
 <span class="hljs-code">````md
-```
 a = &#x27;This is a code block in python&#x27;
-```
 ````</span>
 
 <span class="hljs-code">~~~

--- a/test/markup/markdown/code.txt
+++ b/test/markup/markdown/code.txt
@@ -7,9 +7,7 @@ var code = true;
 ```
 
 ````md
-```
 a = 'This is a code block in python'
-```
 ````
 
 ~~~


### PR DESCRIPTION
I was running into this issue where an underscore in a url would cause the rest of the markdown document to appear in italics. And double line breaks, headers, etc. would not automatically close it. The main goal of this PR is to fix that and a couple other minor things.

### Changes
* Split the CODE mode into separate modes for inline (CODE_SPAN) and blocks (FENCED_CODE, INDENTED_CODE).
* Enable `endsWithParent: true` on all inline elements (INLINE_HTML, LINK, CODE_SPAN, BOLD, ITALIC) and remove them from the top level mode.
     * However `endsWithParent` does not seem to work when the mode is used inside multiple other modes, so do a deepCopy of all the inline modes before using them. I'm totally open to other ways to workaround this. I'm not familiar with JS enough to know what the right approach here is.
     * Convert the inline modes from using regex literals to strings in order to do the copy.
* Add a new default `Paragraph` mode which contains the inline elements. The Paragraph mode as well as the List mode ends whenever it recognizes the beginning of any of the other top level modes.
* Update italics/bold so that underscore is not allowed within words https://spec.commonmark.org/0.29/#example-359.
* Added a ITALICS_CHILD and BOLD_CHILD mode that only appears inside of ITALICS and BOLD. This is to handle edge cases around nesting italics/bold.
* Updated the top level modes (BLANK_LINE, BLOCKQUOTE, HEADER, HORIZONTAL_RULE, FENCED_CODE, LINK_REFERENCE, LIST, INDENTED_CODE, PARAGRAPH) to begin/end at the beginning/ending of lines. Also updated them to accept unlimited white space in the front because they can all be nested inside of a list.
* Updated the horizontal rule to better match https://spec.commonmark.org/0.29/#thematic-break

There is a failing test in `/test/markup/dart/comment-markdown.txt`. The asterisks get read as italics instead of a bulleted list. Removing the `/// ` it parses correctly as markdown, but as part of a dart it doesn't work for some reason. I couldn't figure out how to fix it. I'm thinking it has to due with newlines? Would appreciate help as to how to fix that test.

```
/// text.
/// * bullet
///   * sub-bullet
```

Had to tweak a couple of the markdown tests. `**_` doesn't work anymore for bold + italics, because of the way it checks if the underscore is inside a word. Also the nested code blocks doesn't work... that seems like a small edge case though.  I think overall it is an improvement.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
