### PR TITLE
enh(json) much simpler JSON grammar

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -549,6 +549,7 @@ const HLJS = function(hljs) {
     } catch (err) {
       if (err.message && err.message.includes('Illegal')) {
         return {
+          language: languageName,
           value: escape(codeToHighlight),
           illegal: true,
           relevance: 0,

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -72,7 +72,8 @@ export default function(hljs) {
   };
   const COLLECTION = {
     begin: '[\\[\\{]',
-    end: '[\\]\\}]'
+    end: '[\\]\\}]',
+    relevance: 0
   };
   const HINT = {
     className: 'comment',

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -375,7 +375,7 @@ export default function(hljs) {
       {
         // [Attributes("")]
         className: 'meta',
-        begin: '^\\s*\\[(?=[\w])',
+        begin: '^\\s*\\[(?=[\\w])',
         excludeBegin: true,
         end: '\\]',
         excludeEnd: true,

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -375,7 +375,7 @@ export default function(hljs) {
       {
         // [Attributes("")]
         className: 'meta',
-        begin: '^\\s*\\[',
+        begin: '^\\s*\\[(?=[\w])',
         excludeBegin: true,
         end: '\\]',
         excludeEnd: true,

--- a/src/languages/hy.js
+++ b/src/languages/hy.js
@@ -71,7 +71,8 @@ export default function(hljs) {
   };
   const COLLECTION = {
     begin: '[\\[\\{]',
-    end: '[\\]\\}]'
+    end: '[\\]\\}]',
+    relevance: 0
   };
   const HINT = {
     className: 'comment',

--- a/src/languages/json.js
+++ b/src/languages/json.js
@@ -7,54 +7,31 @@ Category: common, protocols
 */
 
 export default function(hljs) {
-  const LITERALS = {
-    literal: 'true false null'
-  };
-  const ALLOWED_COMMENTS = [
-    hljs.C_LINE_COMMENT_MODE,
-    hljs.C_BLOCK_COMMENT_MODE
+  const LITERALS = [
+    "true",
+    "false",
+    "null"
   ];
-  const TYPES = [
-    hljs.QUOTE_STRING_MODE,
-    hljs.C_NUMBER_MODE
-  ];
-  const VALUE_CONTAINER = {
-    end: ',',
-    endsWithParent: true,
-    excludeEnd: true,
-    contains: TYPES,
-    keywords: LITERALS
+  const ATTRIBUTE = {
+    className: 'attr',
+    begin: /"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+    relevance: 1.01
   };
-  const OBJECT = {
-    begin: /\{/,
-    end: /\}/,
-    contains: [
-      {
-        className: 'attr',
-        begin: /"/,
-        end: /"/,
-        contains: [hljs.BACKSLASH_ESCAPE],
-        illegal: '\\n'
-      },
-      hljs.inherit(VALUE_CONTAINER, {
-        begin: /:/
-      })
-    ].concat(ALLOWED_COMMENTS),
-    illegal: '\\S'
+  const PUNCTUATION = {
+    match: /[{}[\],:]/,
+    className: "punctuation",
+    relevance: 0
   };
-  const ARRAY = {
-    begin: '\\[',
-    end: '\\]',
-    contains: [hljs.inherit(VALUE_CONTAINER)], // inherit is a workaround for a bug that makes shared modes with endsWithParent compile only the ending of one of the parents
-    illegal: '\\S'
-  };
-  TYPES.push(OBJECT, ARRAY);
-  ALLOWED_COMMENTS.forEach(function(rule) {
-    TYPES.push(rule);
-  });
   return {
     name: 'JSON',
-    contains: TYPES,
+    contains: [
+      ATTRIBUTE,
+      PUNCTUATION,
+      hljs.QUOTE_STRING_MODE,
+      hljs.C_NUMBER_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
+    ],
     keywords: LITERALS,
     illegal: '\\S'
   };

--- a/src/languages/json.js
+++ b/src/languages/json.js
@@ -7,11 +7,6 @@ Category: common, protocols
 */
 
 export default function(hljs) {
-  const LITERALS = [
-    "true",
-    "false",
-    "null"
-  ];
   const ATTRIBUTE = {
     className: 'attr',
     begin: /"(\\.|[^\\"\r\n])*"(?=\s*:)/,
@@ -22,17 +17,30 @@ export default function(hljs) {
     className: "punctuation",
     relevance: 0
   };
+  // normally we would rely on `keywords` for this but using a mode here allows us
+  // to use the very tight `illegal: \S` rule later to flag any other character
+  // as illegal indicating that despite looking like JSON we do not truly have
+  // JSON and thus improve false-positively greatly since JSON will try and claim
+  // all sorts of JSON looking stuff
+  const LITERALS = {
+    beginKeywords: [
+      "true",
+      "false",
+      "null"
+    ].join(" ")
+  };
+
   return {
     name: 'JSON',
     contains: [
       ATTRIBUTE,
       PUNCTUATION,
       hljs.QUOTE_STRING_MODE,
+      LITERALS,
       hljs.C_NUMBER_MODE,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE
     ],
-    keywords: LITERALS,
     illegal: '\\S'
   };
 }

--- a/test/markup/http/default.expect.txt
+++ b/test/markup/http/default.expect.txt
@@ -3,5 +3,5 @@
 <span class="hljs-attribute">Content-Type</span><span class="hljs-punctuation">: </span>application/json; charset=utf-8
 <span class="hljs-attribute">Content-Length</span><span class="hljs-punctuation">: </span>19
 
-<span class="language-json">{<span class="hljs-attr">&quot;status&quot;</span>: <span class="hljs-string">&quot;ok&quot;</span>, <span class="hljs-attr">&quot;extended&quot;</span>: <span class="hljs-literal">true</span>}
+<span class="language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;status&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;ok&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;extended&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-keyword">true</span><span class="hljs-punctuation">}</span>
 </span>

--- a/test/markup/json/comments.expect.txt
+++ b/test/markup/json/comments.expect.txt
@@ -1,18 +1,18 @@
 <span class="hljs-comment">/* multi-line comment before */</span>
-[
-  {
-    <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;apples&quot;</span>, <span class="hljs-comment">// yum</span>
-    <span class="hljs-attr">&quot;count&quot;</span>: [<span class="hljs-number">12000</span>, <span class="hljs-number">20000</span>], <span class="hljs-comment">/* so many? */</span>
-    <span class="hljs-attr">&quot;description&quot;</span>: {<span class="hljs-attr">&quot;text&quot;</span>: <span class="hljs-string">&quot;...&quot;</span>, <span class="hljs-attr">&quot;sensitive&quot;</span>: <span class="hljs-literal">false</span>}
-  },
-  {
-    <span class="hljs-attr">&quot;title&quot;</span>: <span class="hljs-string">&quot;oranges&quot;</span>,
-    <span class="hljs-attr">&quot;count&quot;</span>: [<span class="hljs-number">17500</span>, <span class="hljs-literal">null</span>],
-    <span class="hljs-attr">&quot;description&quot;</span>: {<span class="hljs-attr">&quot;text&quot;</span>: <span class="hljs-string">&quot;...&quot;</span>, <span class="hljs-attr">&quot;sensitive&quot;</span>: <span class="hljs-literal">false</span>}
-  }
+<span class="hljs-punctuation">[</span>
+  <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">&quot;title&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;apples&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-comment">// yum</span>
+    <span class="hljs-attr">&quot;count&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-number">12000</span><span class="hljs-punctuation">,</span> <span class="hljs-number">20000</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span> <span class="hljs-comment">/* so many? */</span>
+    <span class="hljs-attr">&quot;description&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;text&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;...&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;sensitive&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-keyword">false</span><span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">&quot;title&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;oranges&quot;</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;count&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-number">17500</span><span class="hljs-punctuation">,</span> <span class="hljs-keyword">null</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">&quot;description&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span><span class="hljs-attr">&quot;text&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;...&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;sensitive&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-keyword">false</span><span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
   <span class="hljs-comment">// {</span>
   <span class="hljs-comment">//   &quot;title&quot; : &quot;brocolli&quot;</span>
   <span class="hljs-comment">// }</span>
-]
+<span class="hljs-punctuation">]</span>
 <span class="hljs-comment">/* multi-line
 comment after */</span>


### PR DESCRIPTION
### Changes

Just what it says.  Pattern match, not parse.

**Needs v11 changes for non-integer relevance scoring.**

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md` (not needed)