### PR TITLE
enh(go) better type highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Parser:
 
 Grammars:
 
+- enh(go) better type highlighting, add `error` type [Josh Goebel][]
 - fix(js/ts) regex inside `SUBST` is no longer highlighted [Josh Goebel][]
 - fix(python) added support for unicode identifiers (#3280) [Austin Schick][]
 - enh(css/less/stylus/scss) improve consistency of function dispatch (#3301) [Josh Goebel][]

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -31,6 +31,28 @@ export default function(hljs) {
     "recover",
     "delete"
   ];
+  const TYPES = [
+    "bool",
+    "byte",
+    "complex64",
+    "complex128",
+    "error",
+    "float32",
+    "float64",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "string",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "int",
+    "uint",
+    "uintptr",
+    "rune"
+  ];
   const KWS = [
     "break",
     "default",
@@ -57,28 +79,10 @@ export default function(hljs) {
     "var",
     "go",
     "defer",
-    "bool",
-    "byte",
-    "complex64",
-    "complex128",
-    "float32",
-    "float64",
-    "int8",
-    "int16",
-    "int32",
-    "int64",
-    "string",
-    "uint8",
-    "uint16",
-    "uint32",
-    "uint64",
-    "int",
-    "uint",
-    "uintptr",
-    "rune"
   ];
   const KEYWORDS = {
     keyword: KWS,
+    type: TYPES,
     literal: LITERALS,
     built_in: BUILT_INS
   };
@@ -125,6 +129,7 @@ export default function(hljs) {
             className: 'params',
             begin: /\(/,
             end: /\)/,
+            endsParent: true,
             keywords: KEYWORDS,
             illegal: /["']/
           }


### PR DESCRIPTION
Resolves #3334 maybe.

### Changes

- Moves types to `type` scope
- Adds `error` to type scope
- Fixes function definition to end after arguments (so types aren't counted as titles)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
