### PR TITLE
enh(scala) remove symbol syntax and fix quoted code syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Grammars:
 - enh(css/less/stylus/scss) add support for CSS Grid properties [monochromer][]
 - enh(java) add support for Java Text Block (#3322) [Teletha][]
 - enh(scala) add missing `do` and `then` keyword (#3323) [Nicolas Stucki][]
+- enh(scala) remove symbol syntax and fix quoted code syntax (#3324) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -59,11 +59,6 @@ export default function(hljs) {
 
   };
 
-  const SYMBOL = {
-    className: 'symbol',
-    begin: '\'\\w[\\w\\d_]*(?!\')'
-  };
-
   const TYPE = {
     className: 'type',
     begin: '\\b[A-Z][A-Za-z0-9_]*',
@@ -127,7 +122,6 @@ export default function(hljs) {
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       STRING,
-      SYMBOL,
       TYPE,
       METHOD,
       CLASS,

--- a/test/markup/scala/quoted-code.expect.txt
+++ b/test/markup/scala/quoted-code.expect.txt
@@ -1,0 +1,1 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>(using <span class="hljs-type">Quotes</span>) = &#x27;{ <span class="hljs-keyword">val</span> x = <span class="hljs-number">1</span>; ${g(&#x27;x)} }

--- a/test/markup/scala/quoted-code.txt
+++ b/test/markup/scala/quoted-code.txt
@@ -1,0 +1,1 @@
+def f(using Quotes) = '{ val x = 1; ${g('x)} }

--- a/test/markup/scala/symbol.expect.txt
+++ b/test/markup/scala/symbol.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>(s: <span class="hljs-type">Symbol</span>) = {
+  s <span class="hljs-keyword">match</span> {
+    <span class="hljs-keyword">case</span> &#x27;foo =&gt;
+  }
+}

--- a/test/markup/scala/symbol.txt
+++ b/test/markup/scala/symbol.txt
@@ -1,0 +1,5 @@
+def f(s: Symbol) = {
+  s match {
+    case 'foo =>
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Scala 2 had only symbols using this syntax. Scala 3 introduced quoted code using the same syntax, which should not be highlighted. Removing this special case makes all use cases consistent.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
