### PR TITLE
beginScope and endScope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,11 @@ module.exports = {
   overrides: [
     {
       files: ["types/*.ts", "src/*.ts"],
-      parser: '@typescript-eslint/parser'
+      parser: '@typescript-eslint/parser',
+      rules: {
+        "import/no-duplicates": "off",
+        "import/extensions": "off"
+      }
     },
     {
       files: ["src/**/*.js"],

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@ Language Grammars:
 
 Parser:
 
+- enh(parser) add `beginScope` and `endScope` to allow separate scoping begin and end (#3159) [Josh Goebel][]
+- enh(parsed) `endScope` now supports multi-class matchers as well (#3159) [Josh Goebel][]
 - enh(parser) `highlightElement` now always tags blocks with a consistent `language-[name]` class [Josh Goebel][]
   - subLanguage `span` tags now also always have the `language-` prefix added
 - enh(parser) support multi-class matchers (#3081) [Josh Goebel][]

--- a/docs/mode-reference.rst
+++ b/docs/mode-reference.rst
@@ -177,8 +177,25 @@ begin
 Regular expression starting a mode. For example a single quote for strings or two forward slashes for C-style comments.
 If absent, ``begin`` defaults to a regexp that matches anything, so the mode starts immediately.
 
+This may also be an array.  See beginScope.
 
-You can also pass an array when you need to individually highlight portions of the match using different scopes:
+beginScope
+^^^^^^^^^^
+
+- **type**: scope
+- **type**: numeric index of scopes (when ``begin`` is an array)
+
+This can be used to apply a scope to just the begin match portion.
+
+::
+
+  {
+    begin: /def/,
+    beginScope: "keyword"
+  }
+
+You can also use ``beginScope`` to individually highlight portions of the match
+with different scopes by passing an array to ``begin``.
 
 ::
 
@@ -188,7 +205,7 @@ You can also pass an array when you need to individually highlight portions of t
     /\s+/,
     hljs.IDENT_RE
   ],
-  scope: {
+  beginScope: {
     1: "keyword",
     3: "title"
   },
@@ -206,6 +223,22 @@ capture groups of their own yet.* If your regexes uses groups at all, they
 For more info see issue `#3095 <https://github.com/highlightjs/highlight.js/issues/3095>`_.
 
 
+endScope
+^^^^^^^^
+
+- **type**: scope
+- **type**: numeric index of scopes (when ``end`` is an array)
+
+This has the same behavior as ``beginScope`` but applies to the content of the
+``end`` match.
+
+::
+
+  {
+    begin: /FIRST/,
+    end: /LAST/,
+    endScope: "built_in"
+  }
 
 
 match

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -14,6 +14,27 @@ import { compileLanguage } from './lib/mode_compiler.js';
 import * as packageJSON from '../package.json';
 import * as logger from "./lib/logger.js";
 
+/**
+@typedef {import('highlight.js').Mode} Mode
+@typedef {import('highlight.js').CompiledMode} CompiledMode
+@typedef {import('highlight.js').Language} Language
+@typedef {import('highlight.js').HLJSApi} HLJSApi
+@typedef {import('highlight.js').HLJSPlugin} HLJSPlugin
+@typedef {import('highlight.js').PluginEvent} PluginEvent
+@typedef {import('highlight.js').HLJSOptions} HLJSOptions
+@typedef {import('highlight.js').LanguageFn} LanguageFn
+@typedef {import('highlight.js').HighlightedHTMLElement} HighlightedHTMLElement
+@typedef {import('highlight.js').BeforeHighlightContext} BeforeHighlightContext
+@typedef {import('highlight.js/private').MatchType} MatchType
+@typedef {import('highlight.js/private').KeywordData} KeywordData
+@typedef {import('highlight.js/private').EnhancedMatch} EnhancedMatch
+@typedef {import('highlight.js/private').AnnotatedError} AnnotatedError
+@typedef {import('highlight.js').AutoHighlightResult} AutoHighlightResult
+@typedef {import('highlight.js').HighlightOptions} HighlightOptions
+@typedef {import('highlight.js').HighlightResult} HighlightResult
+*/
+
+
 const escape = utils.escapeHTML;
 const inherit = utils.inherit;
 const NO_MATCH = Symbol("nomatch");
@@ -94,7 +115,7 @@ const HLJS = function(hljs) {
    * NEW API
    * highlight(code, {lang, ignoreIllegals})
    *
-   * @param {string} codeOrlanguageName - the language to use for highlighting
+   * @param {string} codeOrLanguageName - the language to use for highlighting
    * @param {string | HighlightOptions} optionsOrCode - the code to highlight
    * @param {boolean} [ignoreIllegals] - whether to ignore illegal matches, default is to bail
    * @param {CompiledMode} [continuation] - current continuation mode, if any
@@ -107,11 +128,11 @@ const HLJS = function(hljs) {
    * @property {CompiledMode} top - top of the current mode stack
    * @property {boolean} illegal - indicates whether any illegal matches were found
   */
-  function highlight(codeOrlanguageName, optionsOrCode, ignoreIllegals, continuation) {
+  function highlight(codeOrLanguageName, optionsOrCode, ignoreIllegals, continuation) {
     let code = "";
     let languageName = "";
     if (typeof optionsOrCode === "object") {
-      code = codeOrlanguageName;
+      code = codeOrLanguageName;
       ignoreIllegals = optionsOrCode.ignoreIllegals;
       languageName = optionsOrCode.language;
       // continuation not supported at all via the new API
@@ -121,7 +142,7 @@ const HLJS = function(hljs) {
       // old API
       logger.deprecated("10.7.0", "highlight(lang, code, ...args) has been deprecated.");
       logger.deprecated("10.7.0", "Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277");
-      languageName = codeOrlanguageName;
+      languageName = codeOrLanguageName;
       code = optionsOrCode;
     }
 
@@ -271,7 +292,7 @@ const HLJS = function(hljs) {
         // at this point modeBuffer should just be the match
         emitMultiClass(mode, match);
         modeBuffer = "";
-      } else if (mode.scope) {
+      } else if (mode.scope && typeof mode.scope === "string") {
         emitter.openNode(language.classNameAliases[mode.scope] || mode.scope);
       }
       top = Object.create(mode, { parent: { value: top } });
@@ -315,7 +336,7 @@ const HLJS = function(hljs) {
      */
     function doIgnore(lexeme) {
       if (top.matcher.regexIndex === 0) {
-        // no more regexs to potentially match here, so we move the cursor forward one
+        // no more regexes to potentially match here, so we move the cursor forward one
         // space
         modeBuffer += lexeme[0];
         return 1;
@@ -416,7 +437,7 @@ const HLJS = function(hljs) {
     /**
      *  Process an individual match
      *
-     * @param {string} textBeforeMatch - text preceeding the match (since the last match)
+     * @param {string} textBeforeMatch - text preceding the match (since the last match)
      * @param {EnhancedMatch} [match] - the match itself
      */
     function processLexeme(textBeforeMatch, match) {
@@ -498,7 +519,7 @@ const HLJS = function(hljs) {
       throw new Error('Unknown language: "' + languageName + '"');
     }
 
-    const md = compileLanguage(language, { plugins });
+    const md = compileLanguage(language);
     let result = '';
     /** @type {CompiledMode} */
     let top = continuation || md;
@@ -695,12 +716,12 @@ const HLJS = function(hljs) {
       language: result.language,
       // TODO: remove with version 11.0
       re: result.relevance,
-      relavance: result.relevance
+      relevance: result.relevance
     };
     if (result.secondBest) {
       element.secondBest = {
         language: result.secondBest.language,
-        relavance: result.secondBest.relevance
+        relevance: result.secondBest.relevance
       };
     }
   }
@@ -922,7 +943,7 @@ const HLJS = function(hljs) {
     }
   }
 
-  // merge all the modes/regexs into our main object
+  // merge all the modes/regexes into our main object
   Object.assign(hljs, MODES);
 
   return hljs;

--- a/src/lib/compiler_extensions.js
+++ b/src/lib/compiler_extensions.js
@@ -1,5 +1,10 @@
 import * as regex from './regex.js';
 
+/**
+@typedef {import('highlight.js').CallbackResponse} CallbackResponse
+@typedef {import('highlight.js').CompilerExt} CompilerExt
+*/
+
 // Grammar extensions / plugins
 // See: https://github.com/highlightjs/highlight.js/issues/2833
 
@@ -24,7 +29,7 @@ import * as regex from './regex.js';
  * @param {RegExpMatchArray} match
  * @param {CallbackResponse} response
  */
-function skipIfhasPrecedingDot(match, response) {
+function skipIfHasPrecedingDot(match, response) {
   const before = match.input[match.index - 1];
   if (before === ".") {
     response.ignoreMatch();
@@ -35,7 +40,7 @@ function skipIfhasPrecedingDot(match, response) {
  *
  * @type {CompilerExt}
  */
-export function scopeClassName(mode, parent) {
+export function scopeClassName(mode, _parent) {
   // eslint-disable-next-line no-undefined
   if (mode.className !== undefined) {
     mode.scope = mode.className;
@@ -57,7 +62,7 @@ export function beginKeywords(mode, parent) {
   // doesn't allow spaces in keywords anyways and we still check for the boundary
   // first
   mode.begin = '\\b(' + mode.beginKeywords.split(' ').join('|') + ')(?!\\.)(?=\\b|\\s)';
-  mode.__beforeBegin = skipIfhasPrecedingDot;
+  mode.__beforeBegin = skipIfHasPrecedingDot;
   mode.keywords = mode.keywords || mode.beginKeywords;
   delete mode.beginKeywords;
 

--- a/src/lib/ext/multi_class.js
+++ b/src/lib/ext/multi_class.js
@@ -2,6 +2,10 @@
 import * as logger from "../../lib/logger.js";
 import * as regex from "../regex.js";
 
+/**
+@typedef {import('highlight.js').CompiledMode} CompiledMode
+*/
+
 const MultiClassError = new Error();
 
 /**
@@ -36,7 +40,7 @@ function remapScopeNames(mode, regexes) {
   const scopeNames = mode.scope;
   /** @type Record<number,boolean> */
   const emit = {};
-  /** @type Record<number,string|true> */
+  /** @type Record<number,string> */
   const positions = {};
 
   for (let i = 1; i <= regexes.length; i++) {

--- a/src/lib/mode_compiler.js
+++ b/src/lib/mode_compiler.js
@@ -5,6 +5,14 @@ import { beforeMatchExt } from "./exts/before_match.js";
 import { compileKeywords } from "./compile_keywords.js";
 import { MultiClass } from "./ext/multi_class.js";
 
+/**
+@typedef {import('highlight.js').Mode} Mode
+@typedef {import('highlight.js').CompiledMode} CompiledMode
+@typedef {import('highlight.js').Language} Language
+@typedef {import('highlight.js').HLJSPlugin} HLJSPlugin
+@typedef {import('highlight.js').CompiledLanguage} CompiledLanguage
+*/
+
 // compilation
 
 /**
@@ -13,12 +21,11 @@ import { MultiClass } from "./ext/multi_class.js";
  * Given the raw result of a language definition (Language), compiles this so
  * that it is ready for highlighting code.
  * @param {Language} language
- * @param {{plugins: HLJSPlugin[]}} opts
  * @returns {CompiledLanguage}
  */
-export function compileLanguage(language, { plugins }) {
+export function compileLanguage(language) {
   /**
-   * Builds a regex with the case sensativility of the current language
+   * Builds a regex with the case sensitivity of the current language
    *
    * @param {RegExp | string} value
    * @param {boolean} [global]

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -1,6 +1,9 @@
 import { inherit } from './utils.js';
 import * as regex from './regex.js';
 
+/** @typedef {import('highlight.js').Mode} Mode */
+/** @typedef {import('highlight.js').ModeCallback} ModeCallback */
+
 // Common regexps
 export const MATCH_NOTHING_RE = /\b\B/;
 export const IDENT_RE = '[a-zA-Z]\\w*';

--- a/src/lib/response.js
+++ b/src/lib/response.js
@@ -1,4 +1,7 @@
+/** @typedef {import('highlight.js').CallbackResponse} CallbackResponse */
+/** @typedef {import('highlight.js').CompiledMode} CompiledMode */
 /** @implements CallbackResponse */
+
 export default class Response {
   /**
    * @param {CompiledMode} mode

--- a/src/lib/token_tree.js
+++ b/src/lib/token_tree.js
@@ -2,6 +2,7 @@ import HTMLRenderer from './html_renderer.js';
 
 /** @typedef {{kind?: string, sublanguage?: boolean, children: Node[]} | string} Node */
 /** @typedef {{kind?: string, sublanguage?: boolean, children: Node[]} } DataNode */
+/** @typedef {import('highlight.js').Emitter} Emitter */
 /**  */
 
 class TokenTree {

--- a/test/parser/beginEndScope.js
+++ b/test/parser/beginEndScope.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const hljs = require('../../build');
+hljs.debugMode();
+
+describe('beginScope and endScope', () => {
+  before(() => {
+    const grammar = function() {
+      return {
+        contains: [
+          {
+            begin: /xyz/,
+            end: /123/,
+            scope: "string",
+            beginScope: "red",
+            endScope: "green"
+          },
+          {
+            begin: /123/,
+            end: [ /a/,/((b))/,/c/,/d/ ],
+            endScope: { 1: "apple", 2: "boy", 4: "delta" }
+          },
+          {
+            begin: /dumb/,
+            end: /luck/,
+            beginScope: "red",
+            endScope: "green"
+          },
+          {
+            begin: /abc/,
+            beginScope: "letters",
+            contains: [
+              { match: /def/, scope: "more" }
+            ]
+          }
+        ]
+      }
+    };
+    hljs.registerLanguage("test", grammar);
+  });
+  after(() => {
+    hljs.unregisterLanguage("test");
+  });
+  it('should support multi-class', () => {
+    const code = "123 abcd";
+    const result = hljs.highlight(code, { language: 'test' });
+
+    result.value.should.equal(`123 <span class="hljs-apple">a</span><span class="hljs-boy">b</span>c<span class="hljs-delta">d</span>`);
+  })
+  it('should support an outer scope wrapper', () => {
+    const code = "xyz me 123";
+    const result = hljs.highlight(code, { language: 'test' });
+
+    result.value.should.equal(
+      `<span class="hljs-string">` +
+        `<span class="hljs-red">xyz</span> me <span class="hljs-green">123</span>` +
+      `</span>`);
+  })
+  it('should support textual beginScope & endScope pair', () => {
+    const code = "dumb really luck";
+    const result = hljs.highlight(code, { language: 'test' });
+
+    result.value.should.equal(`<span class="hljs-red">dumb</span> really <span class="hljs-green">luck</span>`);
+  });
+  it('should support textual beginScope', () => {
+    const code = "abcdef";
+    const result = hljs.highlight(code, { language: 'test' });
+
+    result.value.should.equal(`<span class="hljs-letters">abc</span><span class="hljs-more">def</span>`);
+  });
+
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -202,6 +202,8 @@ declare module 'highlight.js' {
             isMultiClass?: boolean
             starts?: CompiledMode
             parent?: CompiledMode
+            beginScope?: Record<number, string> & {_emit?: Record<number,boolean>, _multi?: boolean, _wrap?: string}
+            endScope?: Record<number, string> & {_emit?: Record<number,boolean>, _multi?: boolean, _wrap?: string}
         }
 
     interface ModeDetails {
@@ -211,6 +213,7 @@ declare module 'highlight.js' {
         className?: string
         _emit?: Record<number, boolean>
         scope?: string | Record<number, string>
+        beginScope?: string | Record<number, string>
         contains?: ("self" | Mode)[]
         endsParent?: boolean
         endsWithParent?: boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,19 @@
 // For TS consumers who use Node and don't have dom in their tsconfig lib, import the necessary types here.
 /// <reference lib="dom" />
 
+declare module 'highlight.js/private' {
+    import { CompiledMode, Mode, Language } from "highlight.js";
+
+    type MatchType = "begin" | "end" | "illegal"
+    type EnhancedMatch = RegExpMatchArray & {rule: CompiledMode, type: MatchType}
+    type AnnotatedError = Error & {mode?: Mode | Language, languageName?: string, badRule?: Mode}
+
+    type KeywordData = [string, number];
+    type KeywordDict = Record<string, KeywordData>
+}
 declare module 'highlight.js' {
+
+    import { KeywordDict} from "highlight.js/private";
 
     export type HLJSApi = PublicApi & ModesAPI
 
@@ -12,7 +24,7 @@ declare module 'highlight.js' {
     }
 
     interface PublicApi {
-        highlight: (codeOrlanguageName: string, optionsOrCode: string | HighlightOptions, ignoreIllegals?: boolean, continuation?: Mode) => HighlightResult
+        highlight: (codeOrLanguageName: string, optionsOrCode: string | HighlightOptions, ignoreIllegals?: boolean, continuation?: Mode) => HighlightResult
         highlightAuto: (code: string, languageSubset?: string[]) => AutoHighlightResult
         highlightBlock: (element: HTMLElement) => void
         highlightElement: (element: HTMLElement) => void
@@ -160,16 +172,7 @@ declare module 'highlight.js' {
         addSublanguage(emitter: Emitter, subLanguageName: string): void
     }
 
-    /************
-     PRIVATE API
-    ************/
-
-    /* for jsdoc annotations in the JS source files */
-
-    type AnnotatedError = Error & {mode?: Mode | Language, languageName?: string, badRule?: Mode}
-    type HighlightedHTMLElement = HTMLElement & {result?: object, secondBest?: object, parentNode: HTMLElement}
-    type EnhancedMatch = RegExpMatchArray & {rule: CompiledMode, type: MatchType}
-    type MatchType = "begin" | "end" | "illegal"
+    export type HighlightedHTMLElement = HTMLElement & {result?: object, secondBest?: object, parentNode: HTMLElement}
 
     /* modes */
 
@@ -178,14 +181,11 @@ declare module 'highlight.js' {
         "on:begin"?: ModeCallback
     }
 
-    interface CompiledLanguage extends LanguageDetail, CompiledMode {
+    export interface CompiledLanguage extends LanguageDetail, CompiledMode {
         isCompiled: true
         contains: CompiledMode[]
         keywords: Record<string, any>
     }
-
-    type KeywordData = [string, number];
-    type KeywordDict = Record<string, KeywordData>
 
     export type CompiledMode = Omit<Mode, 'contains'> &
         {
@@ -209,6 +209,8 @@ declare module 'highlight.js' {
         match?: RegExp | string
         end?: RegExp | string
         className?: string
+        _emit?: Record<number, boolean>
+        scope?: string | Record<number, string>
         contains?: ("self" | Mode)[]
         endsParent?: boolean
         endsWithParent?: boolean


### PR DESCRIPTION
Resolves #3156.

### Changes

Adds endScope and beginScope:

```
  {
    begin: /"/,
    end: /"/
    beginScope: "string.delim",
    endScope: "string.delim",
    scope: "string"
  }
```

To produce something like:

```
<string>
  <string.delim>"</>
    hello world
  <string.delim>"</>
</>
```

Multi-match may also be used with `end`, just as with `begin`.

### Checklist
- [x] Added tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`