### PR TITLE
chore(dev) improve match scope visualization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,11 +33,16 @@ Theme Improvements:
 - chore(themes) remove `builtin-name` CSS class (#3119) [Josh Goebel][]
 - chore(theme) Update GitHub theme css to match GitHub's current styling (#1616) [Jan Pilzer][]
 
+Dev Improvements:
+
+- Change the class structure inspector to utilize more vertical space
+
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm
 [R3voA3]: https://github.com/R3voA3
 [Wei Su]: https://github.com/swsoyee
 [Jared Luboff]: https://github.com/jaredlll08
+[NullVoxPopuli]: https://github.com/NullVoxPopuli
 
 ## Version 10.7.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,7 @@ Theme Improvements:
 
 Dev Improvements:
 
-- Change the class structure inspector to utilize more vertical space
+- (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -37,11 +37,13 @@
 
     .visible-structure pre code span {
       display: inline-block;
-      padding:2px;
-      margin: 3px 0;
+      padding: 0.25rem;
+      margin: 0.75rem 0.25rem 0.5rem 0.25rem;
       border: 1px dashed #777;
       border-radius: 5px;
       white-space: pre;
+
+      position: relative;
     }
 
     .visible-structure pre code span:before {
@@ -49,11 +51,23 @@
       content: attr(data-klass);
       font-size: 70%;
       background: #693;
-      padding:1px 5px;
-      border-radius: 3px;
+      padding:1px 4px;
+      border-radius: 2px;
       color:white;
-      margin-right:0.5em;
+      margin-right:0.25rem;
       font-weight: normal;
+
+      position: absolute;
+      top: -0.75rem;
+      left: -0.25rem;
+    }
+
+    .visible-structure pre code span:after {
+      display: block;
+      opacity: 0;
+      font-size: 70%;
+      content: attr(data-klass);
+      margin-top: -1rem;
     }
   </style>
 </head>

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -36,13 +36,15 @@
     }
 
     .visible-structure pre code span {
-      display: inline-block;
+      display: inline-flex;
+      align-items: baseline;
       padding: 0.25rem;
-      margin: 0.75rem 0.25rem 0.5rem 0.25rem;
+      padding-bottom: 0.125rem;
+      padding-top: 0.5rem;
+      margin: 0.5rem 0.25rem 0.125rem 0.25rem;
       border: 1px dashed #777;
       border-radius: 5px;
       white-space: pre;
-
       position: relative;
     }
 
@@ -56,9 +58,8 @@
       color:white;
       margin-right:0.25rem;
       font-weight: normal;
-
       position: absolute;
-      top: -0.75rem;
+      top: -0.5rem;
       left: -0.25rem;
     }
 


### PR DESCRIPTION
this change trades vertical space to reclaim some horizontal space
that was previously lost when inspecting the class structure of the
emitted hljs highlight.

As a bonus, it's slightly easier to see hierarchy between parent/child
elements because the visible structure text is stacked / indented
like a tree, rather than inline, like it was previously.

Example here: https://hljs-glimmer.nullvoxpopuli.com/?debug=true

### Checklist
- [x] Added markup tests, or they don't apply here because...
      no markup changes 
- [x] Updated the changelog at `CHANGES.md`
