### PR TITLE
(HIGHLIGHT) - Add support to highlight to "BACKFILL" keyword in SQL

### DIFF
--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -120,6 +120,7 @@ export default function(hljs) {
     "atomic",
     "authorization",
     "avg",
+    "backfill",
     "begin",
     "begin_frame",
     "begin_partition",


### PR DESCRIPTION
Add support to highlight to "BACKFILL" keyword in SQL
So basically if you see this issue, https://github.com/yugabyte/yugabyte-db/issues/7330, BACKFILL keyword is not highlighted in case of SQL even though other commands like CREATE, UPDATE are. Hence adding BACKFILL to the list of keywords

### Changes
Add "BACKFILL" to list of reserved keywords in SQL.js

### Checklist
- [x] Added markup tests, or they don't apply here because
- [x] Updated the changelog at `CHANGES.md`
