### PR TITLE
fix(csharp) Add missing highlighting  `catch` keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Grammars:
 
+- fix(csharp) add missing `catch` keyword (#3251) [Konrad Rudolph][]
 - add additional keywords to csp.js (#3244) [Elijah Conners][]
 - fix(markdown) Images with empty alt or links with empty text (#3233) [Josh Goebel][]
 - enh(powershell) added `pwsh` alias (#3236) [tebeco][]

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -59,6 +59,7 @@ export default function(hljs) {
     'base',
     'break',
     'case',
+    'catch',
     'class',
     'const',
     'continue',

--- a/test/markup/csharp/try-catch.expect.txt
+++ b/test/markup/csharp/try-catch.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-keyword">try</span>
+{
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> InvalidCastException();
+}
+<span class="hljs-keyword">catch</span> (InvalidCastException e) <span class="hljs-keyword">when</span> (e.Data != <span class="hljs-literal">null</span>)
+{
+    <span class="hljs-keyword">throw</span>;
+}

--- a/test/markup/csharp/try-catch.txt
+++ b/test/markup/csharp/try-catch.txt
@@ -1,0 +1,8 @@
+try
+{
+    throw new InvalidCastException();
+}
+catch (InvalidCastException e) when (e.Data != null)
+{
+    throw;
+}


### PR DESCRIPTION
See https://stackoverflow.com/q/67076915/1968 & comments therein.

### Changes

Add `catch` as a C# keyword.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
