### PR TITLE
(scala) Add `do` and `then` keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,11 +14,13 @@ Grammars:
 - fix(cpp) fix `xor_eq` keyword highlighting. [Denis Kovalchuk][]
 - enh(c,cpp) highlight type modifiers as type (#3316) [Josh Goebel][]
 - enh(css/less/stylus/scss) add support for CSS Grid properties [monochromer][]
+- enh(scala) add missing `do` and `then` keyword (#3323) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel
 [Denis Kovalchuk]: https://github.com/deniskovalchuk
 [monochromer]: https://github.com/monochromer
+[Nicolas Stucki]: https://github.com/nicolasstucki
 
 
 ## Version 11.2.0

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -121,7 +121,7 @@ export default function(hljs) {
     name: 'Scala',
     keywords: {
       literal: 'true false null',
-      keyword: 'type yield lazy override def with val var sealed abstract private trait object if forSome for while throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit'
+      keyword: 'type yield lazy override def with val var sealed abstract private trait object if then forSome for while do throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit'
     },
     contains: [
       hljs.C_LINE_COMMENT_MODE,

--- a/test/markup/scala/for-do.expect.txt
+++ b/test/markup/scala/for-do.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-keyword">for</span> x &lt;- <span class="hljs-type">Nil</span> <span class="hljs-keyword">do</span> println(<span class="hljs-string">&quot;hello&quot;</span>)

--- a/test/markup/scala/for-do.txt
+++ b/test/markup/scala/for-do.txt
@@ -1,0 +1,1 @@
+def f = for x <- Nil do println("hello")

--- a/test/markup/scala/if-then-else.expect.txt
+++ b/test/markup/scala/if-then-else.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-keyword">if</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">then</span> <span class="hljs-number">1</span> <span class="hljs-keyword">else</span> <span class="hljs-number">2</span>

--- a/test/markup/scala/if-then-else.txt
+++ b/test/markup/scala/if-then-else.txt
@@ -1,0 +1,1 @@
+def f = if true then 1 else 2

--- a/test/markup/scala/while-do.expect.txt
+++ b/test/markup/scala/while-do.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-keyword">while</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">do</span> println(<span class="hljs-string">&quot;hello&quot;</span>)

--- a/test/markup/scala/while-do.txt
+++ b/test/markup/scala/while-do.txt
@@ -1,0 +1,1 @@
+def f = while true do println("hello")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Add `then` and `do` as keywords. These keywords are also keywords in Scala 2. `then` was reserved but not used as a keyword. `do` was part of `do .. while` keyword combination.

See https://github.com/scala/vscode-scala-syntax/blob/57e0829cd46980699570101a68c320a20330d36c/src/typescript/Scala.tmLanguage.ts#L595

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
