### PR TITLE
enh(xml) Allow Unicode attribute and tag names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Grammars:
 
+- fix(xml) allow Unicode letters in XML element and attribute names(#3256)[Martin Honnen][]
 - fix(csharp) add missing `catch` keyword (#3251) [Konrad Rudolph][]
 - add additional keywords to csp.js (#3244) [Elijah Conners][]
 - feat(css) handle css variables syntax (#3239) [Thanos Karagiannis][]
@@ -18,6 +19,7 @@ Grammars:
 
 [Stel Abrego]: https://github.com/stelcodes
 [Josh Goebel]: https://github.com/joshgoebel
+[Martin Honnen]: https://github.com/martin-honnen
 [Antoine Lambert]: https://github.com/anlambert
 [Elijah Conners]: https://github.com/elijahepepe
 [Angelika Tyborska]: https://github.com/angelikatyborska

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -10,12 +10,12 @@ import * as regex from '../lib/regex.js';
 /** @type LanguageFn */
 export default function (hljs) {
   // XML names start with the following Unicode characters: https://www.w3.org/TR/xml/#NT-NameStartChar
-  //const NAME_START_CHAR = /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/;
+  // NAME_START_CHAR = /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/;
   // XML names can have the following additional letters: https://www.w3.org/TR/xml/#NT-NameChar
-  //const OTHER_NAME_CHARS = /[:\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]/;
+  // OTHER_NAME_CHARS = /[:\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]/;
   // Element names start with NAME_START_CHAR followed by optional other Unicode letters, ASCII digits, hyphens, underscores, and periods
   const TAG_NAME_RE = regex.concat(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/, regex.optional(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*:/), /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*/);;
-  const XML_IDENT_RE = /[A-Z_a-z:\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]+/;///[A-Za-z0-9._:-]+/;
+  const XML_IDENT_RE = /[A-Z_a-z:\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]+/;
   const XML_ENTITIES = {
     className: 'symbol',
     begin: /&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -15,7 +15,7 @@ export default function (hljs) {
   //const OTHER_NAME_CHARS = /[:\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]/;
   // Element names start with NAME_START_CHAR followed by optional other Unicode letters, ASCII digits, hyphens, underscores, and periods
   const TAG_NAME_RE = regex.concat(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/, regex.optional(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*:/), /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*/);;
-  const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
+  const XML_IDENT_RE = /[A-Z_a-z:\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]+/;///[A-Za-z0-9._:-]+/;
   const XML_ENTITIES = {
     className: 'symbol',
     begin: /&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -8,9 +8,13 @@ Audit: 2020
 import * as regex from '../lib/regex.js';
 
 /** @type LanguageFn */
-export default function(hljs) {
-  // Element names can contain letters, digits, hyphens, underscores, and periods
-  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]*:/), /[A-Z0-9_.-]*/);
+export default function (hljs) {
+  // XML names start with the following Unicode characters: https://www.w3.org/TR/xml/#NT-NameStartChar
+  //const NAME_START_CHAR = /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/;
+  // XML names can have the following additional letters: https://www.w3.org/TR/xml/#NT-NameChar
+  //const OTHER_NAME_CHARS = /[:\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]/;
+  // Element names start with NAME_START_CHAR followed by optional other Unicode letters, ASCII digits, hyphens, underscores, and periods
+  const TAG_NAME_RE = regex.concat(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/, regex.optional(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*:/), /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*/);;
   const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
   const XML_ENTITIES = {
     className: 'symbol',

--- a/test/markup/xml/non-ascii-element-name.expect.txt
+++ b/test/markup/xml/non-ascii-element-name.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-tag">&lt;<span class="hljs-name">categoría</span>&gt;</span>producto<span class="hljs-tag">&lt;/<span class="hljs-name">categoría</span>&gt;</span>

--- a/test/markup/xml/non-ascii-element-name.txt
+++ b/test/markup/xml/non-ascii-element-name.txt
@@ -1,0 +1,1 @@
+<categoría>producto</categoria>

--- a/test/markup/xml/non-ascii-element-name.txt
+++ b/test/markup/xml/non-ascii-element-name.txt
@@ -1,1 +1,1 @@
-<categoría>producto</categoria>
+<categoría>producto</categoría>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixing regular expressions `TAG_NAME_RE` and `XML_IDENT_RE` to include non-ASCII letters the XML spec allows as Unicode range `\uDDDD-\uDDDD`, as far as JavaScript allows that with four digit hex codes
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
This is my attempt to fix issue 3256 https://github.com/highlightjs/highlight.js/issues/3256, instead of using only ASCII letters I fixed the regular expressions to include non-ASCII letters from the XML spec, expressing them as Unicode range `\uDDDD-\uDDDD`
### Changes
<!--- Describe your changes -->
Included non-ASCII letters the XML spec allows as Unicode ranges in regular expressions `TAG_NAME_RE` and `XML_IDENT_RE`
### Checklist
- [X] Added markup test non-ascii-element-name.txt
- [X] Updated the changelog at `CHANGES.md`
