### PR TITLE
Fix registered language name for grammar names with dash, fixes #3263.

### DIFF
--- a/src/stub.js
+++ b/src/stub.js
@@ -5,6 +5,10 @@ import * as builtIns from "builtInLanguages";
 const hljs = HighlightJS;
 
 for (const key of Object.keys(builtIns)) {
+  // our builtInLanguages Rollup plugin has to use `_` to allow identifiers to be 
+  // compatible with `export` naming conventions, so we need to convert the 
+  // identifiers back into the more typical dash style that we use for language 
+  // naming via the API
   const languageName = key.replace("grmr_", "").replace("_", "-");
   hljs.registerLanguage(languageName, builtIns[key]);
 }

--- a/src/stub.js
+++ b/src/stub.js
@@ -5,9 +5,9 @@ import * as builtIns from "builtInLanguages";
 const hljs = HighlightJS;
 
 for (const key of Object.keys(builtIns)) {
-  // our builtInLanguages Rollup plugin has to use `_` to allow identifiers to be 
-  // compatible with `export` naming conventions, so we need to convert the 
-  // identifiers back into the more typical dash style that we use for language 
+  // our builtInLanguages Rollup plugin has to use `_` to allow identifiers to be
+  // compatible with `export` naming conventions, so we need to convert the
+  // identifiers back into the more typical dash style that we use for language
   // naming via the API
   const languageName = key.replace("grmr_", "").replace("_", "-");
   hljs.registerLanguage(languageName, builtIns[key]);

--- a/src/stub.js
+++ b/src/stub.js
@@ -5,7 +5,7 @@ import * as builtIns from "builtInLanguages";
 const hljs = HighlightJS;
 
 for (const key of Object.keys(builtIns)) {
-  const languageName = key.replace("grmr_", "");
+  const languageName = key.replace("grmr_", "").replace("_", "-");
   hljs.registerLanguage(languageName, builtIns[key]);
 }
 // console.log(hljs.listLanguages());

--- a/test/builds/browser_build_as_commonjs.js
+++ b/test/builds/browser_build_as_commonjs.js
@@ -21,4 +21,13 @@ API.forEach(n => {
   assert(_ => keys.includes(n), `API should include ${n}`);
 });
 
+// See e.g. highlightjs/highlight.js#3263
+const langs = ["python", "python-repl"]
+langs.forEach(n => {
+  assert(_ => {
+    res = hljs.getLanguage(n);
+    return typeof res === 'object' && res !== null
+  })
+})
+
 console.log("Pass: browser build works with Node.js just fine.")


### PR DESCRIPTION
Grammars with `-` in the name (`julia-repl`) now correctly register as that instead of `julia_repl`. The replacement here should reverse the modification in https://github.com/highlightjs/highlight.js/blob/55f68f72be2cb69d14561353ad851d6b2242dfcc/tools/build_browser.js#L190

fixes #3263