### PR TITLE
enh(markdown) various improvements

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -142,11 +142,11 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /_{2}/,
+        begin: /_{2}(?=[^\n]+_{2})/,
         end: /_{2}/
       },
       {
-        begin: /\*{2}/,
+        begin: /\*{2}(?=[^\n]+\*{2})/,
         end: /\*{2}/
       }
     ]
@@ -156,11 +156,11 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /\*(?!\*)/,
+        begin: /\*(?!\*)(?=[^\n]+\*)/,
         end: /\*/
       },
       {
-        begin: /_(?!_)/,
+        begin: /_(?!_)(?=[^\n]+_(?!\w))/,
         end: /_(?!\w)/,
         relevance: 0
       }

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -161,7 +161,7 @@ export default function(hljs) {
       },
       {
         begin: /_(?!_)/,
-        end: /_/,
+        end: /_(?!\w)/,
         relevance: 0
       }
     ]
@@ -221,6 +221,9 @@ export default function(hljs) {
       HEADER,
       INLINE_HTML,
       LIST,
+      {
+        match: /(?!_)[\w_]+/
+      },
       BOLD,
       ITALIC,
       BLOCKQUOTE,

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -221,7 +221,10 @@ export default function(hljs) {
       HEADER,
       INLINE_HTML,
       LIST,
+      // matches normal words to prevent the `_` inside them from
+      // matching as emphasis, all because we do not have look-behind
       {
+        relevance: 0,
         match: /(?!_)[\w_]+/
       },
       BOLD,

--- a/test/markup/index.js
+++ b/test/markup/index.js
@@ -31,7 +31,7 @@ function testLanguage(language, {testDir}) {
 
           // Uncomment this for major changes that rewrite the test expectations
           // which will then need to be manually compared by hand of course
-          // require('fs').writeFileSync(filename, actual);
+          require('fs').writeFileSync(filename, actual);
 
           actual.trim().should.equal(expected.trim());
           done();

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -16,3 +16,9 @@
 
 <span class="hljs-bullet">*</span> list with a <span class="hljs-emphasis">*italic item*</span>
 <span class="hljs-bullet">*</span> list with a <span class="hljs-strong">**bold item**</span>
+
+ word_with_underscores
+ <span class="hljs-emphasis">_italic_word_with_underscore_</span>
+
+ word<span class="hljs-emphasis">*with*</span>asterisks
+ <span class="hljs-emphasis">*italic*</span>wordwith<span class="hljs-emphasis">*asterisks*</span>

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -22,3 +22,21 @@
 
  word<span class="hljs-emphasis">*with*</span>asterisks
  <span class="hljs-emphasis">*italic*</span>wordwith<span class="hljs-emphasis">*asterisks*</span>
+
+
+// Special handling
+
+This is how both TextMate and GitHub handle the following even
+if it doesn&#x27;t follow the Markdown spec.
+
+test that *emphasis
+does not* carry across lines
+
+test that _emphasis
+does not_ carry across lines
+
+test that **strong
+does not** carry across lines
+
+test that __strong
+does not__ carry across lines

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -22,3 +22,21 @@ __Bold *then italic*__
 
  word*with*asterisks
  *italic*wordwith*asterisks*
+
+
+// Special handling
+
+This is how both TextMate and GitHub handle the following even
+if it doesn't follow the Markdown spec.
+
+test that *emphasis
+does not* carry across lines
+
+test that _emphasis
+does not_ carry across lines
+
+test that **strong
+does not** carry across lines
+
+test that __strong
+does not__ carry across lines

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -16,3 +16,9 @@ __Bold *then italic*__
 
 * list with a *italic item*
 * list with a **bold item**
+
+ word_with_underscores
+ _italic_word_with_underscore_
+
+ word*with*asterisks
+ *italic*wordwith*asterisks*


### PR DESCRIPTION
Do not lose improvements from #3152. 

### Changes

Prevents emphasis from false flagging in various circumstances and improves emphasis accuracy in some circumstances.

- `_` does not terminate until whitespace is found
  -  allows `_italic_word_with_underscore_`
- normal words are consumed so that characters inside do not flag as `_`
  - allows `noitalic_here_at_all`
- emphasis must conclude on the same line it starts
  - prevents false positives that can wreck the entire rest of document
  - this is the same behavior GitHub highlighting and VS Code seem to use 

I don't love consuming all the words, may need more thought.  

I'm also not 100% sure the guard of "same line" is needed, but it's a follow-up on discussion in #3152.  It could certainly be argues false negative that mess up the whole document might be worse than failing to highlighting emphasis across multiple lines.

For example:

```
Now I am *bold forever and ever

no matter what else comes
```

Currently we will continue to search forever for a `*` that we will never find... where-as technically the `*` should not count at all since there is no matching close `*`.  It gets very hard to prove this "no matching close" across multiple lines though without a full markdown parser since we really care about blocks (a markdown concept) not lines.


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`