### PR TITLE
Fix hljs-attribute color in stackoverflow-dark

### DIFF
--- a/src/styles/stackoverflow-dark.css
+++ b/src/styles/stackoverflow-dark.css
@@ -27,7 +27,7 @@
 }
 
 .hljs-attribute {
-  color: v#c59bc1;
+  color: #c59bc1;
 }
 
 .hljs-name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

This PR fixes what seems a typo in the color for hljs-attribute in stackoverflow-dark, which disabled coloring of attributes.

### Checklist
- [ ] ~Added markup tests, or they don't apply here because...~ I didn't add tests since it's a small CSS change in a theme, but let me know if I should
- [ ] ~Updated the changelog at `CHANGES.md`~ I didn't add anything in the changelog, since it's such a minor fix. Happy to add one if you'd like though!
