### PR TITLE
enh(swift) add `isolated`/`nonisolated` keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Parser:
 
 Grammars:
 
-- enh(swift) Add `isolated`/`nonisolated` keywords (#?) [Bradley Mackey][]
+- enh(swift) Add `isolated`/`nonisolated` keywords (#3296) [Bradley Mackey][]
 
 New Languages:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,17 @@ Parser:
 
 - fix(types) Fix some type definition issues (#3274) [Josh Goebel][]
 
+Grammars:
+
+- enh(swift) Add `isolated`/`nonisolated` keywords (#?) [Bradley Mackey][]
+
 New Languages:
 
 - Added 3rd party X# grammar to SUPPORTED_LANGUAGES [Patrick Kruselburger][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Patrick Kruselburger]: https://github.com/PatrickKru
+[Bradley Mackey]: https://github.com/bradleymackey
 
 
 ## Version 11.1.0

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -73,6 +73,8 @@ export const keywords = [
   'internal',
   'in',
   'is', // operator
+  'isolated', // contextual
+  'nonisolated', // contextual
   'lazy', // contextual
   'let',
   'mutating', // contextual

--- a/test/markup/swift/keywords.expect.txt
+++ b/test/markup/swift/keywords.expect.txt
@@ -16,6 +16,7 @@ x <span class="hljs-keyword">is</span> <span class="hljs-type">String</span>
 <span class="hljs-keyword">fileprivate(set)</span> <span class="hljs-keyword">internal(set)</span> <span class="hljs-keyword">open(set)</span> <span class="hljs-keyword">private(set)</span> <span class="hljs-keyword">public(set)</span>
 <span class="hljs-keyword">unowned(safe)</span> <span class="hljs-keyword">unowned(unsafe)</span>
 <span class="hljs-keyword">async</span> <span class="hljs-keyword">await</span>
+<span class="hljs-keyword">isolated</span> <span class="hljs-keyword">nonisolated</span>
 
 <span class="hljs-keyword">#if</span>
 <span class="hljs-keyword">#error</span>(<span class="hljs-string">&quot;Error&quot;</span>)

--- a/test/markup/swift/keywords.txt
+++ b/test/markup/swift/keywords.txt
@@ -16,6 +16,7 @@ true false nil
 fileprivate(set) internal(set) open(set) private(set) public(set)
 unowned(safe) unowned(unsafe)
 async await
+isolated nonisolated
 
 #if
 #error("Error")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds `isolated`/`nonisolated` keywords to Swift, as this is now officially marked as "implemented" in Swift 5.5, currently in beta. This is as per [SE-0313](https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md).

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- Adds `isolated`/`nonisolated` keywords to Swift.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
