### PR TITLE
enh(parser) keyword relevance has a limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@ Dev Improvements:
 
 Parser:
 
+- keywords now have a maximum # of times they provide relevance (#3129) [Josh Goebel][]
 - enh(api) add `unregisterLanguage` method (#3009) [Antoine du Hamel][]
 - enh: Make alias registration case insensitive (#3026) [David Ostrovsky][]
 - fix(parser) `highlightAll()` now works if the library is lazy loaded [Josh Goebel][]

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -196,7 +196,7 @@ const HLJS = function(hljs) {
           buf = "";
 
           keywordHits[word] = (keywordHits[word] || 0) + 1;
-          if (keywordHits[word] < MAX_KEYWORD_HITS) relevance += keywordRelevance;
+          if (keywordHits[word] <= MAX_KEYWORD_HITS) relevance += keywordRelevance;
           if (kind.startsWith("_")) {
             // _ implied for relevance only, do not highlight
             // by applying a class name

--- a/src/lib/compile_keywords.js
+++ b/src/lib/compile_keywords.js
@@ -23,7 +23,7 @@ const DEFAULT_KEYWORD_CLASSNAME = "keyword";
  */
 export function compileKeywords(rawKeywords, caseInsensitive, className = DEFAULT_KEYWORD_CLASSNAME) {
   /** @type KeywordDict */
-  const compiledKeywords = {};
+  const compiledKeywords = Object.create(null);
 
   // input can be a string of keywords, an array of keywords, or a object with
   // named keys representing className (which can then point to a string or array)

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -8,4 +8,5 @@ describe('hljs', function() {
   require('./reuse-endsWithParent');
   require('./should-not-destroyData');
   require('./compiler-extensions');
+  require('./max_keyword_hits');
 });

--- a/test/parser/max_keyword_hits.js
+++ b/test/parser/max_keyword_hits.js
@@ -1,0 +1,19 @@
+const hljs = require('../../build');
+
+describe("max keyword hits", function() {
+  it("should count a keyword 7 times for relevance, no more", () => {
+    hljs.registerLanguage('test-language', (hljs) => {
+      return {
+        keywords: "bob suzy|2"
+      };
+    });
+
+    let result = hljs.highlight('bob bob bob bob bob bob bob bob bob bob bob bob bob', { language: 'test-language' });
+    result.relevance.should.equal(7);
+
+    result = hljs.highlight('suzy suzy suzy suzy suzy suzy suzy suzy suzy suzy suzy suzy suzy', { language: 'test-language' });
+    result.relevance.should.equal(14);
+
+    hljs.unregisterLanguage("test-language");
+  });
+});


### PR DESCRIPTION
- After a keyword has been matched 7 times it stops adding
  additional relevance.

This prevents variable names that are keywords in another language
from being counted excessively and given more weight than they
should.

The max count may need to be adjusted over time.

Resolves #2826.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Add unit tests
- [ ] Updated the changelog at `CHANGES.md`