### PR TITLE
Removes `beforeMatch`

### DIFF
--- a/docs/mode-reference.rst
+++ b/docs/mode-reference.rst
@@ -250,29 +250,6 @@ This callback is triggered the moment an end match is detected. ``matchData`` in
 For an example of usage see ``END_SAME_AS_BEGIN`` in ``modes.js``.
 
 
-beforeMatch
-^^^^^^^^^^^
-
-- **type**: string
-
-Used to qualify a match by the content that immediately precedes it.  This is syntactic sugar that generates a much more complex mode that first matches the entire sequence (using look-ahead), then glosses over the ``beforeMatch`` portion and ``starts`` a new rule to handle the actual match.
-
-Notes:
-
-- Any ``keywords`` specified are applied to the ``beforeMatch`` text as well (as shown in the example below)
-- Do not get this confused with any type of look-behind.  We are always looking forward.
-- This is incompatible with ``starts``.
-
-::
-
-  {
-    beforeMatch: /\b(enum|class|struct|union)\s+/,
-    keywords: "enum class struct union",
-    begin: /\w+/,
-    className: "title.class"
-  }
-
-
 beginKeywords
 ^^^^^^^^^^^^^
 

--- a/src/languages/actionscript.js
+++ b/src/languages/actionscript.js
@@ -96,16 +96,26 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE,
       hljs.C_NUMBER_MODE,
       {
-        beforeMatch: /\b(package)\s+/,
-        keywords: "package",
-        match: PKG_NAME_RE,
-        className: "title.class"
+        match: [
+          /\bpackage/,
+          /\s+/,
+          PKG_NAME_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
       },
       {
-        beforeMatch: /\b(class|interface|extends|implements)\s+/,
-        keywords: "class interface extends implements",
-        match: IDENT_RE,
-        className: "title.class"
+        match: [
+          /\b(?:class|interface|extends|implements)/,
+          /\s+/,
+          IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
       },
       {
         className: 'meta',

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -403,10 +403,16 @@ export default function(hljs) {
           keywords: CPP_KEYWORDS
         },
         {
-          beforeMatch: /\b(enum|class|struct|union)\s+/,
-          keywords: "enum class struct union",
-          match: /\w+/,
-          className: "title.class"
+          match: [
+            // extra complexity to deal with `enum class` and `enum struct`
+            /\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,
+            /\s+/,
+            /\w+/
+          ],
+          className: {
+            1: "keyword",
+            3: "title.class"
+          }
         }
       ])
   };

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -163,10 +163,15 @@ export default function(hljs) {
       hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
       {
-        beforeMatch: /\b(class|interface|enum|extends|implements|new)\s+/,
-        keywords: "class interface enum extends implements new",
-        match: JAVA_IDENT_RE,
-        className: "title.class"
+        match: [
+          /\b(?:class|interface|enum|extends|implements|new)/,
+          /\s+/,
+          JAVA_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
       },
       {
         begin: [

--- a/src/languages/r.js
+++ b/src/languages/r.js
@@ -132,9 +132,10 @@ export default function(hljs) {
         ],
       },
       {
-        className: 'number',
         relevance: 0,
-        beforeMatch: /([^a-zA-Z0-9._])/, // not part of an identifier
+        className: {
+          2: "number"
+        },
         variants: [
           // TODO: replace with negative look-behind when available
           // { begin: /(?<![a-zA-Z0-9._])0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/ },
@@ -142,15 +143,24 @@ export default function(hljs) {
           // { begin: /(?<![a-zA-Z0-9._])(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?[Li]?/ }
           {
             // Special case: only hexadecimal binary powers can contain fractions.
-            match: /0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,
+            match: [
+              /[^a-zA-Z0-9._]/, // not part of an identifier
+              /0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/
+            ]
           },
           {
-            match: /0[xX][0-9a-fA-F]+([pP][+-]?\d+)?[Li]?/
+            match: [
+              /[^a-zA-Z0-9._]/, // not part of an identifier
+              /0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/
+            ]
           },
           {
-            match: /(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?[Li]?/,
+            match: [
+              /[^a-zA-Z0-9._]/, // not part of an identifier
+              /(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/
+            ]
           }
-        ],
+        ]
       },
       {
         // infix operator

--- a/src/languages/vbnet.js
+++ b/src/languages/vbnet.js
@@ -113,7 +113,7 @@ export default function(hljs) {
         begin: /'/
       },
       {
-        // TODO: Use `beforeMatch:` for leading spaces
+        // TODO: Use multi-class for leading spaces
         begin: /([\t ]|^)REM(?=\s)/
       }
     ]
@@ -121,7 +121,7 @@ export default function(hljs) {
 
   const DIRECTIVES = {
     className: 'meta',
-    // TODO: Use `beforeMatch:` for indentation once available
+    // TODO: Use multi-class for indentation once available
     begin: /[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
     end: /$/,
     keywords: {

--- a/test/markup/cpp/template_complexity.expect.txt
+++ b/test/markup/cpp/template_complexity.expect.txt
@@ -13,9 +13,9 @@ std::wostream &amp;<span class="hljs-keyword">operator</span> &lt;&lt;(std::wost
     <span class="hljs-keyword">return</span> stream &lt;&lt; <span class="hljs-keyword">static_cast</span>&lt;std::wstring_view&gt;(thing);
 }
 
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">struct</span></span> DataHolder { };
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">class</span></span> DataThingy { };
-<span class="hljs-keyword">enum</span> <span class="hljs-title hljs-class"><span class="hljs-keyword">class</span></span> Boolean : <span class="hljs-keyword">char</span> {
+<span class="hljs-keyword">enum struct</span> <span class="hljs-title hljs-class">DataHolder</span> { };
+<span class="hljs-keyword">enum class</span> <span class="hljs-title hljs-class">DataThingy</span> { };
+<span class="hljs-keyword">enum class</span> <span class="hljs-title hljs-class">Boolean</span> : <span class="hljs-keyword">char</span> {
     True, False, FileNotFound
 };
 


### PR DESCRIPTION
Resolves #3105

### Changes

The newer multi-match accomplishes everything beforeMatch does and more
and is clearer - no confusion about *perhaps* whether this is truly 
a look-behind (when it never was).

Perhaps when multi-match is more fleshed out this could become sugar
in the future, but right now that introduces too many complexities
since right now that would create inconsistent behavior.

Example sugar:

```js
{ 
  beforeMatch: /class\s+/,
  keywords: "class",
  match: /\w+/,
  className: "title.class"
}
```

Would be converted to:

```js
{
  match: [ /class\s+/, /\w+/ ],
  keywords: "class",
  className: { 2: "title.class" }
}
```

(also at a glance it's not 100% clear the keywords even SHOULD apply to beforeMatch - that was a decision I made only out of convenience because the common patterns I was seeing needed that)

IE, with sugar `beforeMatch` would just rewrite itself into a multi-
match but this would inconsistent behavior with regard to how keywords
are handled inside `begin`.  Keywords inside begin CAN usually be 
highlighted but once the begin was rewritten into a multi-match
with a `className` applied to the second match group.. yet the current
behavior of multi-match does not ALSO allow keywords to be matched
inside of content when a `className` is already being applied to a 
given segment.

So because of this inconsistency I've just removed this for now.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`