### PR TITLE
fix(cpp) fix `xor_eq` keyword highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 enh(css/less/stylus/scss) improve consistency of function dispatch (#3301) [Josh Goebel][]
 enh(css/less/stylus/scss) detect block comments more fully (#3301) [Josh Goebel][]
+- fix(cpp) fix `xor_eq` keyword highlighting. [Denis Kovalchuk][]
 
 [Josh Goebel]: https://github.com/joshgoebel
-
+[Denis Kovalchuk]: https://github.com/deniskovalchuk
 
 ## Version 11.2.0
 

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -198,7 +198,7 @@ export default function(hljs) {
     'volatile',
     'while',
     'xor',
-    'xor_eq,'
+    'xor_eq'
   ];
 
   // https://en.cppreference.com/w/cpp/keyword

--- a/test/markup/cpp/bitwise-keywords.expect.txt
+++ b/test/markup/cpp/bitwise-keywords.expect.txt
@@ -1,0 +1,14 @@
+<span class="hljs-keyword">unsigned</span> <span class="hljs-type">char</span> a = <span class="hljs-number">0xFA</span>;
+<span class="hljs-keyword">unsigned</span> <span class="hljs-type">char</span> b = <span class="hljs-number">0x4C</span>;
+
+a = <span class="hljs-keyword">compl</span> b;
+a = <span class="hljs-keyword">not</span> b;
+a <span class="hljs-keyword">and</span> b;
+a <span class="hljs-keyword">bitor</span> b;
+a <span class="hljs-keyword">or</span> b;
+a <span class="hljs-keyword">xor</span> b;
+a <span class="hljs-keyword">bitand</span> b;
+a <span class="hljs-keyword">and_eq</span> b;
+a <span class="hljs-keyword">or_eq</span> b;
+a <span class="hljs-keyword">xor_eq</span> b;
+a <span class="hljs-keyword">not_eq</span> b;

--- a/test/markup/cpp/bitwise-keywords.txt
+++ b/test/markup/cpp/bitwise-keywords.txt
@@ -1,0 +1,14 @@
+unsigned char a = 0xFA;
+unsigned char b = 0x4C;
+
+a = compl b;
+a = not b;
+a and b;
+a bitor b;
+a or b;
+a xor b;
+a bitand b;
+a and_eq b;
+a or_eq b;
+a xor_eq b;
+a not_eq b;


### PR DESCRIPTION
The `xor_eq` keyword is not highlighted starting from hljs 11.0.0. It looks
like it's just a typo in the keyword name.

Version 11.0.0 ([jsfiddle](https://jsfiddle.net/sumbgypx/)):
<img width="100" alt="11 0 0" src="https://user-images.githubusercontent.com/15797194/131218167-c0b37b73-a243-4dd6-8f5a-22835fdb6486.png">

Version 10.7.1 ([jsfiddle](https://jsfiddle.net/bajd5623/)):
<img width="100" alt="10 7 1" src="https://user-images.githubusercontent.com/15797194/131218163-c264efbd-d937-4f11-a513-4e644672a0d2.png">

### Changes
- Removed extra `,` from `xor_eq` keyword.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
