### PR TITLE
fix(properties) fix incorrect handling of non-alphanumeric keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version next
 
+- fix(properties) fix incorrect handling of non-alphanumeric keys [Egor Rogov][]
 - enh(parser) Detect comments based on english like text, rather than keyword list [Josh Goebel][]
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
 - enh(shell) consider one space after prompt as part of prompt [Ryan Mulligan][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Version next
 
-- fix(properties) fix incorrect handling of non-alphanumeric keys [Egor Rogov][]
+- chore(properties) disable auto-detection #3102 [Josh Goebel][]
+- fix(properties) fix incorrect handling of non-alphanumeric keys #3102 [Egor Rogov][]
 - enh(parser) Detect comments based on english like text, rather than keyword list [Josh Goebel][]
 - enh(shell) add alias ShellSession [Ryan Mulligan][]
 - enh(shell) consider one space after prompt as part of prompt [Ryan Mulligan][]

--- a/src/languages/properties.js
+++ b/src/languages/properties.js
@@ -5,6 +5,7 @@ Website: https://en.wikipedia.org/wiki/.properties
 Category: common, config
 */
 
+/** @type LanguageFn */
 export default function(hljs) {
   // whitespaces: space, tab, formfeed
   const WS0 = '[ \\t\\f]*';
@@ -37,6 +38,7 @@ export default function(hljs) {
 
   return {
     name: '.properties',
+    disableAutodetect: true,
     case_insensitive: true,
     illegal: /\S/,
     contains: [
@@ -47,20 +49,17 @@ export default function(hljs) {
         returnBegin: true,
         variants: [
           {
-            begin: KEY + EQUAL_DELIM,
-            relevance: 1
+            begin: KEY + EQUAL_DELIM
           },
           {
-            begin: KEY + WS_DELIM,
-            relevance: 0
+            begin: KEY + WS_DELIM
           }
         ],
         contains: [
           {
             className: 'attr',
             begin: KEY,
-            endsParent: true,
-            relevance: 0
+            endsParent: true
           }
         ],
         starts: DELIM_AND_VALUE
@@ -68,7 +67,6 @@ export default function(hljs) {
       // case of an empty key
       {
         className: 'attr',
-        relevance: 0,
         begin: KEY + WS0 + '$'
       }
     ]

--- a/src/languages/properties.js
+++ b/src/languages/properties.js
@@ -6,31 +6,34 @@ Category: common, config
 */
 
 export default function(hljs) {
-
   // whitespaces: space, tab, formfeed
-  var WS0 = '[ \\t\\f]*';
-  var WS1 = '[ \\t\\f]+';
+  const WS0 = '[ \\t\\f]*';
+  const WS1 = '[ \\t\\f]+';
   // delimiter
-  var EQUAL_DELIM = WS0+'[:=]'+WS0;
-  var WS_DELIM = WS1;
-  var DELIM = '(' + EQUAL_DELIM + '|' + WS_DELIM + ')';
-  var KEY = '([^\\\\:= \\t\\f\\n]|\\\\.)+';
+  const EQUAL_DELIM = WS0 + '[:=]' + WS0;
+  const WS_DELIM = WS1;
+  const DELIM = '(' + EQUAL_DELIM + '|' + WS_DELIM + ')';
+  const KEY = '([^\\\\:= \\t\\f\\n]|\\\\.)+';
 
-  var DELIM_AND_VALUE = {
-          // skip DELIM
-          end: DELIM,
-          relevance: 0,
-          starts: {
-            // value: everything until end of line (again, taking into account backslashes)
-            className: 'string',
-            end: /$/,
-            relevance: 0,
-            contains: [
-              { begin: '\\\\\\\\'},
-              { begin: '\\\\\\n' }
-            ]
-          }
-        };
+  const DELIM_AND_VALUE = {
+    // skip DELIM
+    end: DELIM,
+    relevance: 0,
+    starts: {
+      // value: everything until end of line (again, taking into account backslashes)
+      className: 'string',
+      end: /$/,
+      relevance: 0,
+      contains: [
+        {
+          begin: '\\\\\\\\'
+        },
+        {
+          begin: '\\\\\\n'
+        }
+      ]
+    }
+  };
 
   return {
     name: '.properties',
@@ -43,8 +46,14 @@ export default function(hljs) {
       {
         returnBegin: true,
         variants: [
-          { begin: KEY + EQUAL_DELIM, relevance: 1 },
-          { begin: KEY + WS_DELIM, relevance: 0 }
+          {
+            begin: KEY + EQUAL_DELIM,
+            relevance: 1
+          },
+          {
+            begin: KEY + WS_DELIM,
+            relevance: 0
+          }
         ],
         contains: [
           {

--- a/src/languages/properties.js
+++ b/src/languages/properties.js
@@ -14,8 +14,7 @@ export default function(hljs) {
   var EQUAL_DELIM = WS0+'[:=]'+WS0;
   var WS_DELIM = WS1;
   var DELIM = '(' + EQUAL_DELIM + '|' + WS_DELIM + ')';
-  var KEY_ALPHANUM = '([^\\\\\\W:= \\t\\f\\n]|\\\\.)+';
-  var KEY_OTHER = '([^\\\\:= \\t\\f\\n]|\\\\.)+';
+  var KEY = '([^\\\\:= \\t\\f\\n]|\\\\.)+';
 
   var DELIM_AND_VALUE = {
           // skip DELIM
@@ -40,32 +39,17 @@ export default function(hljs) {
     contains: [
       hljs.COMMENT('^\\s*[!#]', '$'),
       // key: everything until whitespace or = or : (taking into account backslashes)
-      // case of a "normal" key
+      // case of a key-value pair
       {
         returnBegin: true,
         variants: [
-          { begin: KEY_ALPHANUM + EQUAL_DELIM, relevance: 1 },
-          { begin: KEY_ALPHANUM + WS_DELIM, relevance: 0 }
+          { begin: KEY + EQUAL_DELIM, relevance: 1 },
+          { begin: KEY + WS_DELIM, relevance: 0 }
         ],
         contains: [
           {
             className: 'attr',
-            begin: KEY_ALPHANUM,
-            endsParent: true,
-            relevance: 0
-          }
-        ],
-        starts: DELIM_AND_VALUE
-      },
-      // case of key containing non-alphanumeric chars => relevance = 0
-      {
-        begin: KEY_OTHER + DELIM,
-        returnBegin: true,
-        relevance: 0,
-        contains: [
-          {
-            className: 'meta',
-            begin: KEY_OTHER,
+            begin: KEY,
             endsParent: true,
             relevance: 0
           }
@@ -76,7 +60,7 @@ export default function(hljs) {
       {
         className: 'attr',
         relevance: 0,
-        begin: KEY_OTHER + WS0 + '$'
+        begin: KEY + WS0 + '$'
       }
     ]
   };


### PR DESCRIPTION
Fixes #3064

### Changes
Removed the special case for non-alphanumeric characters keys, as there are no restrictions for the set of character, and no character has a special meaning (excluding separators of course).

### Checklist
- [X] ~~Added markup tests, or they~~ don't apply here because there is nothing new in markup
- [X] Updated the changelog at `CHANGES.md`
