### PR TITLE
enh(scala) add `using` soft keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Grammars:
 - enh(scala) add Scala 3 `extension` soft keyword (#3326) [Nicolas Stucki][]
 - enh(scala) add Scala 3 `end` soft keyword (#3327) [Nicolas Stucki][]
 - enh(scala) add `inline` soft keyword (#3329) [Nicolas Stucki][]
+- enh(scala) add `using` soft keyword (#3330) [Nicolas Stucki][]
 
 [Austin Schick]: https://github.com/austin-schick
 [Josh Goebel]: https://github.com/joshgoebel

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -6,6 +6,8 @@ Contributors: Erik Osheim <d_m@plastic-idolatry.com>
 Website: https://www.scala-lang.org
 */
 
+import * as regex from '../lib/regex.js';
+
 export default function(hljs) {
   const ANNOTATION = {
     className: 'meta',
@@ -107,8 +109,7 @@ export default function(hljs) {
   const METHOD = {
     className: 'function',
     beginKeywords: 'def',
-    end: /[:={\[(\n;]/,
-    excludeEnd: true,
+    end: regex.lookahead(/[:={\[(\n;]/),
     contains: [ NAME ]
   };
 
@@ -146,6 +147,17 @@ export default function(hljs) {
     keywords: 'inline'
   }];
 
+  const USING_PARAM_CLAUSE = {
+    begin: [
+      /\(\s*/, // Opening `(` of a parameter or argument list
+      /using/,
+      /\s+(?!\))/, // Spaces not followed by `)`
+    ],
+    beginScope: {
+      2: "keyword",
+    }
+  };
+
   return {
     name: 'Scala',
     keywords: {
@@ -163,6 +175,7 @@ export default function(hljs) {
       EXTENSION,
       END,
       ...INLINE_MODES,
+      USING_PARAM_CLAUSE,
       ANNOTATION
     ]
   };

--- a/test/markup/scala/quoted-code.expect.txt
+++ b/test/markup/scala/quoted-code.expect.txt
@@ -1,1 +1,1 @@
-<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>(using <span class="hljs-type">Quotes</span>) = &#x27;{ <span class="hljs-keyword">val</span> x = <span class="hljs-number">1</span>; ${g(&#x27;x)} }
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>(<span class="hljs-keyword">using</span> <span class="hljs-type">Quotes</span>) = &#x27;{ <span class="hljs-keyword">val</span> x = <span class="hljs-number">1</span>; ${g(&#x27;x)} }

--- a/test/markup/scala/using.expect.txt
+++ b/test/markup/scala/using.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>(<span class="hljs-keyword">using</span> x: <span class="hljs-type">Int</span>) = <span class="hljs-number">1</span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">g</span></span>(<span class="hljs-keyword">using</span> <span class="hljs-type">Int</span>) = <span class="hljs-number">1</span>
+<span class="hljs-keyword">given</span> (<span class="hljs-keyword">using</span> ev: <span class="hljs-type">Ev</span>): <span class="hljs-type">Foo</span> = ???
+
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">expressions</span> </span>=
+  f(<span class="hljs-keyword">using</span> <span class="hljs-number">2</span>)
+
+  <span class="hljs-comment">// not `using` keyword</span>
+  (using)
+  (using )
+  ( using )

--- a/test/markup/scala/using.txt
+++ b/test/markup/scala/using.txt
@@ -1,0 +1,11 @@
+def f(using x: Int) = 1
+def g(using Int) = 1
+given (using ev: Ev): Foo = ???
+
+def expressions =
+  f(using 2)
+
+  // not `using` keyword
+  (using)
+  (using )
+  ( using )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
`using` is a keyword if it appears at the start of a parameter or argument list.
See https://docs.scala-lang.org/scala3/reference/soft-modifier.html

Based on https://github.com/scala/vscode-scala-syntax/blob/57e0829cd46980699570101a68c320a20330d36c/src/typescript/Scala.tmLanguage.ts#L504

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
