### PR TITLE
chore(themes) remove `builtin-name` CSS class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ New Languages:
 
 Theme Improvements:
 
+- chore(themes) remove `builtin-name` CSS class (#3119) [Josh Goebel][]
 - chore(theme) Update GitHub theme css to match GitHub's current styling (#1616) [Jan Pilzer][]
 
 [Josh Goebel]: https://github.com/joshgoebel

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -86,9 +86,6 @@ your language is not considered a "Markup" language.
 | name                     | name of an XML tag, the first word in an          |
 |                          | s-expression                                      |
 +--------------------------+---------------------------------------------------+
-| builtin-name             | s-expression name from the language standard      |
-|                          | library                                           |
-+--------------------------+---------------------------------------------------+
 | attr                     | name of an attribute with no language defined     |
 |                          | semantics (keys in JSON, setting names in .ini),  |
 |                          | also sub-attribute within another highlighted     |

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -13,7 +13,7 @@ export default function(hljs) {
   const globals = 'def defonce defprotocol defstruct defmulti defmethod defn- defn defmacro deftype defrecord';
   const keywords = {
     $pattern: SYMBOL_RE,
-    'builtin-name':
+    built_in:
       // Clojure keywords
       globals + ' ' +
       'cond apply if-not if-let if not not= =|0 <|0 >|0 <=|0 >=|0 ==|0 +|0 /|0 *|0 -|0 rem ' +

--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -12,7 +12,7 @@ import * as regex from '../lib/regex.js';
 export default function(hljs) {
   const BUILT_INS = {
     $pattern: /[\w.\/]+/,
-    'builtin-name': [
+    built_in: [
       'action',
       'bindattr',
       'collection',

--- a/src/languages/hy.js
+++ b/src/languages/hy.js
@@ -11,7 +11,7 @@ export default function(hljs) {
   const SYMBOL_RE = '[' + SYMBOLSTART + '][' + SYMBOLSTART + '0-9/;:]*';
   const keywords = {
     $pattern: SYMBOL_RE,
-    'builtin-name':
+    built_in:
       // keywords
       '!= % %= & &= * ** **= *= *map ' +
       '+ += , --build-class-- --import-- -= . / // //= ' +

--- a/src/languages/routeros.js
+++ b/src/languages/routeros.js
@@ -160,7 +160,7 @@ export default function(hljs) {
         returnBegin: true,
         contains: [
           {
-            className: 'builtin-name', // 'function',
+            className: 'built_in', // 'function',
             begin: /\w+/
           }
         ]

--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -15,7 +15,7 @@ export default function(hljs) {
   const SCHEME_COMPLEX_NUMBER_RE = SCHEME_SIMPLE_NUMBER_RE + '[+\\-]' + SCHEME_SIMPLE_NUMBER_RE + 'i';
   const KEYWORDS = {
     $pattern: SCHEME_IDENT_RE,
-    'builtin-name':
+    built_in:
       'case-lambda call/cc class define-class exit-handler field import ' +
       'inherit init-field interface let*-values let-values let/ec mixin ' +
       'opt-lambda override protect provide public rename require ' +

--- a/src/styles/a11y-dark.css
+++ b/src/styles/a11y-dark.css
@@ -23,7 +23,6 @@
 /* Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,
@@ -77,7 +76,6 @@
   .hljs-addition,
   .hljs-attribute,
   .hljs-built_in,
-  .hljs-builtin-name,
   .hljs-bullet,
   .hljs-comment,
   .hljs-link,

--- a/src/styles/a11y-light.css
+++ b/src/styles/a11y-light.css
@@ -23,7 +23,6 @@
 /* Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,
@@ -77,7 +76,6 @@
   .hljs-addition,
   .hljs-attribute,
   .hljs-built_in,
-  .hljs-builtin-name,
   .hljs-bullet,
   .hljs-comment,
   .hljs-link,

--- a/src/styles/agate.css
+++ b/src/styles/agate.css
@@ -55,8 +55,7 @@
 .hljs-section,
 .hljs-attribute,
 .hljs-quote,
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #ffa;
 }
 

--- a/src/styles/an-old-hope.css
+++ b/src/styles/an-old-hope.css
@@ -1,4 +1,4 @@
-/* 
+/*
 
 An Old Hope – Star Wars Syntax (c) Gustavo Costa <gusbemacbe@gmail.com>
 Original theme - Ocean Dark Theme – by https://github.com/gavsiu
@@ -8,7 +8,7 @@ Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/Je
 
 /* Death Star Comment */
 .hljs-comment,
-.hljs-quote 
+.hljs-quote
 {
   color: #B6B18B;
 }
@@ -21,7 +21,7 @@ Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/Je
 .hljs-selector-id,
 .hljs-selector-class,
 .hljs-regexp,
-.hljs-deletion 
+.hljs-deletion
 {
   color: #EB3C54;
 }
@@ -29,18 +29,17 @@ Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/Je
 /* Threepio */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,
 .hljs-meta,
-.hljs-link 
+.hljs-link
 {
   color: #E7CE56;
 }
 
 /* Luke Skywalker */
-.hljs-attribute 
+.hljs-attribute
 {
   color: #EE7C2B;
 }
@@ -49,27 +48,27 @@ Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/Je
 .hljs-string,
 .hljs-symbol,
 .hljs-bullet,
-.hljs-addition 
+.hljs-addition
 {
   color: #4FB4D7;
 }
 
 /* Yoda */
 .hljs-title,
-.hljs-section 
+.hljs-section
 {
   color: #78BB65;
 }
 
 /* Mace Windu */
 .hljs-keyword,
-.hljs-selector-tag 
+.hljs-selector-tag
 {
   color: #B45EA4;
 }
 
 /* Millenium Falcon */
-.hljs 
+.hljs
 {
   display: block;
   overflow-x: auto;
@@ -78,12 +77,12 @@ Based on Jesse Leite's Atom syntax theme 'An Old Hope' – https://github.com/Je
   padding: 0.5em;
 }
 
-.hljs-emphasis 
+.hljs-emphasis
 {
   font-style: italic;
 }
 
-.hljs-strong 
+.hljs-strong
 {
   font-weight: bold;
 }

--- a/src/styles/arta.css
+++ b/src/styles/arta.css
@@ -38,7 +38,6 @@ Author: pumbur <pumbur@pumbur.net>
 }
 
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-template-variable,

--- a/src/styles/atelier-cave-dark.css
+++ b/src/styles/atelier-cave-dark.css
@@ -25,7 +25,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-cave-light.css
+++ b/src/styles/atelier-cave-light.css
@@ -27,7 +27,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-dune-dark.css
+++ b/src/styles/atelier-dune-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-dune-light.css
+++ b/src/styles/atelier-dune-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-estuary-dark.css
+++ b/src/styles/atelier-estuary-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-estuary-light.css
+++ b/src/styles/atelier-estuary-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-forest-dark.css
+++ b/src/styles/atelier-forest-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-forest-light.css
+++ b/src/styles/atelier-forest-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-heath-dark.css
+++ b/src/styles/atelier-heath-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-heath-light.css
+++ b/src/styles/atelier-heath-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-lakeside-dark.css
+++ b/src/styles/atelier-lakeside-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-lakeside-light.css
+++ b/src/styles/atelier-lakeside-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-plateau-dark.css
+++ b/src/styles/atelier-plateau-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-plateau-light.css
+++ b/src/styles/atelier-plateau-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-savanna-dark.css
+++ b/src/styles/atelier-savanna-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-savanna-light.css
+++ b/src/styles/atelier-savanna-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-seaside-dark.css
+++ b/src/styles/atelier-seaside-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-seaside-light.css
+++ b/src/styles/atelier-seaside-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-sulphurpool-dark.css
+++ b/src/styles/atelier-sulphurpool-dark.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/atelier-sulphurpool-light.css
+++ b/src/styles/atelier-sulphurpool-light.css
@@ -26,7 +26,6 @@
 .hljs-number,
 .hljs-meta,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/codepen-embed.css
+++ b/src/styles/codepen-embed.css
@@ -24,7 +24,6 @@
 .hljs-meta,
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-params,
 .hljs-symbol,

--- a/src/styles/darcula.css
+++ b/src/styles/darcula.css
@@ -56,7 +56,6 @@ Darcula color scheme from the JetBrains family of IDEs
 .hljs-subst,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-symbol,
 .hljs-selector-id,
 .hljs-selector-attr,

--- a/src/styles/docco.css
+++ b/src/styles/docco.css
@@ -70,8 +70,7 @@ Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine
   color: #990073;
 }
 
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #0086b3;
 }
 

--- a/src/styles/far.css
+++ b/src/styles/far.css
@@ -21,7 +21,6 @@ FAR Style (c) MajestiC <majestic2k@gmail.com>
 .hljs-symbol,
 .hljs-bullet,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-template-tag,
 .hljs-template-variable,
 .hljs-addition {

--- a/src/styles/github.css
+++ b/src/styles/github.css
@@ -13,7 +13,6 @@
   background: #ffffff;
 }
 
-.hljs-builtin-name,
 .hljs-doctag,
 .hljs-keyword,
 .hljs-meta-keyword,

--- a/src/styles/googlecode.css
+++ b/src/styles/googlecode.css
@@ -51,7 +51,6 @@ Google Code style (c) Aahan Krish <geekpanth3r@gmail.com>
 .hljs-type,
 .hljs-attr,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-params {
   color: #606;
 }

--- a/src/styles/gradient-dark.css
+++ b/src/styles/gradient-dark.css
@@ -42,7 +42,7 @@ color:#e7e4eb;
 
 {
   color:#F19FFF;
-  
+
 }
 
 .hljs-keyword,
@@ -83,7 +83,6 @@ color:#e7e4eb;
   color:#E447FF;
 }
 
-.hljs-builtin-name,
 .hljs-built_in,
 .hljs-formula,
 .hljs-name,

--- a/src/styles/gradient-light.css
+++ b/src/styles/gradient-light.css
@@ -42,7 +42,7 @@ color:#01958B;
 
 {
   color:#43449F;
-  
+
 }
 
 .hljs-keyword,
@@ -83,7 +83,6 @@ color:#01958B;
   color:#025C8F;
 }
 
-.hljs-builtin-name,
 .hljs-built_in,
 .hljs-formula,
 .hljs-name,

--- a/src/styles/grayscale.css
+++ b/src/styles/grayscale.css
@@ -71,8 +71,7 @@ grayscale style (c) MY Sun <simonmysun@gmail.com>
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAKElEQVQIW2NkQAO7d+/+z4gsBhJwdXVlhAvCBECKwIIwAbhKZBUwBQA6hBpm5efZsgAAAABJRU5ErkJggg==) repeat;
 }
 
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #000;
   text-decoration: underline;
 }

--- a/src/styles/gruvbox-dark.css
+++ b/src/styles/gruvbox-dark.css
@@ -45,7 +45,6 @@ Gruvbox style (dark) (c) Pavel Pertsev (original style at https://github.com/mor
 }
 
 /* Gruvbox Purple */
-.hljs-builtin-name,
 .hljs-doctag,
 .hljs-literal,
 .hljs-number {

--- a/src/styles/gruvbox-light.css
+++ b/src/styles/gruvbox-light.css
@@ -45,7 +45,6 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 }
 
 /* Gruvbox Purple */
-.hljs-builtin-name,
 .hljs-doctag,
 .hljs-literal,
 .hljs-number {

--- a/src/styles/hopscotch.css
+++ b/src/styles/hopscotch.css
@@ -29,7 +29,6 @@
 /* Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {

--- a/src/styles/hybrid.css
+++ b/src/styles/hybrid.css
@@ -86,7 +86,6 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 /*color: fg_orange*/
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-quote,
 .hljs-section,
 .hljs-selector-class {

--- a/src/styles/kimbie.dark.css
+++ b/src/styles/kimbie.dark.css
@@ -26,7 +26,6 @@
 /* Kimbie Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/kimbie.light.css
+++ b/src/styles/kimbie.light.css
@@ -26,7 +26,6 @@
 /* Kimbie Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/lioshi.css
+++ b/src/styles/lioshi.css
@@ -26,7 +26,6 @@
 /* Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-subst

--- a/src/styles/monokai-sublime.css
+++ b/src/styles/monokai-sublime.css
@@ -66,7 +66,6 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 .hljs-string,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-selector-id,
 .hljs-selector-attr,
 .hljs-selector-pseudo,

--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -42,7 +42,6 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-emphasis,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-addition,

--- a/src/styles/night-owl.css
+++ b/src/styles/night-owl.css
@@ -2,8 +2,8 @@
 
 Night Owl for highlight.js (c) Carl Baxter <carl@cbax.tech>
 
-An adaptation of Sarah Drasner's Night Owl VS Code Theme 
-https://github.com/sdras/night-owl-vscode-theme 
+An adaptation of Sarah Drasner's Night Owl VS Code Theme
+https://github.com/sdras/night-owl-vscode-theme
 
 Copyright (c) 2018 Sarah Drasner
 
@@ -102,8 +102,7 @@ SOFTWARE.
   color: #82b1ff;
 }
 .hljs-tag,
-.hljs-name,
-.hljs-builtin-name {
+.hljs-name {
   color: #7fdbca;
 }
 .hljs-attr {

--- a/src/styles/nnfx-dark.css
+++ b/src/styles/nnfx-dark.css
@@ -57,8 +57,7 @@
 .hljs-title,
 .hljs-symbol,
 .hljs-bullet,
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #d40;
 }
 

--- a/src/styles/nnfx.css
+++ b/src/styles/nnfx.css
@@ -57,8 +57,7 @@
 .hljs-title,
 .hljs-symbol,
 .hljs-bullet,
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #f40;
 }
 

--- a/src/styles/nord.css
+++ b/src/styles/nord.css
@@ -183,10 +183,6 @@ Aurora
   color: #D8DEE9;
 }
 
-.hljs-builtin-name {
-  color: #81A1C1;
-}
-
 .hljs-name {
   color: #81A1C1;
 }

--- a/src/styles/ocean.css
+++ b/src/styles/ocean.css
@@ -23,7 +23,6 @@
 /* Ocean Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/paraiso-dark.css
+++ b/src/styles/paraiso-dark.css
@@ -26,7 +26,6 @@
 /* Paraíso Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/paraiso-light.css
+++ b/src/styles/paraiso-light.css
@@ -26,7 +26,6 @@
 /* Paraíso Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/purebasic.css
+++ b/src/styles/purebasic.css
@@ -61,8 +61,7 @@ NOTE_2:	Color names provided in comments were derived using "Name that Color" on
 .hljs-class,
 .hljs-meta-keyword,
 .hljs-selector-class,
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
 	color: #006666; /* Blue Stone (approx.) */
 	font-weight: bold;
 }

--- a/src/styles/qtcreator_dark.css
+++ b/src/styles/qtcreator_dark.css
@@ -68,7 +68,6 @@ Qt Creator dark color scheme
 .hljs-selector-pseudo,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-template-tag,
 .hljs-template-variable,
 .hljs-addition,

--- a/src/styles/qtcreator_light.css
+++ b/src/styles/qtcreator_light.css
@@ -68,7 +68,6 @@ Qt Creator light color scheme
 .hljs-selector-pseudo,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-template-tag,
 .hljs-template-variable,
 .hljs-addition,

--- a/src/styles/railscasts.css
+++ b/src/styles/railscasts.css
@@ -48,7 +48,6 @@ Railscasts-like style (c) Visoft, Inc. (Damien White)
 .hljs-symbol,
 .hljs-bullet,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-attr,
 .hljs-link {
   color: #6d9cbe;

--- a/src/styles/routeros.css
+++ b/src/styles/routeros.css
@@ -32,13 +32,9 @@
 
 .hljs-attribute {
   color: #0E9A00;
-}    
-
-.hljs-function {
-  color: #99069A;
 }
 
-.hljs-builtin-name {
+.hljs-function {
   color: #99069A;
 }
 

--- a/src/styles/school-book.css
+++ b/src/styles/school-book.css
@@ -35,7 +35,6 @@ School Book style from goldblog.com.ua (c) Zaripov Yura <yur4ik7@ukr.net>
 .hljs-bullet,
 .hljs-attribute,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-addition,
 .hljs-variable,
 .hljs-template-tag,

--- a/src/styles/srcery.css
+++ b/src/styles/srcery.css
@@ -60,7 +60,6 @@ Date: 2020-04-06
 
 .hljs-subst,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-symbol,
 .hljs-selector-id,
 .hljs-selector-attr,

--- a/src/styles/tomorrow-night-blue.css
+++ b/src/styles/tomorrow-night-blue.css
@@ -24,7 +24,6 @@
 /* Tomorrow Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/tomorrow-night-bright.css
+++ b/src/styles/tomorrow-night-bright.css
@@ -23,7 +23,6 @@
 /* Tomorrow Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/tomorrow-night-eighties.css
+++ b/src/styles/tomorrow-night-eighties.css
@@ -23,7 +23,6 @@
 /* Tomorrow Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/tomorrow-night.css
+++ b/src/styles/tomorrow-night.css
@@ -24,7 +24,6 @@
 /* Tomorrow Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/tomorrow.css
+++ b/src/styles/tomorrow.css
@@ -21,7 +21,6 @@
 /* Tomorrow Orange */
 .hljs-number,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params,

--- a/src/styles/vs2015.css
+++ b/src/styles/vs2015.css
@@ -72,8 +72,7 @@
 }
 
 .hljs-attr,
-.hljs-attribute,
-.hljs-builtin-name {
+.hljs-attribute {
   color: #9CDCFE;
 }
 

--- a/src/styles/xcode.css
+++ b/src/styles/xcode.css
@@ -63,7 +63,6 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 .hljs-class .hljs-title,
 .hljs-type,
 .hljs-built_in,
-.hljs-builtin-name,
 .hljs-params {
   color: #5c2699;
 }

--- a/src/styles/xt256.css
+++ b/src/styles/xt256.css
@@ -26,7 +26,6 @@
   font-weight: bold;
 }
 
-.hljs-builtin-name,
 .hljs-type {
   color: #eaeaea;
 }

--- a/src/styles/zenburn.css
+++ b/src/styles/zenburn.css
@@ -58,8 +58,7 @@ based on dark.css by Ivan Sagalaev
 
 .hljs-deletion,
 .hljs-string,
-.hljs-built_in,
-.hljs-builtin-name {
+.hljs-built_in {
   color: #cc9393;
 }
 

--- a/test/markup/clojure/globals_definition.expect.txt
+++ b/test/markup/clojure/globals_definition.expect.txt
@@ -1,18 +1,18 @@
-(<span class="hljs-name"><span class="hljs-builtin-name">ns</span></span> playground
+(<span class="hljs-name"><span class="hljs-built_in">ns</span></span> playground
   (<span class="hljs-symbol">:require</span>
     [clojure.string <span class="hljs-symbol">:as</span> str]))
 
 <span class="hljs-comment">; function</span>
 (<span class="hljs-keyword">defn</span> <span class="hljs-title">clojure-function</span> [args]
-  (<span class="hljs-name"><span class="hljs-builtin-name">let</span></span> [string   <span class="hljs-string">&quot;multiline\nstring&quot;</span>
+  (<span class="hljs-name"><span class="hljs-built_in">let</span></span> [string   <span class="hljs-string">&quot;multiline\nstring&quot;</span>
         regexp   #<span class="hljs-string">&quot;regexp&quot;</span>
         number   <span class="hljs-number">100</span>,<span class="hljs-number">000</span>
         booleans [<span class="hljs-literal">false</span> <span class="hljs-literal">true</span>]
         keyword  <span class="hljs-symbol">::the-keyword</span>]
     <span class="hljs-comment">;; this is comment</span>
-    (<span class="hljs-name"><span class="hljs-builtin-name">if</span></span> <span class="hljs-literal">true</span>
-      (<span class="hljs-name"><span class="hljs-builtin-name">-&gt;&gt;</span></span>
-        (<span class="hljs-name"><span class="hljs-builtin-name">list</span></span> [vector] {<span class="hljs-symbol">:map</span> map} #{&#x27;set})))))
+    (<span class="hljs-name"><span class="hljs-built_in">if</span></span> <span class="hljs-literal">true</span>
+      (<span class="hljs-name"><span class="hljs-built_in">-&gt;&gt;</span></span>
+        (<span class="hljs-name"><span class="hljs-built_in">list</span></span> [vector] {<span class="hljs-symbol">:map</span> map} #{&#x27;set})))))
 
 <span class="hljs-comment">; global</span>
 (<span class="hljs-keyword">def</span> <span class="hljs-title">some-var</span>)
@@ -22,7 +22,7 @@
 (<span class="hljs-keyword">defonce</span> ^<span class="hljs-symbol">:private</span> <span class="hljs-title">another-var</span> #<span class="hljs-string">&quot;foo&quot;</span>)
 
 <span class="hljs-comment">; private function</span>
-(<span class="hljs-keyword">defn-</span> <span class="hljs-title">add</span> [x y] (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> x y))
+(<span class="hljs-keyword">defn-</span> <span class="hljs-title">add</span> [x y] (<span class="hljs-name"><span class="hljs-built_in">+</span></span> x y))
 
 <span class="hljs-comment">; protocols</span>
 (<span class="hljs-keyword">defprotocol</span> <span class="hljs-title">Fly</span>
@@ -31,17 +31,17 @@
 
 (<span class="hljs-keyword">defrecord</span> <span class="hljs-title">Bird</span> [name species]
   Fly
-  (<span class="hljs-name">fly</span> [this] (<span class="hljs-name"><span class="hljs-builtin-name">str</span></span> (<span class="hljs-symbol">:name</span> this) <span class="hljs-string">&quot; flies...&quot;</span>)))
+  (<span class="hljs-name">fly</span> [this] (<span class="hljs-name"><span class="hljs-built_in">str</span></span> (<span class="hljs-symbol">:name</span> this) <span class="hljs-string">&quot; flies...&quot;</span>)))
 
 <span class="hljs-comment">; multimethods</span>
-(<span class="hljs-keyword">defmulti</span> <span class="hljs-title">service-charge</span> (<span class="hljs-name"><span class="hljs-builtin-name">fn</span></span> [acct] [(<span class="hljs-name">account-level</span> acct) (<span class="hljs-symbol">:tag</span> acct)]))
+(<span class="hljs-keyword">defmulti</span> <span class="hljs-title">service-charge</span> (<span class="hljs-name"><span class="hljs-built_in">fn</span></span> [acct] [(<span class="hljs-name">account-level</span> acct) (<span class="hljs-symbol">:tag</span> acct)]))
 (<span class="hljs-keyword">defmethod</span> <span class="hljs-title">service-charge</span> [<span class="hljs-symbol">::acc/Basic</span> <span class="hljs-symbol">::acc/Checking</span>]   [_] <span class="hljs-number">25</span>)
 (<span class="hljs-keyword">defmethod</span> <span class="hljs-title">service-charge</span> [<span class="hljs-symbol">::acc/Basic</span> <span class="hljs-symbol">::acc/Savings</span>]    [_] <span class="hljs-number">10</span>)
 (<span class="hljs-keyword">defmethod</span> <span class="hljs-title">service-charge</span> [<span class="hljs-symbol">::acc/Premium</span> <span class="hljs-symbol">::acc/Account</span>] [_] <span class="hljs-number">0</span>)
 
 <span class="hljs-comment">; macros</span>
 (<span class="hljs-keyword">defmacro</span> <span class="hljs-title">unless</span> [pred a b]
-  `(<span class="hljs-name"><span class="hljs-builtin-name">if</span></span> (<span class="hljs-name"><span class="hljs-builtin-name">not</span></span> ~pred) ~a ~b))
+  `(<span class="hljs-name"><span class="hljs-built_in">if</span></span> (<span class="hljs-name"><span class="hljs-built_in">not</span></span> ~pred) ~a ~b))
 
 (<span class="hljs-name">unless</span> <span class="hljs-literal">false</span> (<span class="hljs-name">println</span> <span class="hljs-string">&quot;Will print&quot;</span>) (<span class="hljs-name">println</span> <span class="hljs-string">&quot;Will not print&quot;</span>))
 
@@ -52,9 +52,9 @@
 <span class="hljs-comment">;; multimethods again</span>
 (<span class="hljs-keyword">defmulti</span> <span class="hljs-title">area</span> class)
 (<span class="hljs-keyword">defmethod</span> <span class="hljs-title">area</span> Circle [c]
-    (<span class="hljs-name"><span class="hljs-builtin-name">*</span></span> Math/PI (<span class="hljs-name"><span class="hljs-builtin-name">*</span></span> (<span class="hljs-name">.radius</span> c) (<span class="hljs-name">.radius</span> c))))
+    (<span class="hljs-name"><span class="hljs-built_in">*</span></span> Math/PI (<span class="hljs-name"><span class="hljs-built_in">*</span></span> (<span class="hljs-name">.radius</span> c) (<span class="hljs-name">.radius</span> c))))
 (<span class="hljs-keyword">defmethod</span> <span class="hljs-title">area</span> Square [s]
-    (<span class="hljs-name"><span class="hljs-builtin-name">*</span></span> (<span class="hljs-name">.length</span> s) (<span class="hljs-name">.width</span> s)))
+    (<span class="hljs-name"><span class="hljs-built_in">*</span></span> (<span class="hljs-name">.length</span> s) (<span class="hljs-name">.width</span> s)))
 
 <span class="hljs-comment">;; create a couple shapes and get their area</span>
 (<span class="hljs-keyword">def</span> <span class="hljs-title">myCircle</span> (<span class="hljs-name">Circle.</span> <span class="hljs-number">10</span>))

--- a/test/markup/clojure/hint_col.expect.txt
+++ b/test/markup/clojure/hint_col.expect.txt
@@ -1,4 +1,4 @@
-(<span class="hljs-name"><span class="hljs-builtin-name">import</span></span> [java.lang.annotation Retention RetentionPolicy Target ElementType]
+(<span class="hljs-name"><span class="hljs-built_in">import</span></span> [java.lang.annotation Retention RetentionPolicy Target ElementType]
         [javax.xml.ws WebServiceRef WebServiceRefs])
 
 (<span class="hljs-name">definterface</span> Foo (<span class="hljs-name">foo</span> []))
@@ -29,6 +29,6 @@
                          (<span class="hljs-name">WebServiceRef</span> {<span class="hljs-symbol">:name</span> <span class="hljs-string">&quot;ethel&quot;</span> <span class="hljs-symbol">:mappedName</span> <span class="hljs-string">&quot;lucy&quot;</span>})]}</span>
        foo [this] <span class="hljs-number">42</span>))
 
-(<span class="hljs-name"><span class="hljs-builtin-name">seq</span></span> (<span class="hljs-name">.getAnnotations</span> Bar))
-(<span class="hljs-name"><span class="hljs-builtin-name">seq</span></span> (<span class="hljs-name">.getAnnotations</span> (<span class="hljs-name">.getField</span> Bar <span class="hljs-string">&quot;b&quot;</span>)))
-(<span class="hljs-name"><span class="hljs-builtin-name">seq</span></span> (<span class="hljs-name">.getAnnotations</span> (<span class="hljs-name">.getMethod</span> Bar <span class="hljs-string">&quot;foo&quot;</span> <span class="hljs-literal">nil</span>)))
+(<span class="hljs-name"><span class="hljs-built_in">seq</span></span> (<span class="hljs-name">.getAnnotations</span> Bar))
+(<span class="hljs-name"><span class="hljs-built_in">seq</span></span> (<span class="hljs-name">.getAnnotations</span> (<span class="hljs-name">.getField</span> Bar <span class="hljs-string">&quot;b&quot;</span>)))
+(<span class="hljs-name"><span class="hljs-built_in">seq</span></span> (<span class="hljs-name">.getAnnotations</span> (<span class="hljs-name">.getMethod</span> Bar <span class="hljs-string">&quot;foo&quot;</span> <span class="hljs-literal">nil</span>)))

--- a/test/markup/handlebars/block-parameters-as.expect.txt
+++ b/test/markup/handlebars/block-parameters-as.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">each</span></span> filter <span class="hljs-keyword">as</span> | value index|}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">each</span></span>}}</span><span class="xml">
+<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">each</span></span> filter <span class="hljs-keyword">as</span> | value index|}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">each</span></span>}}</span><span class="xml">
 
-</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">with</span></span> as <span class="hljs-keyword">as</span> | as |}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">with</span></span>}}</span><span class="xml">
+</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">with</span></span> as <span class="hljs-keyword">as</span> | as |}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">with</span></span>}}</span><span class="xml">
 </span>

--- a/test/markup/handlebars/built-ins.expect.txt
+++ b/test/markup/handlebars/built-ins.expect.txt
@@ -1,12 +1,12 @@
-<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">if</span></span> test}}</span><span class="xml">yes</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">if</span></span>}}</span><span class="xml">
+<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">if</span></span> test}}</span><span class="xml">yes</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">if</span></span>}}</span><span class="xml">
 
-</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">unless</span></span> test}}</span><span class="xml">no</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">unless</span></span>}}</span><span class="xml">
+</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">unless</span></span> test}}</span><span class="xml">no</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">unless</span></span>}}</span><span class="xml">
 
-</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">with</span></span> test}}</span><span class="xml">abc</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">with</span></span>}}</span><span class="xml">
+</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">with</span></span> test}}</span><span class="xml">abc</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">with</span></span>}}</span><span class="xml">
 
-</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">each</span></span> test}}</span><span class="xml">abc</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">each</span></span>}}</span><span class="xml">
+</span><span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">each</span></span> test}}</span><span class="xml">abc</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">each</span></span>}}</span><span class="xml">
 
-</span><span class="hljs-template-variable">{{<span class="hljs-name"><span class="hljs-builtin-name">lookup</span></span> abc}}</span><span class="xml">
+</span><span class="hljs-template-variable">{{<span class="hljs-name"><span class="hljs-built_in">lookup</span></span> abc}}</span><span class="xml">
 
-</span><span class="hljs-template-variable">{{<span class="hljs-name"><span class="hljs-builtin-name">log</span></span> test}}</span><span class="xml">
+</span><span class="hljs-template-variable">{{<span class="hljs-name"><span class="hljs-built_in">log</span></span> test}}</span><span class="xml">
 </span>

--- a/test/markup/handlebars/hashes.expect.txt
+++ b/test/markup/handlebars/hashes.expect.txt
@@ -2,7 +2,7 @@
 
 </span><span class="hljs-template-variable">{{{<span class="hljs-name">helper</span> <span class="hljs-attr">key</span>=value}}}</span><span class="xml">
 
-</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-builtin-name">partial</span></span> <span class="hljs-attr">key</span>=value}}</span><span class="xml">
+</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-built_in">partial</span></span> <span class="hljs-attr">key</span>=value}}</span><span class="xml">
 
 </span><span class="hljs-template-tag">{{#<span class="hljs-name">helper</span> <span class="hljs-attr">key</span>=value}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name">helper</span>}}</span><span class="xml">
 

--- a/test/markup/handlebars/if-else.expect.txt
+++ b/test/markup/handlebars/if-else.expect.txt
@@ -1,7 +1,7 @@
-<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-builtin-name">if</span></span> this.userData.isLoaded}}</span><span class="xml">
+<span class="hljs-template-tag">{{#<span class="hljs-name"><span class="hljs-built_in">if</span></span> this.userData.isLoaded}}</span><span class="xml">
   </span><span class="hljs-template-variable">{{<span class="hljs-name">this.userData.value.userName</span>}}</span><span class="xml">
 </span><span class="hljs-template-tag">{{<span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> this.userData.isError}}</span><span class="xml">
   Whoops, something went wrong!
 </span><span class="hljs-template-tag">{{<span class="hljs-keyword">else</span>}}</span><span class="xml">
   Something else!
-</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-builtin-name">if</span></span>}}</span>
+</span><span class="hljs-template-tag">{{/<span class="hljs-name"><span class="hljs-built_in">if</span></span>}}</span>

--- a/test/markup/handlebars/literals-in-different-places.expect.txt
+++ b/test/markup/handlebars/literals-in-different-places.expect.txt
@@ -6,7 +6,7 @@
 
 </span><span class="hljs-template-tag">{{{{#<span class="hljs-name">helper</span> <span class="hljs-literal">true</span> <span class="hljs-literal">false</span>}}}}</span><span class="xml"> </span><span class="hljs-template-tag">{{{{/<span class="hljs-name">helper</span>}}}}</span><span class="xml">
 
-</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-builtin-name">partial</span></span> <span class="hljs-literal">true</span>}}</span><span class="xml">
+</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-built_in">partial</span></span> <span class="hljs-literal">true</span>}}</span><span class="xml">
 
 </span><span class="hljs-template-variable">{{<span class="hljs-name">helper</span> (<span class="hljs-name">helper</span> <span class="hljs-literal">true</span> <span class="hljs-literal">false</span>)}}</span><span class="xml">
 

--- a/test/markup/handlebars/partial-call.expect.txt
+++ b/test/markup/handlebars/partial-call.expect.txt
@@ -1,2 +1,2 @@
-<span class="hljs-template-variable">{{&gt; <span class="hljs-name"><span class="hljs-builtin-name">partial</span></span>}}</span><span class="xml">
+<span class="hljs-template-variable">{{&gt; <span class="hljs-name"><span class="hljs-built_in">partial</span></span>}}</span><span class="xml">
 </span>

--- a/test/markup/handlebars/sub-expressions.expect.txt
+++ b/test/markup/handlebars/sub-expressions.expect.txt
@@ -6,7 +6,7 @@
 
 </span><span class="hljs-template-tag">{{#<span class="hljs-name">helper</span> (<span class="hljs-name">subExpression</span> <span class="hljs-number">1</span> <span class="hljs-number">2</span>)}}</span><span class="xml"> </span><span class="hljs-template-tag">{{/<span class="hljs-name">helper</span>}}</span><span class="xml">
 
-</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-builtin-name">partial</span></span> (<span class="hljs-name">subExpression</span> <span class="hljs-number">1</span> <span class="hljs-number">2</span>)}}</span><span class="xml">
+</span><span class="hljs-template-variable">{{&gt;<span class="hljs-name"><span class="hljs-built_in">partial</span></span> (<span class="hljs-name">subExpression</span> <span class="hljs-number">1</span> <span class="hljs-number">2</span>)}}</span><span class="xml">
 
 </span><span class="hljs-template-variable">{{<span class="hljs-name">helper</span> <span class="hljs-attr">key</span>=(<span class="hljs-name">subExpression</span> <span class="hljs-number">1</span> <span class="hljs-number">2</span>)}}</span><span class="xml">
 

--- a/test/markup/hy/default.expect.txt
+++ b/test/markup/hy/default.expect.txt
@@ -1,36 +1,36 @@
 <span class="hljs-meta">#!/usr/bin/env hy</span>
 
-(<span class="hljs-name"><span class="hljs-builtin-name">import</span></span> os.path)
+(<span class="hljs-name"><span class="hljs-built_in">import</span></span> os.path)
 
-(<span class="hljs-name"><span class="hljs-builtin-name">import</span></span> hy.compiler)
-(<span class="hljs-name"><span class="hljs-builtin-name">import</span></span> hy.core)
+(<span class="hljs-name"><span class="hljs-built_in">import</span></span> hy.compiler)
+(<span class="hljs-name"><span class="hljs-built_in">import</span></span> hy.core)
 
 
 <span class="hljs-comment">;; absolute path for Hy core</span>
-(<span class="hljs-name"><span class="hljs-builtin-name">setv</span></span> *core-path* (<span class="hljs-name">os.path.dirname</span> hy.core.--file--))
+(<span class="hljs-name"><span class="hljs-built_in">setv</span></span> *core-path* (<span class="hljs-name">os.path.dirname</span> hy.core.--file--))
 
 
-(<span class="hljs-name"><span class="hljs-builtin-name">defn</span></span> collect-macros [collected-names opened-file]
-  (<span class="hljs-name"><span class="hljs-builtin-name">while</span></span> <span class="hljs-literal">True</span>
-    (<span class="hljs-name"><span class="hljs-builtin-name">try</span></span>
-     (<span class="hljs-name"><span class="hljs-builtin-name">let</span></span> [data (<span class="hljs-name"><span class="hljs-builtin-name">read</span></span> opened-file)]
-       (<span class="hljs-name"><span class="hljs-builtin-name">if</span></span> (<span class="hljs-name"><span class="hljs-builtin-name">and</span></span> (<span class="hljs-name"><span class="hljs-builtin-name">in</span></span> (<span class="hljs-name"><span class="hljs-builtin-name">first</span></span> data)
-                    &#x27;(<span class="hljs-name"><span class="hljs-builtin-name">defmacro</span></span> defmacro/g! defn))
-                (<span class="hljs-name"><span class="hljs-builtin-name">not</span></span> (<span class="hljs-name">.startswith</span> (<span class="hljs-name"><span class="hljs-builtin-name">second</span></span> data) <span class="hljs-string">&quot;_&quot;</span>)))
-         (<span class="hljs-name">.add</span> collected-names (<span class="hljs-name"><span class="hljs-builtin-name">second</span></span> data))))
-     (<span class="hljs-name"><span class="hljs-builtin-name">except</span></span> [e EOFError] (<span class="hljs-name"><span class="hljs-builtin-name">break</span></span>)))))
+(<span class="hljs-name"><span class="hljs-built_in">defn</span></span> collect-macros [collected-names opened-file]
+  (<span class="hljs-name"><span class="hljs-built_in">while</span></span> <span class="hljs-literal">True</span>
+    (<span class="hljs-name"><span class="hljs-built_in">try</span></span>
+     (<span class="hljs-name"><span class="hljs-built_in">let</span></span> [data (<span class="hljs-name"><span class="hljs-built_in">read</span></span> opened-file)]
+       (<span class="hljs-name"><span class="hljs-built_in">if</span></span> (<span class="hljs-name"><span class="hljs-built_in">and</span></span> (<span class="hljs-name"><span class="hljs-built_in">in</span></span> (<span class="hljs-name"><span class="hljs-built_in">first</span></span> data)
+                    &#x27;(<span class="hljs-name"><span class="hljs-built_in">defmacro</span></span> defmacro/g! defn))
+                (<span class="hljs-name"><span class="hljs-built_in">not</span></span> (<span class="hljs-name">.startswith</span> (<span class="hljs-name"><span class="hljs-built_in">second</span></span> data) <span class="hljs-string">&quot;_&quot;</span>)))
+         (<span class="hljs-name">.add</span> collected-names (<span class="hljs-name"><span class="hljs-built_in">second</span></span> data))))
+     (<span class="hljs-name"><span class="hljs-built_in">except</span></span> [e EOFError] (<span class="hljs-name"><span class="hljs-built_in">break</span></span>)))))
 
 
-(<span class="hljs-name"><span class="hljs-builtin-name">defmacro</span></span> core-file [filename]
-  `(<span class="hljs-name"><span class="hljs-builtin-name">open</span></span> (<span class="hljs-name">os.path.join</span> *core-path* ~filename)))
+(<span class="hljs-name"><span class="hljs-built_in">defmacro</span></span> core-file [filename]
+  `(<span class="hljs-name"><span class="hljs-built_in">open</span></span> (<span class="hljs-name">os.path.join</span> *core-path* ~filename)))
 
 
-(<span class="hljs-name"><span class="hljs-builtin-name">defmacro</span></span> contrib-file [filename]
-  `(<span class="hljs-name"><span class="hljs-builtin-name">open</span></span> (<span class="hljs-name">os.path.join</span> *core-path* <span class="hljs-string">&quot;..&quot;</span> <span class="hljs-string">&quot;contrib&quot;</span> ~filename)))
+(<span class="hljs-name"><span class="hljs-built_in">defmacro</span></span> contrib-file [filename]
+  `(<span class="hljs-name"><span class="hljs-built_in">open</span></span> (<span class="hljs-name">os.path.join</span> *core-path* <span class="hljs-string">&quot;..&quot;</span> <span class="hljs-string">&quot;contrib&quot;</span> ~filename)))
 
 
-(<span class="hljs-name"><span class="hljs-builtin-name">defn</span></span> collect-core-names []
-  (<span class="hljs-name"><span class="hljs-builtin-name">doto</span></span> (<span class="hljs-name">set</span>)
+(<span class="hljs-name"><span class="hljs-built_in">defn</span></span> collect-core-names []
+  (<span class="hljs-name"><span class="hljs-built_in">doto</span></span> (<span class="hljs-name">set</span>)
         (<span class="hljs-name">.update</span> hy.core.language.*exports*)
         (<span class="hljs-name">.update</span> hy.core.shadow.*exports*)
         (<span class="hljs-name">collect-macros</span> (<span class="hljs-name">core-file</span> <span class="hljs-string">&quot;macros.hy&quot;</span>))

--- a/test/markup/routeros/default.expect.txt
+++ b/test/markup/routeros/default.expect.txt
@@ -3,14 +3,14 @@
 <span class="hljs-comment"># и только рабочие прописываем в настройки DHCP сервера</span>
 <span class="hljs-keyword">:global</span> ActiveDNSServers []
 <span class="hljs-keyword">:local</span> PingResult 0
-<span class="hljs-keyword">:foreach</span> serv <span class="hljs-keyword">in</span>=[<span class="hljs-built_in">/ip dns </span><span class="hljs-builtin-name">get</span> servers] <span class="hljs-keyword">do</span>={
-  <span class="hljs-keyword">:do</span> {:<span class="hljs-builtin-name">set</span> PingResult [ping <span class="hljs-variable">$serv</span> <span class="hljs-attribute">count</span>=3]} <span class="hljs-keyword">on-error</span>={:<span class="hljs-builtin-name">set</span> PingResult 0}
-  <span class="hljs-keyword">:if</span> (<span class="hljs-variable">$PingResult</span>=3) <span class="hljs-keyword">do</span>={ :<span class="hljs-builtin-name">set</span> ActiveDNSServers (<span class="hljs-variable">$ActiveDNSServers</span>,<span class="hljs-variable">$serv</span>) }
+<span class="hljs-keyword">:foreach</span> serv <span class="hljs-keyword">in</span>=[<span class="hljs-built_in">/ip dns </span><span class="hljs-built_in">get</span> servers] <span class="hljs-keyword">do</span>={
+  <span class="hljs-keyword">:do</span> {:<span class="hljs-built_in">set</span> PingResult [ping <span class="hljs-variable">$serv</span> <span class="hljs-attribute">count</span>=3]} <span class="hljs-keyword">on-error</span>={:<span class="hljs-built_in">set</span> PingResult 0}
+  <span class="hljs-keyword">:if</span> (<span class="hljs-variable">$PingResult</span>=3) <span class="hljs-keyword">do</span>={ :<span class="hljs-built_in">set</span> ActiveDNSServers (<span class="hljs-variable">$ActiveDNSServers</span>,<span class="hljs-variable">$serv</span>) }
 <span class="hljs-comment"># отладочный вывод в журнал </span>
-  <span class="hljs-keyword">:log</span> <span class="hljs-builtin-name">info</span> <span class="hljs-string">&quot;Server: <span class="hljs-variable">$serv</span>, Ping-result: <span class="hljs-variable">$PingResult</span>&quot;</span>;
+  <span class="hljs-keyword">:log</span> <span class="hljs-built_in">info</span> <span class="hljs-string">&quot;Server: <span class="hljs-variable">$serv</span>, Ping-result: <span class="hljs-variable">$PingResult</span>&quot;</span>;
 }
 
-<span class="hljs-built_in">/ip dhcp-server network </span><span class="hljs-builtin-name">set</span> [<span class="hljs-builtin-name">find</span> <span class="hljs-attribute">address</span>=192.168.254.0/24] <span class="hljs-attribute">dns-server</span>=<span class="hljs-variable">$ActiveDNSServers</span>
+<span class="hljs-built_in">/ip dhcp-server network </span><span class="hljs-built_in">set</span> [<span class="hljs-built_in">find</span> <span class="hljs-attribute">address</span>=192.168.254.0/24] <span class="hljs-attribute">dns-server</span>=<span class="hljs-variable">$ActiveDNSServers</span>
 
 <span class="hljs-comment">#---   FIX TTL  ----</span>
 <span class="hljs-built_in">/ip firewall mangle </span><span class="hljs-attribute">chain</span>=postrouting <span class="hljs-attribute">action</span>=change-ttl <span class="hljs-attribute">new-ttl</span>=set:128 <span class="hljs-attribute">comment</span>=<span class="hljs-string">&quot;NAT hide&quot;</span> 

--- a/test/markup/scheme/lambda.expect.txt
+++ b/test/markup/scheme/lambda.expect.txt
@@ -1,7 +1,7 @@
-(<span class="hljs-name"><span class="hljs-builtin-name">lambda</span></span> (x y z) (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> y z))
+(<span class="hljs-name"><span class="hljs-built_in">lambda</span></span> (x y z) (<span class="hljs-name"><span class="hljs-built_in">+</span></span> y z))
 
-(<span class="hljs-name"><span class="hljs-builtin-name">define</span></span> add-point
-  (<span class="hljs-name"><span class="hljs-builtin-name">lambda</span></span> [p1 p2]
+(<span class="hljs-name"><span class="hljs-built_in">define</span></span> add-point
+  (<span class="hljs-name"><span class="hljs-built_in">lambda</span></span> [p1 p2]
     (<span class="hljs-name">make-point</span>
-      (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> (<span class="hljs-name">point-x</span> p1) (<span class="hljs-name">point-x</span> p2))
-      (<span class="hljs-name"><span class="hljs-builtin-name">+</span></span> (<span class="hljs-name">point-y</span> p1) (<span class="hljs-name">point-y</span> p2)))))
+      (<span class="hljs-name"><span class="hljs-built_in">+</span></span> (<span class="hljs-name">point-x</span> p1) (<span class="hljs-name">point-x</span> p2))
+      (<span class="hljs-name"><span class="hljs-built_in">+</span></span> (<span class="hljs-name">point-y</span> p1) (<span class="hljs-name">point-y</span> p2)))))

--- a/tools/checkTheme.js
+++ b/tools/checkTheme.js
@@ -93,7 +93,6 @@ const TEMPLATES = {
   selectors: [
     "tag",
     "name",
-    "builtin-name",
     "attr",
     "attribute",
     "template-tag",


### PR DESCRIPTION
### Changes

Removed the `builtin-name` replacing it with `built_in` in the few (4-5) 
grammars it was used.  Also only 4 themes made any distinction between 
built_in and builtin-name, the rest choosing to style these exactly the
same - so it's never been clear what the difference is or there is none.

If more nuance is needed here it should be addressed via #2500 and #2521.

In only one grammar was both `built_in` and `builtin-name` used side by
side so other than that (in combo with very particular themes) this
should be a quiet change.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`