### PR TITLE
(chore) Opt-out of package encapsulation for non-JS folders

### DIFF
--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -121,9 +121,9 @@ async function buildPackageJSON(options) {
     "./lib/common": dual("./lib/common.js"),
     "./lib/core": dual("./lib/core.js"),
     "./lib/languages/*": dual("./lib/languages/*.js"),
-    "./scss/": "./scss/",
-    "./styles/": "./styles/",
-    "./types/": "./types/",
+    "./scss/*": "./scss/*",
+    "./styles/*": "./styles/*",
+    "./types/*": "./types/*",
   };
   if (options.esm) packageJson.exports = exports;
 

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -121,6 +121,9 @@ async function buildPackageJSON(options) {
     "./lib/common": dual("./lib/common.js"),
     "./lib/core": dual("./lib/core.js"),
     "./lib/languages/*": dual("./lib/languages/*.js"),
+    "./scss/": "./scss/",
+    "./styles/": "./styles/",
+    "./types/": "./types/",
   };
   if (options.esm) packageJson.exports = exports;
 


### PR DESCRIPTION
Fixes: https://github.com/highlightjs/highlight.js/issues/3174

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Checklist
- [x] Added markup tests, or they don't apply here because markup is left untouched.
- [ ] Updated the changelog at `CHANGES.md`
