### PR TITLE
fix(python) identifiers starting with underscore not highlighted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,13 @@
 
 Grammars:
 
+- fix(python) identifiers starting with underscore not highlighted (#3221) [Antoine Lambert][]
 - enh(clojure) added `edn` alias (#3213) [Stel Abrego][]
 - enh(elixir) much improved regular expression sigil support (#3207) [Josh Goebel][]
 
 [Stel Abrego]: https://github.com/stelcodes
 [Josh Goebel]: https://github.com/joshgoebel
+[Antoine Lambert]: https://github.com/anlambert
 
 ## Version 11.0.0
 

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -5,7 +5,7 @@ Website: https://www.python.org
 Category: common
 */
 
-import { IDENT_RE } from '../lib/modes.js';
+import { UNDERSCORE_IDENT_RE } from '../lib/modes.js';
 import * as regex from '../lib/regex.js';
 
 export default function(hljs) {
@@ -379,7 +379,7 @@ export default function(hljs) {
       {
         match: [
           /def/, /\s+/,
-          IDENT_RE
+          UNDERSCORE_IDENT_RE
         ],
         scope: {
           1: "keyword",
@@ -392,14 +392,14 @@ export default function(hljs) {
           {
             match: [
               /class/, /\s+/,
-              IDENT_RE, /\s*/,
-              /\(\s*/, IDENT_RE,/\s*\)/
+              UNDERSCORE_IDENT_RE, /\s*/,
+              /\(\s*/, UNDERSCORE_IDENT_RE,/\s*\)/
             ],
           },
           {
             match: [
               /class/, /\s+/,
-              IDENT_RE
+              UNDERSCORE_IDENT_RE
             ],
           }
         ],

--- a/test/markup/python/identifiers.expect.txt
+++ b/test/markup/python/identifiers.expect.txt
@@ -1,0 +1,15 @@
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">func</span>():
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">_private_func</span>():
+    <span class="hljs-keyword">pass</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">IdentifiersTest</span>:
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">pass</span>
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">method</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">pass</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">_PrivateClass</span>:
+    <span class="hljs-keyword">pass</span>

--- a/test/markup/python/identifiers.txt
+++ b/test/markup/python/identifiers.txt
@@ -1,0 +1,15 @@
+def func():
+    pass
+
+def _private_func():
+    pass
+
+class IdentifiersTest:
+    def __init__(self):
+        pass
+
+    def method(self):
+        pass
+
+class _PrivateClass:
+    pass


### PR DESCRIPTION
Hello and thanks for maintaining that great library.

I noticed a regression in `highlightjs.js 11.0`, Python identifiers starting with an underscore
character (`__init__` for instance) are no longer highlighted (introduced in 952fa0a).

That PR fixes that issue and add new markup tests to cover it.

On a related note, Python 3.0 introduces additional characters from [outside the ASCII range](https://docs.python.org/3/reference/lexical_analysis.html#identifiers) for identifiers. Adding support for those in highlight.js is out of that PR scope and does not seem easy to implement but I could try to have a look when I have some time.