### PR TITLE
Add Glimmer to SUPPORTED_LANGUAGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Language Grammars:
 - Default CDN build drops support for several languages.
 - Some language grammar files have been removed.
 - Some redundant language aliases have been removed.
+- Added 3rd party Glimmer grammar to SUPPORTED_LANGUAGES(#3123) [NullVoxPopuli][]
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,7 +38,6 @@ Language Grammars:
 - Default CDN build drops support for several languages.
 - Some language grammar files have been removed.
 - Some redundant language aliases have been removed.
-- Added 3rd party Glimmer grammar to SUPPORTED_LANGUAGES(#3123) [NullVoxPopuli][]
 
 ### Other changes
 
@@ -79,6 +78,7 @@ Grammars:
 
 New Languages:
 
+- Added 3rd party Glimmer grammar to SUPPORTED_LANGUAGES(#3123) [NullVoxPopuli][]
 - Added 3rd party Splunk search processing language grammar to SUPPORTED_LANGUAGES (#3090) [Wei Su][]
 - Added 3rd party ZenScript grammar to SUPPORTED_LANGUAGES(#3106) [Jared Luboff][]
 - Added 3rd party Papyrus grammar to SUPPORTED_LANGUAGES(#3125) [Mike Watling][]

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -78,6 +78,7 @@ Languages that listed a **Package** below are 3rd party languages and are not bu
 | GAUSS                   | gauss, gss             |         |
 | GDScript                | godot, gdscript        | [highlightjs-gdscript](https://github.com/highlightjs/highlightjs-gdscript) |
 | Gherkin                 | gherkin                |         |
+| Glimmer and EmberJS     | hbs, glimmer, html.hbs, html.handlebars, htmlbars | [highlightjs-glimmer](https://github.com/NullVoxPopuli/highlightjs-glimmer) |
 | GN for Ninja            | gn, gni                | [highlightjs-GN](https://github.com/highlightjs/highlightjs-GN) |
 | Go                      | go, golang             |         |
 | Grammatical Framework   | gf                     | [highlightjs-gf](https://github.com/johnjcamilleri/highlightjs-gf) |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds Glimmer highlighting plugin to list of supported languages
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

