### PR TITLE
Add pwsh as an alias for Powershell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Grammars:
 
+- enh(powershell) added `pwsh` alias (#3236) [tebeco][]
 - fix(r) fix bug highlighting examples in doc comments [Konrad Rudolph][]
 - fix(python) identifiers starting with underscore not highlighted (#3221) [Antoine Lambert][]
 - enh(clojure) added `edn` alias (#3213) [Stel Abrego][]
@@ -14,6 +15,8 @@ Grammars:
 [Antoine Lambert]: https://github.com/anlambert
 [Angelika Tyborska]: https://github.com/angelikatyborska
 [Konrad Rudolph]: https://github.com/klmr
+[tebeco]: https://github.com/tebeco
+
 
 ## Version 11.0.0
 

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -345,6 +345,7 @@ export default function(hljs) {
   return {
     name: 'PowerShell',
     aliases: [
+      "pwsh",
       "ps",
       "ps1"
     ],


### PR DESCRIPTION
`pwsh` is the name of the shell binary for powershell core
`powershell` is the name of the shell binary for the old deprecated Windows PowerShell

Resolves #3235

### Changes
adding `pwsh` in the `alias` list of `powershell`

### Checklist
No clue how to do that yet, any hint ?
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
