### PR TITLE
Add ZenScript as a supported language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Grammars:
 New Languages:
 
 - Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]
+- Added 3rd party ZenScript grammar to SUPPORTED_LANGUAGES(#3106) [Jared Luboff][]
 
 Theme Improvements:
 
@@ -33,6 +34,7 @@ Theme Improvements:
 [Ryan Mulligan]: https://github.com/ryantm
 [R3voA3]: https://github.com/R3voA3
 [Wei Su]: https://github.com/swsoyee
+[Jared Luboff]: https://github.com/jaredlll08
 
 ## Version 10.7.1
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -197,7 +197,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | Transact-SQL            | tsql                   | [highlightjs-tsql](https://github.com/highlightjs/highlightjs-tsql) |
 | Twig                    | twig, craftcms         |         |
 | TypeScript              | typescript, ts         |         |
-| Unicorn Rails log       | unicorn-rails-log      | [highlightjs-unicorn-rails-log](https://github.com/sweetppro/highlightjs-unicorn-rails-log)
+| Unicorn Rails log       | unicorn-rails-log      | [highlightjs-unicorn-rails-log](https://github.com/sweetppro/highlightjs-unicorn-rails-log) |
 | VB.Net                  | vbnet, vb              |         |
 | VBA                     | vba                    | [highlightjs-vba](https://github.com/dullin/highlightjs-vba) |
 | VBScript                | vbscript, vbs          |         |
@@ -210,6 +210,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | XL                      | xl, tao                |         |
 | XQuery                  | xquery, xpath, xq      |         |
 | YAML                    | yml, yaml              |         |
+| ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |
 | Zephir                  | zephir, zep            |         |
 <!-- LANGLIST_END -->
 


### PR DESCRIPTION

Adds ZenScript to the list of supported languages.

### Changes
<!--- Describe your changes -->
Adds a row for ZenScript to the table.
Also added a missing `|` to the end of  `highlightjs-unicorn-rails-log`


### Checklist
- [x] Updated the changelog at `CHANGES.md`
