### PR TITLE
(chore) fix CSS in the dev tool to be cross-browser once again

### DIFF
--- a/tools/developer.html
+++ b/tools/developer.html
@@ -39,31 +39,29 @@
     }
 
     .visible-structure pre code span {
-      display: inline flow-root list-item;
-      list-style: none;
-      padding: 0.2rem 0.25rem;
-      padding-bottom: 0.25rem;
-      margin: 0.5rem 0.25rem 0.25rem 0.25rem;
       border: 1px dashed #777;
       border-radius: 3px;
-      white-space: pre;
+      display: inline-block;
+      margin-top: 1.4rem;
+      line-height: 1rem;
+      padding: 0 0.25rem;
       position: relative;
-      vertical-align: super;
+      white-space: pre;
     }
 
     .visible-structure pre code span:before {
-      display: inline-block;
-      content: attr(data-klass);
-      font-size: 70%;
       background: #693;
-      padding:1px 4px;
       border-radius: 2px;
       color:white;
-      margin-right:0.25rem;
-      font-weight: normal;
+      content: attr(data-klass);
+      font-size: 70%;
+      left: 0;
+      line-height: 1;
+      padding: 0.2rem 0.25rem;
       position: absolute;
-      top: -0.5rem;
-      left: -0.25rem;
+      top: 0;
+      transform: translate(0, -1.15rem);
+      white-space: nowrap;
     }
 
     .visible-structure pre code span:after {

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -49,6 +49,10 @@
       white-space: pre;
     }
 
+    .visible-structure pre code span span {
+      margin-bottom: 5px;
+    }
+
     .visible-structure pre code span:before {
       background: #693;
       border-radius: 2px;


### PR DESCRIPTION
Related to #3133
Fixes #3290

![Screen Shot 2021-08-01 at 1 36 21 PM](https://user-images.githubusercontent.com/1246453/127784660-0fcac7d1-87bf-4b1f-a6de-f3da02acd4e3.png)

![image](https://user-images.githubusercontent.com/1246453/127784680-3576fbdc-0cfe-4566-a89c-fed3f6d84751.png)

### Changes

Replace CSS that only worked on Gecko browsers with more generic CSS

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
