### PR TITLE
Add additional keywords for CSP.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Grammars:
 
+- add additional keywords to csp.js (#3244) [Elijah Conners][]
 - fix(markdown) Images with empty alt or links with empty text (#3233) [Josh Goebel][]
 - enh(powershell) added `pwsh` alias (#3236) [tebeco][]
 - fix(r) fix bug highlighting examples in doc comments [Konrad Rudolph][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Grammars:
 [Stel Abrego]: https://github.com/stelcodes
 [Josh Goebel]: https://github.com/joshgoebel
 [Antoine Lambert]: https://github.com/anlambert
+[Elijah Conners]: https://github.com/elijahepepe
 [Angelika Tyborska]: https://github.com/angelikatyborska
 [Konrad Rudolph]: https://github.com/klmr
 [tebeco]: https://github.com/tebeco

--- a/src/languages/csp.js
+++ b/src/languages/csp.js
@@ -19,13 +19,17 @@ export default function(hljs) {
     "frame-ancestors",
     "frame-src",
     "img-src",
+    "manifest-src",
     "media-src",
     "object-src",
     "plugin-types",
     "report-uri",
     "sandbox",
     "script-src",
-    "style-src"
+    "style-src",
+    "trusted-types",
+    "unsafe-hashes",
+    "worker-src"
   ];
   return {
     name: 'CSP',


### PR DESCRIPTION
worker-src, unsafe-hashes, trusted-types, and manifest-src

### Changes
Add worker-src, unsafe-hashes, trusted-types, and manifest-src to the list of keywords in csp.js

### Checklist
- [ ] Added worker-src, unsafe-hashes, trusted-types, and manifest-src to the list of keywords in csp.js