### PR TITLE
Edn support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 11.1.0 (pending)
+
+Grammars:
+
+- enh(clojure) added `edn` alias (#3213) [Stel Abrego][]
+
+[Stel Abrego]: https://github.com/stelcodes
+
+
 ## Version 11.0.0
 
 **This is a major release.**  As such it contains breaking changes which may require action from users.  Please read [VERSION_11_UPGRADE.md](https://github.com/highlightjs/highlight.js/blob/main/VERSION_11_UPGRADE.md) for a detailed summary of all breaking changes.
@@ -102,7 +111,6 @@ Grammars:
 - fix(cpp) fix detection of common functions that are function templates (#3178) [Kris van Rens][]
 - enh(cpp) add various keywords and commonly used types for hinting (#3178) [Kris van Rens][]
 - enh(cpp) cleanup reserved keywords and type lists (#3178) [Kris van Rens][]
-- enh(clojure) added `edn` alias (#3213) [Stel Abrego][]
 
 New Languages:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,7 @@ Grammars:
 - fix(cpp) fix detection of common functions that are function templates (#3178) [Kris van Rens][]
 - enh(cpp) add various keywords and commonly used types for hinting (#3178) [Kris van Rens][]
 - enh(cpp) cleanup reserved keywords and type lists (#3178) [Kris van Rens][]
+- enh(clojure) added `edn` alias (#3213) [Stel Abrego][]
 
 New Languages:
 

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -143,7 +143,7 @@ export default function(hljs) {
 
   return {
     name: 'Clojure',
-    aliases: [ 'clj' ],
+    aliases: [ 'clj', 'edn' ],
     illegal: /\S/,
     contains: [
       LIST,

--- a/test/markup/clojure/deps_edn.expect.txt
+++ b/test/markup/clojure/deps_edn.expect.txt
@@ -1,0 +1,14 @@
+{<span class="hljs-symbol">:aliases</span> {<span class="hljs-symbol">:export</span> {<span class="hljs-symbol">:exec-fn</span> stelcodes.dev-blog.generator/export},
+           <span class="hljs-symbol">:repl</span> {<span class="hljs-symbol">:extra-deps</span> {cider/cider-nrepl {<span class="hljs-symbol">:mvn/version</span> <span class="hljs-string">&quot;0.25.2&quot;</span>},
+                               nrepl/nrepl {<span class="hljs-symbol">:mvn/version</span> <span class="hljs-string">&quot;0.8.3&quot;</span>}},
+                  <span class="hljs-symbol">:extra-paths</span> [<span class="hljs-string">&quot;dev&quot;</span>],
+                  <span class="hljs-symbol">:main-opts</span> [<span class="hljs-string">&quot;-m&quot;</span>
+                              <span class="hljs-string">&quot;nrepl.cmdline&quot;</span>
+                              <span class="hljs-string">&quot;--middleware&quot;</span>
+                              <span class="hljs-string">&quot;[cider.nrepl/cider-middleware]&quot;</span>
+                              <span class="hljs-string">&quot;--interactive&quot;</span>]},
+           <span class="hljs-symbol">:webhook</span> {<span class="hljs-symbol">:exec-fn</span> stelcodes.dev-blog.webhook/listen}},
+ <span class="hljs-symbol">:deps</span> {http-kit/http-kit {<span class="hljs-symbol">:mvn/version</span> <span class="hljs-string">&quot;2.5.3&quot;</span>},
+        org.clojure/clojure {<span class="hljs-symbol">:mvn/version</span> <span class="hljs-string">&quot;1.10.1&quot;</span>},
+        stasis/stasis {<span class="hljs-symbol">:mvn/version</span> <span class="hljs-string">&quot;2.5.1&quot;</span>}},
+ <span class="hljs-symbol">:paths</span> [<span class="hljs-string">&quot;src&quot;</span> <span class="hljs-string">&quot;resources&quot;</span>]}

--- a/test/markup/clojure/deps_edn.txt
+++ b/test/markup/clojure/deps_edn.txt
@@ -1,0 +1,14 @@
+{:aliases {:export {:exec-fn stelcodes.dev-blog.generator/export},
+           :repl {:extra-deps {cider/cider-nrepl {:mvn/version "0.25.2"},
+                               nrepl/nrepl {:mvn/version "0.8.3"}},
+                  :extra-paths ["dev"],
+                  :main-opts ["-m"
+                              "nrepl.cmdline"
+                              "--middleware"
+                              "[cider.nrepl/cider-middleware]"
+                              "--interactive"]},
+           :webhook {:exec-fn stelcodes.dev-blog.webhook/listen}},
+ :deps {http-kit/http-kit {:mvn/version "2.5.3"},
+        org.clojure/clojure {:mvn/version "1.10.1"},
+        stasis/stasis {:mvn/version "2.5.1"}},
+ :paths ["src" "resources"]}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I added an alias for clojure, "edn", so edn tagged markup will get the syntax highlighting as clojure. I also added a markup test using the [deps.edn](https://github.com/babashka/babashka/blob/master/deps.edn) file from [babashka](https://github.com/babashka/babashka). I definitely need some review and advice because this is my first contribution. Very new to the code base. Ran `npm run build_and_test` and all the tests passed. I couldn't get `npm run test` or `npm run test-markup` to run, however. Getting `Error: Cannot find module '../build'` errors.
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3205 
### Changes
<!--- Describe your changes -->
Added "edn" to clojure aliases, added edn markup test
### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
