### PR TITLE
enh(dts) cleanup and enhance DTS support

### DIFF
--- a/src/languages/dts.js
+++ b/src/languages/dts.js
@@ -76,72 +76,86 @@ export default function(hljs) {
     ]
   };
 
-  const DTS_REFERENCE = {
+  const REFERENCE = {
     className: 'variable',
     begin: /&[a-z\d_]*\b/
   };
 
-  const DTS_KEYWORD = {
+  const KEYWORD = {
     className: 'meta-keyword',
     begin: '/[a-z][a-z\\d-]*/'
   };
 
-  const DTS_LABEL = {
+  const LABEL = {
     className: 'symbol',
     begin: '^\\s*[a-zA-Z_][a-zA-Z\\d_]*:'
   };
 
-  const DTS_CELL_PROPERTY = {
+  const CELL_PROPERTY = {
     className: 'params',
     begin: '<',
     end: '>',
     contains: [
       NUMBERS,
-      DTS_REFERENCE
+      REFERENCE
     ]
   };
 
-  const DTS_NODE = {
-    className: 'class',
-    begin: /[a-zA-Z_][a-zA-Z\d_@]*\s\{/,
-    end: /[{;=]/,
-    returnBegin: true,
-    excludeEnd: true
+  const NODE = {
+    className: 'title.class',
+    begin: /[a-zA-Z_][a-zA-Z\d_@-]*(?=\s\{)/
   };
 
-  const DTS_ROOT_NODE = {
-    className: 'class',
-    begin: '/\\s*\\{',
-    end: /\};/,
-    relevance: 10,
-    contains: [
-      DTS_REFERENCE,
-      DTS_KEYWORD,
-      DTS_LABEL,
-      DTS_NODE,
-      DTS_CELL_PROPERTY,
-      hljs.C_LINE_COMMENT_MODE,
-      hljs.C_BLOCK_COMMENT_MODE,
-      NUMBERS,
-      STRINGS
-    ]
+  const ROOT_NODE = {
+    className: 'title.class',
+    begin: /\/(?=\s*\{)/,
+    relevance: 10
+  };
+
+  // TODO: `attribute` might be the right scope here, unsure
+  // I'm not sure if all these key names have semantic meaning or not
+  const ATTR_NO_VALUE = {
+    match: /[a-z][a-z-,]+(?=;)/,
+    relevance: 0,
+    scope: "attr"
+  };
+  const ATTR = {
+    relevance: 0,
+    match: [
+      /[a-z][a-z-,]+/,
+      /\s*/,
+      /=/
+    ],
+    scope: {
+      1: "attr",
+      3: "operator"
+    }
+  };
+
+  const PUNC = {
+    scope: "punctuation",
+    relevance: 0,
+    // `};` combined is just to avoid tons of useless punctuation nodes
+    match: /\};|[;{}]/
   };
 
   return {
     name: 'Device Tree',
-    keywords: "",
     contains: [
-      DTS_ROOT_NODE,
-      DTS_REFERENCE,
-      DTS_KEYWORD,
-      DTS_LABEL,
-      DTS_NODE,
-      DTS_CELL_PROPERTY,
+      ROOT_NODE,
+      REFERENCE,
+      KEYWORD,
+      LABEL,
+      NODE,
+      ATTR,
+      ATTR_NO_VALUE,
+      CELL_PROPERTY,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       NUMBERS,
       STRINGS,
       PREPROCESSOR,
+      PUNC,
       {
         begin: hljs.IDENT_RE + '::',
         keywords: ""

--- a/src/languages/dts.js
+++ b/src/languages/dts.js
@@ -82,7 +82,7 @@ export default function(hljs) {
   };
 
   const KEYWORD = {
-    className: 'meta-keyword',
+    className: 'meta',
     begin: '/[a-z][a-z\\d-]*/'
   };
 

--- a/src/languages/dts.js
+++ b/src/languages/dts.js
@@ -93,6 +93,7 @@ export default function(hljs) {
 
   const CELL_PROPERTY = {
     className: 'params',
+    relevance: 0,
     begin: '<',
     end: '>',
     contains: [
@@ -108,7 +109,7 @@ export default function(hljs) {
 
   const ROOT_NODE = {
     className: 'title.class',
-    begin: /\/(?=\s*\{)/,
+    begin: /^\/(?=\s*\{)/,
     relevance: 10
   };
 

--- a/test/markup/dts/default.expect.txt
+++ b/test/markup/dts/default.expect.txt
@@ -10,7 +10,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */</span>
-<span class="hljs-meta-keyword">/include/</span> <span class="hljs-string">&quot;skeleton.dtsi&quot;</span>
+<span class="hljs-meta">/include/</span> <span class="hljs-string">&quot;skeleton.dtsi&quot;</span>
 
 <span class="hljs-title class_">/</span> <span class="hljs-punctuation">{</span>
 	<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;xlnx,zynq-7000&quot;</span><span class="hljs-punctuation">;</span>

--- a/test/markup/dts/default.expect.txt
+++ b/test/markup/dts/default.expect.txt
@@ -12,60 +12,60 @@
  */</span>
 <span class="hljs-meta-keyword">/include/</span> <span class="hljs-string">&quot;skeleton.dtsi&quot;</span>
 
-<span class="hljs-class">/ {
-	compatible = <span class="hljs-string">&quot;xlnx,zynq-7000&quot;</span>;
+<span class="hljs-title class_">/</span> <span class="hljs-punctuation">{</span>
+	<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;xlnx,zynq-7000&quot;</span><span class="hljs-punctuation">;</span>
 
-	<span class="hljs-class">pmu </span>{
-		compatible = <span class="hljs-string">&quot;arm,cortex-a9-pmu&quot;</span>;
-		interrupts = <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">5</span> <span class="hljs-number">4</span>&gt;</span>, <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">6</span> <span class="hljs-number">4</span>&gt;</span>;
-		interrupt-parent = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span>;
-		reg = <span class="hljs-params">&lt; <span class="hljs-number">0xf8891000</span> <span class="hljs-number">0x1000</span> <span class="hljs-number">0xf8893000</span> <span class="hljs-number">0x1000</span> &gt;</span>;
-	};</span>
+	<span class="hljs-title class_">pmu</span> <span class="hljs-punctuation">{</span>
+		<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;arm,cortex-a9-pmu&quot;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">interrupts</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">5</span> <span class="hljs-number">4</span>&gt;</span>, <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">6</span> <span class="hljs-number">4</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">interrupt-parent</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">reg</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt; <span class="hljs-number">0xf8891000</span> <span class="hljs-number">0x1000</span> <span class="hljs-number">0xf8893000</span> <span class="hljs-number">0x1000</span> &gt;</span><span class="hljs-punctuation">;</span>
+	<span class="hljs-punctuation">};</span>
 <span class="hljs-symbol">
-	regulator_vccpint:</span> <span class="hljs-class">fixedregulator@0 </span>{
-		compatible = <span class="hljs-string">&quot;regulator-fixed&quot;</span>;
-		regulator-name = <span class="hljs-string">&quot;VCCPINT&quot;</span>;
-		regulator-min-microvolt = <span class="hljs-params">&lt;<span class="hljs-number">1000000</span>&gt;</span>;
-		regulator-max-microvolt = <span class="hljs-params">&lt;<span class="hljs-number">1000000</span>&gt;</span>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
+	regulator_vccpint:</span> <span class="hljs-title class_">fixedregulator@0</span> <span class="hljs-punctuation">{</span>
+		<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;regulator-fixed&quot;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">regulator-name</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;VCCPINT&quot;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">regulator-min-microvolt</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">1000000</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">regulator-max-microvolt</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">1000000</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">regulator-boot-on</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">regulator-always-on</span><span class="hljs-punctuation">;</span>
+	<span class="hljs-punctuation">};</span>
 <span class="hljs-symbol">
-	amba:</span> <span class="hljs-class">amba </span>{
-		compatible = <span class="hljs-string">&quot;simple-bus&quot;</span>;
+	amba:</span> <span class="hljs-title class_">amba</span> <span class="hljs-punctuation">{</span>
+		<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;simple-bus&quot;</span><span class="hljs-punctuation">;</span>
 		<span class="hljs-meta">#address-cells = &lt;1&gt;;</span>
 		<span class="hljs-meta">#size-cells = &lt;1&gt;;</span>
-		interrupt-parent = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span>;
-		ranges;
+		<span class="hljs-attr">interrupt-parent</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-attr">ranges</span><span class="hljs-punctuation">;</span>
 <span class="hljs-symbol">
-		adc:</span> <span class="hljs-class">adc@f8007100 </span>{
-			compatible = <span class="hljs-string">&quot;xlnx,zynq-xadc-1.00.a&quot;</span>;
-			reg = <span class="hljs-params">&lt;<span class="hljs-number">0xf8007100</span> <span class="hljs-number">0x20</span>&gt;</span>;
-			interrupts = <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">7</span> <span class="hljs-number">4</span>&gt;</span>;
-			interrupt-parent = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span>;
-			clocks = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;clkc</span> <span class="hljs-number">12</span>&gt;</span>;
-		};
+		adc:</span> <span class="hljs-title class_">adc@f8007100</span> <span class="hljs-punctuation">{</span>
+			<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;xlnx,zynq-xadc-1.00.a&quot;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">reg</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0xf8007100</span> <span class="hljs-number">0x20</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">interrupts</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">7</span> <span class="hljs-number">4</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">interrupt-parent</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">clocks</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;clkc</span> <span class="hljs-number">12</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-punctuation">};</span>
 <span class="hljs-symbol">
-		i2c0:</span> <span class="hljs-class">i2c@e0004000 </span>{
-			compatible = <span class="hljs-string">&quot;cdns,i2c-r1p10&quot;</span>;
-			status = <span class="hljs-string">&quot;disabled&quot;</span>;
-			clocks = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;clkc</span> <span class="hljs-number">38</span>&gt;</span>;
-			interrupt-parent = <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span>;
-			interrupts = <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">25</span> <span class="hljs-number">4</span>&gt;</span>;
-			reg = <span class="hljs-params">&lt;<span class="hljs-number">0xe0004000</span> <span class="hljs-number">0x1000</span>&gt;</span>;
+		i2c0:</span> <span class="hljs-title class_">i2c@e0004000</span> <span class="hljs-punctuation">{</span>
+			<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;cdns,i2c-r1p10&quot;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">status</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;disabled&quot;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">clocks</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;clkc</span> <span class="hljs-number">38</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">interrupt-parent</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-variable">&amp;intc</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">interrupts</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">25</span> <span class="hljs-number">4</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">reg</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0xe0004000</span> <span class="hljs-number">0x1000</span>&gt;</span><span class="hljs-punctuation">;</span>
 			<span class="hljs-meta">#address-cells = &lt;1&gt;;</span>
 			<span class="hljs-meta">#size-cells = &lt;0&gt;;</span>
-		};
+		<span class="hljs-punctuation">};</span>
 <span class="hljs-symbol">
-		L2:</span> cache-<span class="hljs-class">controller@f8f02000 </span>{
-			compatible = <span class="hljs-string">&quot;arm,pl310-cache&quot;</span>;
-			reg = <span class="hljs-params">&lt;<span class="hljs-number">0xF8F02000</span> <span class="hljs-number">0x1000</span>&gt;</span>;
-			interrupts = <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">2</span> <span class="hljs-number">4</span>&gt;</span>;
-			arm,data-latency = <span class="hljs-params">&lt;<span class="hljs-number">3</span> <span class="hljs-number">2</span> <span class="hljs-number">2</span>&gt;</span>;
-			arm,tag-latency = <span class="hljs-params">&lt;<span class="hljs-number">2</span> <span class="hljs-number">2</span> <span class="hljs-number">2</span>&gt;</span>;
-			cache-unified;
-			cache-level = <span class="hljs-params">&lt;<span class="hljs-number">2</span>&gt;</span>;
-		};
+		L2:</span> <span class="hljs-title class_">cache-controller@f8f02000</span> <span class="hljs-punctuation">{</span>
+			<span class="hljs-attr">compatible</span> <span class="hljs-operator">=</span> <span class="hljs-string">&quot;arm,pl310-cache&quot;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">reg</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0xF8F02000</span> <span class="hljs-number">0x1000</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">interrupts</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">0</span> <span class="hljs-number">2</span> <span class="hljs-number">4</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">arm,data-latency</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">3</span> <span class="hljs-number">2</span> <span class="hljs-number">2</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">arm,tag-latency</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">2</span> <span class="hljs-number">2</span> <span class="hljs-number">2</span>&gt;</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">cache-unified</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-attr">cache-level</span> <span class="hljs-operator">=</span> <span class="hljs-params">&lt;<span class="hljs-number">2</span>&gt;</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-punctuation">};</span>
 
-	};
-};
+	<span class="hljs-punctuation">};</span>
+<span class="hljs-punctuation">};</span>


### PR DESCRIPTION
Simplifies grammar as well as adds/improves support for:

- `punctuation`
- `operator`
- `attr`
- `title.class`


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`