### PR TITLE
enh(sqf) improve function name highlighting (slightly broader)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,7 @@ Dev Improvements:
 [Josh Goebel]: https://github.com/joshgoebel
 [Ryan Mulligan]: https://github.com/ryantm
 [R3voA3]: https://github.com/R3voA3
+[JonBons]: https://github.com/JonBons
 [Wei Su]: https://github.com/swsoyee
 [Jared Luboff]: https://github.com/jaredlll08
 [NullVoxPopuli]: https://github.com/NullVoxPopuli

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,7 @@ Grammars:
 - enh(nginx) improving highlighting of some sections [Josh Goebel][]
 - fix(vim) variable names may not be zero length [Josh Goebel][]
 - enh(sqf) Updated keywords to Arma 3 v2.02 (#3084) [R3voA3][]
+- enh(sqf) Refactored function regex to match CBA component func naming scheme (#3181) [JonBons][]
 - enh(nim) highlight types properly (not as built-ins) [Josh Goebel][]
 - (chore) throttle deprecation messages (#3092) [Mihkel Eidast][]
 - enh(c) Update keyword list for C11/C18 (#3010) [Josh Goebel][]

--- a/src/languages/sqf.js
+++ b/src/languages/sqf.js
@@ -19,7 +19,7 @@ export default function(hljs) {
   // https://community.bistudio.com/wiki/Functions_Library_(Arma_3)#Adding_a_Function
   const FUNCTION = {
     className: 'title',
-    begin: /\w+_fnc_\w+/
+    begin: /[a-zA-Z]\w+_fnc_\w+/
   };
 
   // In SQF strings, quotes matching the start are escaped by adding a consecutive.

--- a/src/languages/sqf.js
+++ b/src/languages/sqf.js
@@ -19,7 +19,7 @@ export default function(hljs) {
   // https://community.bistudio.com/wiki/Functions_Library_(Arma_3)#Adding_a_Function
   const FUNCTION = {
     className: 'title',
-    begin: /[a-zA-Z][a-zA-Z0-9]+_fnc_\w*/
+    begin: /\w+_fnc_\w+/
   };
 
   // In SQF strings, quotes matching the start are escaped by adding a consecutive.

--- a/test/detect/sqf/default.txt
+++ b/test/detect/sqf/default.txt
@@ -13,4 +13,5 @@ _unit addAction ["Eat Energy Bar", {
     // 4 - means something...
     Z_obj_vip = nil;
     [_boat, ["Black", 1], true] call BIS_fnc_initVehicle;
+    [_boat] call myTag_component_fnc_initVehicle;
 }];

--- a/test/markup/sqf/default.expect.txt
+++ b/test/markup/sqf/default.expect.txt
@@ -13,4 +13,5 @@
     <span class="hljs-comment">// 4 - means something...</span>
     Z_obj_vip = <span class="hljs-literal">nil</span>;
     [<span class="hljs-variable">_boat</span>, [<span class="hljs-string">&quot;Black&quot;</span>, <span class="hljs-number">1</span>], <span class="hljs-literal">true</span>] <span class="hljs-built_in">call</span> <span class="hljs-title">BIS_fnc_initVehicle</span>;
+    [<span class="hljs-variable">_boat</span>] <span class="hljs-built_in">call</span> <span class="hljs-title">myTag_component_fnc_initVehicle</span>;
 }];

--- a/test/markup/sqf/default.txt
+++ b/test/markup/sqf/default.txt
@@ -13,4 +13,5 @@ _unit addAction ["Eat Energy Bar", {
     // 4 - means something...
     Z_obj_vip = nil;
     [_boat, ["Black", 1], true] call BIS_fnc_initVehicle;
+    [_boat] call myTag_component_fnc_initVehicle;
 }];


### PR DESCRIPTION
I've tweaked the function matching regex for the sqf language so that it can match functions with the `myTag_component_fnc_initVehicle` naming convention which is common with popular mods for arma, CBA, ACE, etc.

### Changes
Changed regex for sqf functions to `\w+_fnc_\w+` which matches the whole word now instead of just one section.

### Checklist
- [x] Updated markup tests,
- [x] Updated the changelog at `CHANGES.md`
