### PR TITLE
Added pde alias

### DIFF
--- a/src/languages/processing.js
+++ b/src/languages/processing.js
@@ -9,6 +9,7 @@ Category: graphics
 export default function(hljs) {
   return {
     name: 'Processing',
+    aliases: [ 'pde' ],
     keywords: {
       keyword: 'BufferedReader PVector PFont PImage PGraphics HashMap boolean byte char color ' +
         'double float int long String Array FloatDict FloatList IntDict IntList JSONArray JSONObject ' +


### PR DESCRIPTION
Added the processing file extension as an alias as i think this would also be used to highlight the code just like shorthand js works for javascript files

<!-- Please link to a related issue below. -->

Resolves #3142.

### Changes
Added new `pde` alias

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
