### PR TITLE
Trusted Types compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 11.1.1 (pending)
 
-- Trusted Types compatibility [Jakub Vrána][]
+- Trusted Types compatibility (#3281) [Jakub Vrána][]
 
 [Jakub Vrána]: https://github.com/vrana
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 11.1.1 (pending)
+
+- Trusted Types compatibility [Jakub Vrána][]
+
+[Jakub Vrána]: https://github.com/vrana
+
 ## Version 11.1.0
 
 Grammars:

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -709,7 +709,7 @@ const HLJS = function(hljs) {
   }
 
   let ttPolicy = {createHTML: s => s};
-  if (typeof trustedTypes != 'undefined') {
+  if (typeof trustedTypes != 'undefined' && trustedTypes.createPolicy) {
     ttPolicy = trustedTypes.createPolicy('highlight.js', ttPolicy);
   }
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -708,6 +708,11 @@ const HLJS = function(hljs) {
     element.classList.add(`language-${language}`);
   }
 
+  let ttPolicy = {createHTML: s => s};
+  if (typeof trustedTypes != 'undefined') {
+    ttPolicy = trustedTypes.createPolicy('highlight.js', ttPolicy);
+  }
+
   /**
    * Applies highlighting to a DOM node containing code.
    *
@@ -734,7 +739,7 @@ const HLJS = function(hljs) {
     const text = node.textContent;
     const result = language ? highlight(text, { language, ignoreIllegals: true }) : highlightAuto(text);
 
-    element.innerHTML = result.value;
+    element.innerHTML = ttPolicy.createHTML(result.value);
     updateClassName(element, language, result.language);
     element.result = {
       language: result.language,


### PR DESCRIPTION
https://web.dev/trusted-types/ disallows string assignments to `innerHTML`. This change makes the code compatible by converting the string to `TrustedHTML` if the browser supports Trusted Types.

### Checklist
- [X] Added markup tests, or they don't apply here because the change is not markup related.
- [X] Updated the changelog at `CHANGES.md`
