### PR TITLE
(chore) fix dual package hazard

### DIFF
--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -15,7 +15,7 @@ const safeImportName = (s) => {
 };
 
 async function buildESMIndex(name, languages) {
-  const header = `import hljs from './core.js';`;
+  const header = `import hljs from 'highlight.js/lib/core';`;
   const footer = "export default hljs;";
 
 
@@ -119,7 +119,10 @@ async function buildPackageJSON(options) {
     ".": dual("./lib/index.js"),
     "./package.json": "./package.json",
     "./lib/common": dual("./lib/common.js"),
-    "./lib/core": dual("./lib/core.js"),
+    "./lib/core": {
+      get node() { return this.require; },
+      ...dual("./lib/core.js"),
+    },
     "./lib/languages/*": dual("./lib/languages/*.js"),
     "./scss/*": "./scss/*",
     "./styles/*": "./styles/*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To avoid dual package hazard in Node.js, it's important that the instance of hljs is shared across CJS and ESM modules.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Refs: https://github.com/highlightjs/highlight.js/pull/3188

### Changes
<!--- Describe your changes -->
This PR is disabling use of ESM for the `core` module in Node.js, as ESM is able to import CJS modules but not the oother way around.

