### PR TITLE
Added pde alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,7 @@ Theme Improvements:
 Dev Improvements:
 
 - (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
+- added new pde to processing language as that is its file extension [DylanMcBean][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ Parser:
 
 Grammars:
 
-- enh(processing) added `pde` alias (#3142) [DylanMcBean][]
+- enh(processing) added `pde` alias (#3142) [Dylan McBean][]
 - enh(thrift) Use proper scope for types [Josh Goebel][]
 - enh(java) Simplified class-like matcher (#3078) [Josh Goebel][]
 - enh(cpp) Simplified class-like matcher (#3078) [Josh Goebel][]
@@ -96,6 +96,7 @@ Dev Improvements:
 
 - (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
 
+[Dylan McBean]: https://github.com/DylanMcBean
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm
 [R3voA3]: https://github.com/R3voA3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Parser:
 
 Grammars:
 
+- enh(processing) added `pde` alias (#3142) [DylanMcBean][]
 - enh(thrift) Use proper scope for types [Josh Goebel][]
 - enh(java) Simplified class-like matcher (#3078) [Josh Goebel][]
 - enh(cpp) Simplified class-like matcher (#3078) [Josh Goebel][]
@@ -94,7 +95,6 @@ Theme Improvements:
 Dev Improvements:
 
 - (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
-- added new pde to processing language as that is its file extension (#3142) [DylanMcBean][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,7 +94,7 @@ Theme Improvements:
 Dev Improvements:
 
 - (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
-- added new pde to processing language as that is its file extension [DylanMcBean][]
+- added new pde to processing language as that is its file extension (#3142) [DylanMcBean][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm

--- a/src/languages/processing.js
+++ b/src/languages/processing.js
@@ -9,6 +9,7 @@ Category: graphics
 export default function(hljs) {
   return {
     name: 'Processing',
+    aliases: [ 'pde' ],
     keywords: {
       keyword: 'BufferedReader PVector PFont PImage PGraphics HashMap boolean byte char color ' +
         'double float int long String Array FloatDict FloatList IntDict IntList JSONArray JSONObject ' +


### PR DESCRIPTION
Added the processing file extension as an alias as i think this would also be used to highlight the code just like shorthand js works for javascript files

<!-- Please link to a related issue below. -->

Resolves #3142.

### Changes
Added new `pde` alias

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
