### PR TITLE
fix(elixir) Bring back the `when` keyword

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -41,6 +41,7 @@ export default function(hljs) {
     "unquote",
     "unquote_splicing",
     "use",
+    "when",
     "with|0"
   ];
   const LITERALS = [

--- a/test/markup/elixir/conditionals.expect.txt
+++ b/test/markup/elixir/conditionals.expect.txt
@@ -1,6 +1,7 @@
 <span class="hljs-keyword">case</span> x <span class="hljs-keyword">do</span>
   <span class="hljs-number">1</span> -&gt; <span class="hljs-symbol">:one</span>
   <span class="hljs-number">2</span> -&gt; <span class="hljs-symbol">:two</span>
+  n <span class="hljs-keyword">when</span> is_integer(n) -&gt; <span class="hljs-symbol">:more</span>
   _ -&gt; <span class="hljs-symbol">:error</span>
 <span class="hljs-keyword">end</span>
 

--- a/test/markup/elixir/conditionals.txt
+++ b/test/markup/elixir/conditionals.txt
@@ -1,6 +1,7 @@
 case x do
   1 -> :one
   2 -> :two
+  n when is_integer(n) -> :more
   _ -> :error
 end
 


### PR DESCRIPTION
### Changes

I accidentally removed `when` from the keyword list in https://github.com/highlightjs/highlight.js/pull/3212

This PR brings it back.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
