### PR TITLE
enh(scala) add `inline` soft keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Grammars:
 - enh(scala) add missing `do` and `then` keyword (#3323) [Nicolas Stucki][]
 - enh(scala) add missing `enum`, `export` and `given` keywords (#3328) [Nicolas Stucki][]
 - enh(scala) remove symbol syntax and fix quoted code syntax (#3324) [Nicolas Stucki][]
+- enh(scala) add `inline` soft keyword (#3329) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -112,6 +112,16 @@ export default function(hljs) {
     contains: [ NAME ]
   };
 
+  // TODO: use negative look-behind in future
+  //       /(?<!\.)\binline(?=\s)/
+  const INLINE_MODES = [{
+    match: /\.inline\b/
+  },
+  {
+    begin: /\binline(?=\s)/,
+    keywords: 'inline'
+  }];
+
   return {
     name: 'Scala',
     keywords: {
@@ -126,6 +136,7 @@ export default function(hljs) {
       METHOD,
       CLASS,
       hljs.C_NUMBER_MODE,
+      ...INLINE_MODES,
       ANNOTATION
     ]
   };

--- a/test/markup/scala/inline.expect.txt
+++ b/test/markup/scala/inline.expect.txt
@@ -1,0 +1,15 @@
+<span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">pow</span></span>(<span class="hljs-keyword">inline</span> x: <span class="hljs-type">Int</span>, <span class="hljs-keyword">inline</span> n: <span class="hljs-type">Int</span>) = ???
+transparent <span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>: <span class="hljs-type">Int</span> = ???
+<span class="hljs-keyword">inline</span> <span class="hljs-keyword">val</span> a: <span class="hljs-type">Int</span> = <span class="hljs-number">9</span>
+<span class="hljs-keyword">inline</span> <span class="hljs-keyword">given</span> <span class="hljs-type">Int</span> = <span class="hljs-number">9</span>
+
+notinline <span class="hljs-keyword">given</span> <span class="hljs-type">Int</span> = <span class="hljs-number">9</span>
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">expressions</span> </span>=
+  <span class="hljs-keyword">inline</span> <span class="hljs-keyword">if</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">then</span> () <span class="hljs-keyword">else</span> ()
+  <span class="hljs-keyword">inline</span> x <span class="hljs-keyword">match</span> ...
+
+  x.inline
+  x.inline(y)
+  x.inline[<span class="hljs-type">T</span>]
+  `inline` + <span class="hljs-number">1</span>

--- a/test/markup/scala/inline.txt
+++ b/test/markup/scala/inline.txt
@@ -1,0 +1,15 @@
+inline def pow(inline x: Int, inline n: Int) = ???
+transparent inline def f: Int = ???
+inline val a: Int = 9
+inline given Int = 9
+
+notinline given Int = 9
+
+def expressions =
+  inline if true then () else ()
+  inline x match ...
+
+  x.inline
+  x.inline(y)
+  x.inline[T]
+  `inline` + 1


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Make `inline` a keyword when it is not part of a member selection of application.

Basic idea form https://github.com/scala/vscode-scala-syntax/blob/main/src/typescript/Scala.tmLanguage.ts#L665, but without the need to distinguish the two kinds of keyword.
Also see https://docs.scala-lang.org/scala3/reference/soft-modifier.html

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
