### PR TITLE
enh(scala) add Scala 3 `end` and `extension` soft keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Grammars:
 - enh(scala) add missing `do` and `then` keyword (#3323) [Nicolas Stucki][]
 - enh(scala) add missing `enum`, `export` and `given` keywords (#3328) [Nicolas Stucki][]
 - enh(scala) remove symbol syntax and fix quoted code syntax (#3324) [Nicolas Stucki][]
+- enh(scala) add Scala 3 `extension` soft keyword (#3326) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Grammars:
 - enh(scala) add missing `enum`, `export` and `given` keywords (#3328) [Nicolas Stucki][]
 - enh(scala) remove symbol syntax and fix quoted code syntax (#3324) [Nicolas Stucki][]
 - enh(scala) add Scala 3 `extension` soft keyword (#3326) [Nicolas Stucki][]
+- enh(scala) add Scala 3 `end` soft keyword (#3327) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -112,6 +112,17 @@ export default function(hljs) {
     contains: [ NAME ]
   };
 
+  const EXTENSION = {
+    begin: [
+      /^\s*/, // Is first token on the line
+      'extension',
+      /\s+(?=[[(])/, // followed by at least one space and `[` or `(`
+    ],
+    beginScope: {
+      2: "keyword",
+    }
+  };
+
   return {
     name: 'Scala',
     keywords: {
@@ -126,6 +137,7 @@ export default function(hljs) {
       METHOD,
       CLASS,
       hljs.C_NUMBER_MODE,
+      EXTENSION,
       ANNOTATION
     ]
   };

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -123,6 +123,19 @@ export default function(hljs) {
     }
   };
 
+  const END = [{
+    begin: [
+      /^\s*/, // Is first token on the line
+      /end/,
+      /\s+/,
+      /(extension\b)?/, // `extension` is the only marker that follows an `end` that cannot be captured by another rule.
+    ],
+    beginScope: {
+      2: "keyword",
+      4: "keyword",
+    }
+  }];
+
   return {
     name: 'Scala',
     keywords: {
@@ -138,6 +151,7 @@ export default function(hljs) {
       CLASS,
       hljs.C_NUMBER_MODE,
       EXTENSION,
+      END,
       ANNOTATION
     ]
   };

--- a/test/markup/scala/end.expect.txt
+++ b/test/markup/scala/end.expect.txt
@@ -1,0 +1,41 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">foo</span> </span>=
+  <span class="hljs-keyword">if</span> (<span class="hljs-literal">true</span>)
+    ()
+  <span class="hljs-keyword">else</span>
+    ()
+  <span class="hljs-keyword">end</span> <span class="hljs-keyword">if</span>
+
+  <span class="hljs-keyword">while</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">do</span>
+    ()
+  <span class="hljs-keyword">end</span> <span class="hljs-keyword">while</span>
+
+  <span class="hljs-keyword">for</span> x &lt;- xs <span class="hljs-keyword">do</span>
+    ()
+  <span class="hljs-keyword">end</span> <span class="hljs-keyword">for</span>
+
+  x <span class="hljs-keyword">match</span>
+    <span class="hljs-keyword">case</span> _ =&gt;
+  <span class="hljs-keyword">end</span> <span class="hljs-keyword">match</span>
+<span class="hljs-keyword">end</span> foo
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">bar</span> </span>=
+  <span class="hljs-keyword">new</span> <span class="hljs-type">Foo</span>:
+    <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= ()
+  <span class="hljs-keyword">end</span> <span class="hljs-keyword">new</span>
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-keyword">val</span> baz =
+  ()
+<span class="hljs-keyword">end</span> <span class="hljs-keyword">val</span>
+
+<span class="hljs-keyword">var</span> baz2 =
+  ()
+<span class="hljs-keyword">end</span> <span class="hljs-keyword">var</span>
+
+<span class="hljs-keyword">extension</span> (x: <span class="hljs-type">Int</span>)
+  <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">1</span>
+  <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">2</span>
+<span class="hljs-keyword">end</span> <span class="hljs-keyword">extension</span>
+
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span></span>:
+<span class="hljs-keyword">end</span> <span class="hljs-type">Foo</span>

--- a/test/markup/scala/end.txt
+++ b/test/markup/scala/end.txt
@@ -1,0 +1,41 @@
+def foo =
+  if (true)
+    ()
+  else
+    ()
+  end if
+
+  while true do
+    ()
+  end while
+
+  for x <- xs do
+    ()
+  end for
+
+  x match
+    case _ =>
+  end match
+end foo
+
+def bar =
+  new Foo:
+    def f = ()
+  end new
+end
+
+val baz =
+  ()
+end val
+
+var baz2 =
+  ()
+end var
+
+extension (x: Int)
+  def f = 1
+  def f = 2
+end extension
+
+class Foo:
+end Foo

--- a/test/markup/scala/extension.expect.txt
+++ b/test/markup/scala/extension.expect.txt
@@ -1,0 +1,19 @@
+<span class="hljs-keyword">extension</span> (x: <span class="hljs-type">Int</span>) <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">plus</span></span>(y: <span class="hljs-type">Int</span>) = x + y
+
+<span class="hljs-keyword">extension</span> [<span class="hljs-type">T</span>](x: <span class="hljs-type">T</span>) <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= ()
+
+<span class="hljs-keyword">extension</span> (x: <span class="hljs-type">Int</span>)
+  <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">1</span>
+  <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">2</span>
+
+<span class="hljs-class"><span class="hljs-keyword">object</span> <span class="hljs-title">Foo</span> </span>{
+  <span class="hljs-keyword">extension</span> (x: <span class="hljs-type">Int</span>)
+    <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">1</span>
+    <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span> </span>= <span class="hljs-number">2</span>
+}
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">extension</span></span>(file: <span class="hljs-type">File</span>) =
+  file.extension
+
+  file
+    .extension

--- a/test/markup/scala/extension.txt
+++ b/test/markup/scala/extension.txt
@@ -1,0 +1,19 @@
+extension (x: Int) def plus(y: Int) = x + y
+
+extension [T](x: T) def f = ()
+
+extension (x: Int)
+  def f = 1
+  def f = 2
+
+object Foo {
+  extension (x: Int)
+    def f = 1
+    def f = 2
+}
+
+def extension(file: File) =
+  file.extension
+
+  file
+    .extension


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Add Scala 3 `end` of definition or expression marker (see https://docs.scala-lang.org/scala3/reference/soft-modifier.html)

Simplified version of https://github.com/scala/vscode-scala-syntax/blob/main/src/typescript/Scala.tmLanguage.ts#L599-L634. Here we only need one kind of keyword.

Based on #3326

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
