### PR TITLE
fix(js/ts) fix detecting types as JSX

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -38,21 +38,30 @@ export default function(hljs) {
     isTrulyOpeningTag: (match, response) => {
       const afterMatchIndex = match[0].length + match.index;
       const nextChar = match.input[afterMatchIndex];
-      // nested type?
-      // HTML should not include another raw `<` inside a tag
-      // But a type might: `<Array<Array<number>>`, etc.
-      if (nextChar === "<") {
+      // TODO: can this conditional be removed entirely?
+      // in favor of the fallback below?
+      if (
+        // HTML should not include another raw `<` inside a tag
+        // nested type?
+        // `<Array<Array<number>>`, etc.
+        nextChar === "<" ||
+        // the , gives away that this is not HTML
+        // `<T, A extends keyof T, V>`
+        nextChar === ",") {
         response.ignoreMatch();
         return;
       }
-      // <something>
-      // This is now either a tag or a type.
-      if (nextChar === ">") {
+      // `<something>` or `<something ...`
+      // Quite possibly a tag, lets look for a matching closing tag...
+      if (nextChar === ">" || nextChar === " ") {
         // if we cannot find a matching closing tag, then we
         // will ignore it
         if (!hasClosingTag(match, { after: afterMatchIndex })) {
           response.ignoreMatch();
         }
+      } else {
+        // fallback, doesn't look like HTML
+        response.ignoreMatch();
       }
     }
   };
@@ -460,6 +469,7 @@ export default function(hljs) {
                 end: XML_TAG.end
               }
             ],
+            scope: "booger",
             subLanguage: 'xml',
             contains: [
               {


### PR DESCRIPTION
Resolves #3276.

### Changes

- adds a fallback default so when a confusing `<....>` block appears not to be JSX/HTML it's falls back to simply being ignored
- this should prevent false positives of JSX blocks that effectively (and in some cases silently) break further highlighting

Prior there was no fallback so if the common cases didn't classify the block it would DEFAULT to being HTML... where-as we really shouldn't consider something HTML unless it not only LOOKS like HTML but we can also find a closing tag.

I'm not sure the first conditional is needed at all now and think perhaps:

- If `<blah` is followed by `>` or space it MIGHT be HTML/JSX and we should search for a closing tag
- if not, then the JSX rule should ignore it

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
