### PR TITLE
Allow wider syntax for magic comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Grammars:
 - enh(elixir) updated list of keywords (#3212) [Angelika Tyborska][]
 - fix(elixir) fixed number detection when numbers start with a zero (#3212) [Angelika Tyborska][]
 - fix(ps1) Flag highlighted incorrectly (#3167) [Pankaj Patil][]
+- fix(latex) Allow wider syntax for magic comments (#3243) [Benedikt Wilde][]
 
 [Stel Abrego]: https://github.com/stelcodes
 [Josh Goebel]: https://github.com/joshgoebel
@@ -21,6 +22,7 @@ Grammars:
 [Konrad Rudolph]: https://github.com/klmr
 [tebeco]: https://github.com/tebeco
 [Pankaj Patil]: https://github.com/patil2099
+[Benedikt Wilde]: https://github.com/schtandard
 
 
 ## Version 11.0.0

--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -105,7 +105,7 @@ export default function(hljs) {
   };
   const MAGIC_COMMENT = {
     className: 'meta',
-    begin: /% ?!(?:T[eE]X|tex|BIB|bib)/,
+    begin: /% ?!(T[eE]X|tex|BIB|bib)/,
     end: '$',
     relevance: 10
   };

--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -105,7 +105,7 @@ export default function(hljs) {
   };
   const MAGIC_COMMENT = {
     className: 'meta',
-    begin: '% !TeX',
+    begin: /% ?!(?:T[eE]X|tex|BIB|bib)/,
     end: '$',
     relevance: 10
   };

--- a/test/markup/latex/comments.expect.txt
+++ b/test/markup/latex/comments.expect.txt
@@ -2,3 +2,10 @@
 foo<span class="hljs-comment">%</span>
 <span class="hljs-meta">% !TeX program = pdflatex</span>
 <span class="hljs-comment">%% !TeX encoding = utf8</span>
+<span class="hljs-meta">%!TEX spellcheck = en-US</span>
+<span class="hljs-comment">%  !TeX foo</span>
+<span class="hljs-meta">% !tex foo</span>
+<span class="hljs-comment">% !tEx foo</span>
+<span class="hljs-meta">% !BIB foo</span>
+<span class="hljs-meta">%!bib foo</span>
+<span class="hljs-comment">% !Bib foo</span>

--- a/test/markup/latex/comments.txt
+++ b/test/markup/latex/comments.txt
@@ -2,3 +2,10 @@
 foo%
 % !TeX program = pdflatex
 %% !TeX encoding = utf8
+%!TEX spellcheck = en-US
+%  !TeX foo
+% !tex foo
+% !tEx foo
+% !BIB foo
+%!bib foo
+% !Bib foo


### PR DESCRIPTION
Resolves #3243.

### Changes
Only the `begin` regex for magic comments has been changed to allow for the more flexible syntax.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
