### PR TITLE
fix(types) Fix some type definition issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 11.2.0 (pending)
+
+Parser:
+
+- fix(types) Fix some type definition issues (#3274) [Josh Goebel][]
+
+[Josh Goebel]: https://github.com/joshgoebel
+
 ## Version 11.1.0
 
 Grammars:

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -428,7 +428,7 @@ const HLJS = function(hljs) {
         }
       }
       do {
-        if (top.scope && !top.isMultiClass) {
+        if (top.scope) {
           emitter.closeNode();
         }
         if (!top.skip && !top.subLanguage) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -212,9 +212,11 @@ declare module 'highlight.js' {
         begin?: RegExp | string | (RegExp | string)[]
         match?: RegExp | string | (RegExp | string)[]
         end?: RegExp | string | (RegExp | string)[]
+        // deprecated in favor of `scope`
         className?: string
         scope?: string | Record<number, string>
         beginScope?: string | Record<number, string>
+        endScope?: string | Record<number, string>
         contains?: ("self" | Mode)[]
         endsParent?: boolean
         endsWithParent?: boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,7 +74,7 @@ declare module 'highlight.js' {
         RE_STARTERS_RE: string
     }
 
-    export type LanguageFn = (hljs?: HLJSApi) => Language
+    export type LanguageFn = (hljs: HLJSApi) => Language
     export type CompilerExt = (mode: Mode, parent: Mode | Language | null) => void
 
     export interface HighlightResult {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -213,7 +213,6 @@ declare module 'highlight.js' {
         match?: RegExp | string | (RegExp | string)[]
         end?: RegExp | string | (RegExp | string)[]
         className?: string
-        _emit?: Record<number, boolean>
         scope?: string | Record<number, string>
         beginScope?: string | Record<number, string>
         contains?: ("self" | Mode)[]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -209,9 +209,9 @@ declare module 'highlight.js' {
         }
 
     interface ModeDetails {
-        begin?: RegExp | string
-        match?: RegExp | string
-        end?: RegExp | string
+        begin?: RegExp | string | (RegExp | string)[]
+        match?: RegExp | string | (RegExp | string)[]
+        end?: RegExp | string | (RegExp | string)[]
         className?: string
         _emit?: Record<number, boolean>
         scope?: string | Record<number, string>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -201,7 +201,6 @@ declare module 'highlight.js' {
             illegalRe: RegExp
             matcher: any
             isCompiled: true
-            isMultiClass?: boolean
             starts?: CompiledMode
             parent?: CompiledMode
             beginScope?: Record<number, string> & {_emit?: Record<number,boolean>, _multi?: boolean, _wrap?: string}


### PR DESCRIPTION
Should resolve #3272 and #3273.

### Changes

- fix(types) begin, match, end all now take arrays
- fix(types) _emit now a scope attribute, not mode attribute
- fix(types) do not forget about endScope
- remove dead code
- fix(types) make hljs not optional


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
