### PR TITLE
enh(swift) add `@resultBuilder` attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ Parser:
 
 Grammars:
 
-- enh(swift) add `@resultBuilder` attribute (#?) [Bradley Mackey][]
+- enh(swift) add `@resultBuilder` attribute (#3151) [Bradley Mackey][]
 - enh(processing) added `pde` alias (#3142) [Dylan McBean][]
 - enh(thrift) Use proper scope for types [Josh Goebel][]
 - enh(java) Simplified class-like matcher (#3078) [Josh Goebel][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Parser:
 
 Grammars:
 
+- enh(swift) add `@resultBuilder` attribute (#?) [Bradley Mackey][]
 - enh(processing) added `pde` alias (#3142) [Dylan McBean][]
 - enh(thrift) Use proper scope for types [Josh Goebel][]
 - enh(java) Simplified class-like matcher (#3078) [Josh Goebel][]
@@ -96,6 +97,7 @@ Dev Improvements:
 
 - (chore) greatly improve match scope visualization in dev tool (#3126) [NullVoxPopuli][]
 
+[Bradley Mackey]: https://github.com/bradleymackey
 [Dylan McBean]: https://github.com/DylanMcBean
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -297,6 +297,7 @@ export const keywordAttributes = [
   'objcMembers',
   'propertyWrapper',
   'requires_stored_property_inits',
+  'resultBuilder',
   'testable',
   'UIApplicationMain',
   'unknown',

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -5,5 +5,6 @@
 
 <span class="hljs-keyword">@propertyWrapper</span>
 <span class="hljs-meta">@SomeWrapper</span>(value: <span class="hljs-number">1.0</span>, other: <span class="hljs-string">&quot;string&quot;</span>, bool: <span class="hljs-literal">false</span>)
+<span class="hljs-keyword">@resultBuilder</span>
 
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -5,5 +5,6 @@
 
 @propertyWrapper
 @SomeWrapper(value: 1.0, other: "string", bool: false)
+@resultBuilder
 
 @ notAnAttribute


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

This is a new attribute that will be added in Swift 5.4, expected to be released in a few days.

[Proposal Document](https://github.com/apple/swift-evolution/blob/main/proposals/0289-result-builders.md)

### Changes
<!--- Describe your changes -->

Adds support for `@resultBuilder` to Swift.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
