### PR TITLE
Fix highlighting for rust raw byte string literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,7 @@ Dev Improvements:
 [Jared Luboff]: https://github.com/jaredlll08
 [NullVoxPopuli]: https://github.com/NullVoxPopuli
 [Mike Watling]: https://github.com/Pickysaurus
+[Nico Abram]:https://github.com/nico-abram
 
 
 ## Version 10.7.1
@@ -872,7 +873,6 @@ Language Improvements:
 [Kirill Saksin]: https://github.com/saksmt
 [Samia Ali]:https://github.com/samiaab1990
 [Erik Demaine]:https://github.com/edemaine
-[Nico Abram]:https://github.com/nico-abram
 
 
 ## Version 9.16.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,7 @@ Grammars:
 - enh(haskell) add support for NumericUnderscores (#3150) [Martijn Bastiaan][]
 - enh(haskell) add support for HexFloatLiterals (#3150) [Martijn Bastiaan][]
 - fix(c,cpp) allow declaring multiple functions and (for C++) parenthetical initializers (#3155) [Erik Demaine][]
+- enh(rust) highlight raw byte string literals correctly (#3173) [Nico Abram][]
 
 New Languages:
 
@@ -871,6 +872,7 @@ Language Improvements:
 [Kirill Saksin]: https://github.com/saksmt
 [Samia Ali]:https://github.com/samiaab1990
 [Erik Demaine]:https://github.com/edemaine
+[Nico Abram]:https://github.com/nico-abram
 
 
 ## Version 9.16.2

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -196,7 +196,7 @@ export default function(hljs) {
         className: 'string',
         variants: [
           {
-            begin: /r(#*)"(.|\n)*?"\1(?!#)/
+            begin: /b?r(#*)"(.|\n)*?"\1(?!#)/
           },
           {
             begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/

--- a/test/markup/rust/strings.expect.txt
+++ b/test/markup/rust/strings.expect.txt
@@ -12,3 +12,7 @@
 <span class="hljs-string">r###&quot;world&quot;###</span>;
 <span class="hljs-string">r##&quot; &quot;###
 &quot;# &quot;##</span>;
+
+<span class="hljs-string">br&quot; &quot;</span>;
+<span class="hljs-string">br#&quot;hello&quot;#</span>;
+<span class="hljs-string">br##&quot;foo&quot;##</span>;

--- a/test/markup/rust/strings.txt
+++ b/test/markup/rust/strings.txt
@@ -12,3 +12,7 @@ r"hello";
 r###"world"###;
 r##" "###
 "# "##;
+
+br" ";
+br#"hello"#;
+br##"foo"##;


### PR DESCRIPTION
Here's an example of what this should fix: https://doc.rust-lang.org/reference/tokens.html?highlight=raw%20string#raw-byte-string-literals


![imagen](https://user-images.githubusercontent.com/24706838/116771337-ea35c580-aa20-11eb-811d-6d726bcfb8be.png)
