### PR TITLE
fix(parser) Resolve issue with missing TS property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 10.7.3 (pending)
+
+- fix(parser) Resolves issue with missing TypeScript property [Jacob Swanner][]
+
+[Jacob Swanner]: https://github.com/jswanner
+
 ## Version 10.7.2
 
 This is a patch release.  The only change is that deprecation messages

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@ interface PublicApi {
     highlightAuto: (code: string, languageSubset?: string[]) => AutoHighlightResult
     fixMarkup: (html: string) => string
     highlightBlock: (element: HTMLElement) => void
+    highlightElement: (element: HTMLElement) => void
     configure: (options: Partial<HLJSOptions>) => void
     initHighlighting: () => void
     initHighlightingOnLoad: () => void


### PR DESCRIPTION
Using `highlightElement` with version 10.7.2 causes the following TypeScript build error:

```
error TS2339: Property 'highlightElement' does not exist on type 'HLJSApi'.
```

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
fix(parser) Resolves issue with missing TypeScript property

### Checklist
- [x] Added markup tests, or they don't apply here because only modified types definitions
- [x] Updated the changelog at `CHANGES.md`
