### PR TITLE
(chore) Update StackOverflow themes for v11

### DIFF
--- a/src/styles/stackoverflow-dark.css
+++ b/src/styles/stackoverflow-dark.css
@@ -1,33 +1,50 @@
 /*!
- * StackOverflow.com dark style
- *
- * @stackoverflow/stacks v0.56.0
- * https://github.com/StackExchange/Stacks
- */
+  Theme: StackOverflow Dark
+  Description: Dark theme as used on stackoverflow.com
+  Author: stackoverflow.com
+  Maintainer: @Hirse
+  Website: https://github.com/StackExchange/Stacks
+  License: MIT
+  Updated: 2021-05-15
+
+  Updated for @stackoverflow/stacks v0.64.0
+  Code Blocks: /blob/v0.64.0/lib/css/components/_stacks-code-blocks.less
+  Colors: /blob/v0.64.0/lib/css/exports/_stacks-constants-colors.less
+*/
 
 .hljs {
+  /* var(--highlight-color) */
   color: #ffffff;
+  /* var(--highlight-bg) */
   background: #1c1b1b;
 }
 
+.hljs-subst {
+  /* var(--highlight-color) */
+  color: #ffffff;
+}
+
 .hljs-comment {
+  /* var(--highlight-comment) */
   color: #999999;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-meta .hljs-keyword,
-
 .hljs-doctag,
-.hljs-section,
-.hljs-selector-class,
-.hljs-meta,
-.hljs-selector-pseudo,
+.hljs-section {
+  /* var(--highlight-keyword) */
+  color: #88aece;
+}
+
 .hljs-attr {
+  /* var(--highlight-attribute); */
   color: #88aece;
 }
 
 .hljs-attribute {
+  /* var(--highlight-symbol) */
   color: #c59bc1;
 }
 
@@ -36,11 +53,14 @@
 .hljs-number,
 .hljs-selector-id,
 .hljs-quote,
-.hljs-template-tag,
-.hljs-built_in,
-.hljs-title,
-.hljs-literal {
+.hljs-template-tag {
+  /* var(--highlight-namespace) */
   color: #f08d49;
+}
+
+.hljs-selector-class {
+  /* var(--highlight-keyword) */
+  color: #88aece;
 }
 
 .hljs-string,
@@ -49,21 +69,42 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-link,
-.hljs-selector-attr,
-.hljs-meta .hljs-string {
+.hljs-selector-attr {
+  /* var(--highlight-variable) */
   color: #b5bd68;
+}
+
+.hljs-meta,
+.hljs-selector-pseudo {
+  /* var(--highlight-keyword) */
+  color: #88aece;
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  /* var(--highlight-literal) */
+  color: #f08d49;
 }
 
 .hljs-bullet,
 .hljs-code {
+  /* var(--highlight-punctuation) */
   color: #cccccc;
 }
 
+.hljs-meta .hljs-string {
+  /* var(--highlight-variable) */
+  color: #b5bd68;
+}
+
 .hljs-deletion {
+  /* var(--highlight-deletion) */
   color: #de7176;
 }
 
 .hljs-addition {
+  /* var(--highlight-addition) */
   color: #76c490;
 }
 
@@ -73,4 +114,13 @@
 
 .hljs-strong {
   font-weight: bold;
+}
+
+.hljs-formula,
+.hljs-operator,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
 }

--- a/src/styles/stackoverflow-light.css
+++ b/src/styles/stackoverflow-light.css
@@ -1,33 +1,50 @@
 /*!
- * StackOverflow.com light style
- *
- * @stackoverflow/stacks v0.56.0
- * https://github.com/StackExchange/Stacks
- */
+  Theme: StackOverflow Light
+  Description: Light theme as used on stackoverflow.com
+  Author: stackoverflow.com
+  Maintainer: @Hirse
+  Website: https://github.com/StackExchange/Stacks
+  License: MIT
+  Updated: 2021-05-15
+
+  Updated for @stackoverflow/stacks v0.64.0
+  Code Blocks: /blob/v0.64.0/lib/css/components/_stacks-code-blocks.less
+  Colors: /blob/v0.64.0/lib/css/exports/_stacks-constants-colors.less
+*/
 
 .hljs {
+  /* var(--highlight-color) */
   color: #2f3337;
+  /* var(--highlight-bg) */
   background: #f6f6f6;
 }
 
+.hljs-subst {
+  /* var(--highlight-color) */
+  color: #2f3337;
+}
+
 .hljs-comment {
+  /* var(--highlight-comment) */
   color: #656e77;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-meta .hljs-keyword,
-
 .hljs-doctag,
-.hljs-section,
-.hljs-selector-class,
-.hljs-meta,
-.hljs-selector-pseudo,
+.hljs-section {
+  /* var(--highlight-keyword) */
+  color: #015692;
+}
+
 .hljs-attr {
+  /* var(--highlight-attribute); */
   color: #015692;
 }
 
 .hljs-attribute {
+  /* var(--highlight-symbol) */
   color: #803378;
 }
 
@@ -36,11 +53,14 @@
 .hljs-number,
 .hljs-selector-id,
 .hljs-quote,
-.hljs-template-tag,
-.hljs-built_in,
-.hljs-title,
-.hljs-literal {
+.hljs-template-tag {
+  /* var(--highlight-namespace) */
   color: #b75501;
+}
+
+.hljs-selector-class {
+  /* var(--highlight-keyword) */
+  color: #015692;
 }
 
 .hljs-string,
@@ -49,21 +69,42 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-link,
-.hljs-selector-attr,
-.hljs-meta .hljs-string {
+.hljs-selector-attr {
+  /* var(--highlight-variable) */
   color: #54790d;
+}
+
+.hljs-meta,
+.hljs-selector-pseudo {
+  /* var(--highlight-keyword) */
+  color: #015692;
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  /* var(--highlight-literal) */
+  color: #b75501;
 }
 
 .hljs-bullet,
 .hljs-code {
+  /* var(--highlight-punctuation) */
   color: #535a60;
 }
 
+.hljs-meta .hljs-string {
+  /* var(--highlight-variable) */
+  color: #54790d;
+}
+
 .hljs-deletion {
+  /* var(--highlight-deletion) */
   color: #c02d2e;
 }
 
 .hljs-addition {
+  /* var(--highlight-addition) */
   color: #2f6f44;
 }
 
@@ -73,4 +114,13 @@
 
 .hljs-strong {
   font-weight: bold;
+}
+
+.hljs-formula,
+.hljs-operator,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
 }


### PR DESCRIPTION
### Changes
Adding metadata and missing selectors for v11 as described in #3134.
The new selectors are intentionally empty to keep the theme in line with the source.

Also changed the structure to be closer to the source for faster future updates.

### Checklist
- [x] ~Added markup tests~, or they don't apply here because only theme changes
- [x] ~Updated the changelog at `CHANGES.md`~ No public changes
