### PR TITLE
enh(nim) highlight types properly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,11 @@
 - enh(nginx) improving highlighting of some sections [Josh Goebel][]
 - fix(vim) variable names may not be zero length [Josh Goebel][]
 - enh(sqf) Updated keywords to Arma 3 v2.02 (#3084) [R3voA3][]
+- enh(nim) highlight types properly (not as built-ins) [Josh Goebel][]
 
 New Languages:
 
-- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]  
+- Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]
 
 Theme Improvements:
 

--- a/src/languages/nim.js
+++ b/src/languages/nim.js
@@ -6,7 +6,7 @@ Category: system
 */
 
 export default function(hljs) {
-  const BUILT_INS = [
+  const TYPES = [
     "int",
     "int8",
     "int16",
@@ -82,6 +82,7 @@ export default function(hljs) {
     "from",
     "func",
     "generic",
+    "guarded",
     "if",
     "import",
     "in",
@@ -107,6 +108,7 @@ export default function(hljs) {
     "raise",
     "ref",
     "return",
+    "shared",
     "shl",
     "shr",
     "static",
@@ -123,13 +125,13 @@ export default function(hljs) {
     "xor",
     "yield"
   ];
-  const LITERALS = [
-    "shared",
-    "guarded",
+  const BUILT_INS = [
     "stdin",
     "stdout",
     "stderr",
-    "result",
+    "result"
+  ];
+  const LITERALS = [
     "true",
     "false"
   ];
@@ -138,6 +140,7 @@ export default function(hljs) {
     keywords: {
       keyword: KEYWORDS,
       literal: LITERALS,
+      type: TYPES,
       built_in: BUILT_INS
     },
     contains: [

--- a/test/markup/nim/default.expect.txt
+++ b/test/markup/nim/default.expect.txt
@@ -3,7 +3,7 @@
 
 <span class="hljs-keyword">type</span>
   <span class="hljs-type">TFoo</span> = <span class="hljs-keyword">object</span> <span class="hljs-comment">## Doc comment</span>
-    a: <span class="hljs-built_in">int32</span>
+    a: <span class="hljs-type">int32</span>
   <span class="hljs-type">PFoo</span> = <span class="hljs-keyword">ref</span> <span class="hljs-type">TFoo</span>
 
 <span class="hljs-keyword">proc</span> do_stuff314(param_1: <span class="hljs-type">TFoo</span>, par2am: <span class="hljs-keyword">var</span> <span class="hljs-type">PFoo</span>): <span class="hljs-type">PFoo</span> <span class="hljs-meta">{.exportc: &quot;dostuff&quot; .}</span> =
@@ -12,10 +12,10 @@
   dfag
 sdfg&quot;&quot;
 &quot;&quot;&quot;</span>
-  <span class="hljs-literal">result</span> = <span class="hljs-keyword">nil</span>
+  <span class="hljs-built_in">result</span> = <span class="hljs-keyword">nil</span>
 
 <span class="hljs-keyword">method</span> abc(a: <span class="hljs-type">TFoo</span>) = <span class="hljs-keyword">discard</span> <span class="hljs-number">1u32</span> + <span class="hljs-number">0xabcdefABCDEFi32</span> + <span class="hljs-number">0o01234567i8</span> + <span class="hljs-number">0b010</span>
 
 <span class="hljs-keyword">discard</span> <span class="hljs-string">rawstring&quot;asdf&quot;&quot;adfa&quot;</span>
 <span class="hljs-keyword">var</span> normalstring = <span class="hljs-string">&quot;asdf&quot;</span>
-<span class="hljs-keyword">let</span> a: <span class="hljs-built_in">uint32</span> = <span class="hljs-number">0xFFaF&#x27;u32</span>
+<span class="hljs-keyword">let</span> a: <span class="hljs-type">uint32</span> = <span class="hljs-number">0xFFaF&#x27;u32</span>


### PR DESCRIPTION
Resolves #3086.

- moves most types into `types`
- moves `stderr` and similar to built_ins (rather than literals)
- moved `guarded` and `shared` to keywords

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`