### PR TITLE
enh(fsharp) Global overhaul

### DIFF
--- a/test/markup/fsharp/attributes.expect.txt
+++ b/test/markup/fsharp/attributes.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-comment">// Strings and numbers are highlighted inside the attribute</span>
+[&lt;<span class="hljs-meta">Foo</span>&gt;]
+[&lt;<span class="hljs-meta">Bar(<span class="hljs-string">&quot;bar&quot;</span>); Foo(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>)</span>&gt;]
+<span class="hljs-keyword">let</span> x () = ()

--- a/test/markup/fsharp/attributes.txt
+++ b/test/markup/fsharp/attributes.txt
@@ -1,0 +1,4 @@
+// Strings and numbers are highlighted inside the attribute
+[<Foo>]
+[<Bar("bar"); Foo(1, 2)>]
+let x () = ()

--- a/test/markup/fsharp/comments.expect.txt
+++ b/test/markup/fsharp/comments.expect.txt
@@ -3,12 +3,42 @@
 <span class="hljs-comment">(*
     here is a multi-line comment on
     multiple lines
+
+trying to break it:
+<span class="hljs-comment">(**)</span>
+/*
+asdf
+*/
+
+<span class="hljs-comment">(* *)</span>
+
 *)</span>
 
 <span class="hljs-keyword">let</span> index =
     len
-    |&gt; float
-    |&gt; Operators.(*) <span class="hljs-number">0.1</span>      <span class="hljs-comment">// (*) here is not comment</span>
-    |&gt; Operators.(+) <span class="hljs-number">1</span>        <span class="hljs-comment">// (+) here is not comment</span>
-    |&gt; Operators.(-) len      <span class="hljs-comment">// (-) here is not comment</span>
-;;
+    <span class="hljs-operator">|&gt;</span> float
+    <span class="hljs-operator">|&gt;</span> Operators.(*) <span class="hljs-number">0.1</span>      <span class="hljs-comment">// (*) here is not comment</span>
+    <span class="hljs-operator">|&gt;</span> Operators.(+) <span class="hljs-number">1</span>        <span class="hljs-comment">// (+) here is not comment</span>
+    <span class="hljs-operator">|&gt;</span> Operators.(-) len      <span class="hljs-comment">// (-) here is not comment</span>
+
+
+<span class="hljs-comment">// foobar</span>
+<span class="hljs-comment">//bar</span>
+<span class="hljs-comment">(**)</span>
+<span class="hljs-comment">(*nospace*)</span>
+<span class="hljs-comment">(* space *)</span>
+<span class="hljs-comment">/// &lt;summary&gt;</span>
+<span class="hljs-comment">/// Class level summary documentation goes here.</span>
+<span class="hljs-comment">/// &lt;/summary&gt;</span>
+<span class="hljs-comment">/// &lt;remarks&gt;</span>
+<span class="hljs-comment">/// Longer comments can be associated with a type or member through</span>
+<span class="hljs-comment">/// the remarks tag.</span>
+<span class="hljs-comment">/// &lt;/remarks&gt;</span>
+<span class="hljs-keyword">let</span> x = ()
+
+<span class="hljs-comment">// the next one is not a comment</span>
+(*) (*)
+
+/*
+this one is <span class="hljs-keyword">not</span> a valid comment either
+*/

--- a/test/markup/fsharp/comments.txt
+++ b/test/markup/fsharp/comments.txt
@@ -3,6 +3,15 @@
 (*
     here is a multi-line comment on
     multiple lines
+
+trying to break it:
+(**)
+/*
+asdf
+*/
+
+(* *)
+
 *)
 
 let index =
@@ -11,4 +20,25 @@ let index =
     |> Operators.(*) 0.1      // (*) here is not comment
     |> Operators.(+) 1        // (+) here is not comment
     |> Operators.(-) len      // (-) here is not comment
-;;
+
+
+// foobar
+//bar
+(**)
+(*nospace*)
+(* space *)
+/// <summary>
+/// Class level summary documentation goes here.
+/// </summary>
+/// <remarks>
+/// Longer comments can be associated with a type or member through
+/// the remarks tag.
+/// </remarks>
+let x = ()
+
+// the next one is not a comment
+(*) (*)
+
+/*
+this one is not a valid comment either
+*/

--- a/test/markup/fsharp/computation-expressions.expect.txt
+++ b/test/markup/fsharp/computation-expressions.expect.txt
@@ -1,0 +1,23 @@
+<span class="hljs-meta">#<span class="hljs-keyword">r</span> &quot;nuget: Ply&quot;</span>
+<span class="hljs-keyword">open</span> FSharp.Control.Tasks
+<span class="hljs-keyword">open</span> System.Threading.Tasks
+
+<span class="hljs-comment">// Single line, and contains a capital letter</span>
+<span class="hljs-keyword">let</span> unitTask = <span class="hljs-emphasis">unitTask</span> { <span class="hljs-keyword">return</span> () }
+
+<span class="hljs-keyword">let</span> work =
+    <span class="hljs-emphasis">async</span> {
+        <span class="hljs-keyword">let</span> delayTask () =
+            <span class="hljs-comment">// Nested computation</span>
+            <span class="hljs-emphasis">task</span> {
+                printfn <span class="hljs-string">&quot;Delay...&quot;</span>
+                <span class="hljs-keyword">do!</span> Task.Delay <span class="hljs-number">1000</span>
+                <span class="hljs-keyword">return</span> <span class="hljs-number">42</span>
+            }
+        <span class="hljs-keyword">let!</span> result = delayTask () <span class="hljs-operator">|&gt;</span> Async.AwaitTask
+        printfn <span class="hljs-string">&quot;Async F# sleep...&quot;</span>
+        <span class="hljs-keyword">do!</span> Async.Sleep <span class="hljs-number">1000</span>
+        <span class="hljs-keyword">return</span> result
+    }
+
+<span class="hljs-keyword">let</span> result = work <span class="hljs-operator">|&gt;</span> Async.RunSynchronously

--- a/test/markup/fsharp/computation-expressions.txt
+++ b/test/markup/fsharp/computation-expressions.txt
@@ -1,0 +1,23 @@
+#r "nuget: Ply"
+open FSharp.Control.Tasks
+open System.Threading.Tasks
+
+// Single line, and contains a capital letter
+let unitTask = unitTask { return () }
+
+let work =
+    async {
+        let delayTask () =
+            // Nested computation
+            task {
+                printfn "Delay..."
+                do! Task.Delay 1000
+                return 42
+            }
+        let! result = delayTask () |> Async.AwaitTask
+        printfn "Async F# sleep..."
+        do! Async.Sleep 1000
+        return result
+    }
+
+let result = work |> Async.RunSynchronously

--- a/test/markup/fsharp/fsi-and-preprocessor.expect.txt
+++ b/test/markup/fsharp/fsi-and-preprocessor.expect.txt
@@ -1,0 +1,10 @@
+
+<span class="hljs-meta">#<span class="hljs-keyword">r</span> &quot;file.dll&quot;;;                               // Reference (dynamically <span class="hljs-keyword">load</span>) the given DLL</span>
+<span class="hljs-meta">#<span class="hljs-keyword">i</span> &quot;package source uri&quot;;;                     // Include package source uri when searching for packages</span>
+<span class="hljs-meta">#<span class="hljs-keyword">I</span> &quot;path&quot;;;                                   // Add the given search path for referenced DLLs</span>
+<span class="hljs-meta">#<span class="hljs-keyword">load</span> &quot;file.fs&quot; ...;;                         // Load the given file(s) as <span class="hljs-keyword">if</span> compiled and referenced</span>
+<span class="hljs-meta">#<span class="hljs-keyword">time</span> [&quot;on&quot;|&quot;off&quot;];;                          // Toggle timing on/off</span>
+<span class="hljs-meta">#<span class="hljs-keyword">help</span>;;                                       // Display <span class="hljs-keyword">help</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">r</span> &quot;nuget:FSharp.Data, 3.1.2&quot;;;               // Load Nuget Package &#x27;FSharp.Data&#x27; version &#x27;3.1.2&#x27;</span>
+<span class="hljs-meta">#<span class="hljs-keyword">r</span> &quot;nuget:FSharp.Data&quot;;;                      // Load Nuget Package &#x27;FSharp.Data&#x27; with the highest version</span>
+<span class="hljs-meta">#<span class="hljs-keyword">quit</span>;;</span>

--- a/test/markup/fsharp/fsi-and-preprocessor.txt
+++ b/test/markup/fsharp/fsi-and-preprocessor.txt
@@ -1,0 +1,10 @@
+
+#r "file.dll";;                               // Reference (dynamically load) the given DLL
+#i "package source uri";;                     // Include package source uri when searching for packages
+#I "path";;                                   // Add the given search path for referenced DLLs
+#load "file.fs" ...;;                         // Load the given file(s) as if compiled and referenced
+#time ["on"|"off"];;                          // Toggle timing on/off
+#help;;                                       // Display help
+#r "nuget:FSharp.Data, 3.1.2";;               // Load Nuget Package 'FSharp.Data' version '3.1.2'
+#r "nuget:FSharp.Data";;                      // Load Nuget Package 'FSharp.Data' with the highest version
+#quit;;

--- a/test/markup/fsharp/generic-types.expect.txt
+++ b/test/markup/fsharp/generic-types.expect.txt
@@ -1,0 +1,36 @@
+<span class="hljs-comment">// Primarily testing for generic parameters highlighting...</span>
+
+<span class="hljs-title class_"><span class="hljs-keyword">type</span> <span class="hljs-title">Ref</span>&lt;<span class="hljs-symbol">&#x27;a</span>&gt; </span>=
+{ <span class="hljs-keyword">mutable</span> contents: <span class="hljs-symbol">&#x27;a</span> }
+
+<span class="hljs-title class_"><span class="hljs-keyword">type</span> <span class="hljs-title">Bla</span>&lt;<span class="hljs-symbol">&#x27;a</span>&gt; </span>= {X: string}
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> asdf x: Bla&lt;<span class="hljs-symbol">&#x27;a</span>&gt; = {X = <span class="hljs-string">&quot;&quot;</span>}
+
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> asdf x: Bla&lt;<span class="hljs-symbol">^a</span>&gt; = {X = <span class="hljs-string">&quot;&quot;</span>}
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> asdf x: Bla&lt; <span class="hljs-symbol">^a</span> &gt; = {X = <span class="hljs-string">&quot;&quot;</span>}
+
+<span class="hljs-keyword">let</span> genericSumUnits ( x : float&lt;<span class="hljs-symbol">&#x27;u</span>&gt;) (y: float&lt;<span class="hljs-symbol">&#x27;u</span>&gt;) = x + y
+
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> konst x _ = x
+
+<span class="hljs-title class_"><span class="hljs-keyword">type</span> <span class="hljs-title">CFunctor</span></span>() =
+    <span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> <span class="hljs-keyword">inline</span> fmap (f: <span class="hljs-symbol">^a</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^b</span>, a: <span class="hljs-symbol">^a</span> list) = List.map f a
+    <span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> <span class="hljs-keyword">inline</span> fmap (f: <span class="hljs-symbol">^a</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^b</span>, a: <span class="hljs-symbol">^a</span> option) =
+        <span class="hljs-keyword">match</span> a <span class="hljs-keyword">with</span>
+        <span class="hljs-operator">|</span> None <span class="hljs-operator">-&gt;</span> None
+        <span class="hljs-operator">|</span> Some x <span class="hljs-operator">-&gt;</span> Some (f x)
+
+    <span class="hljs-comment">// default implementation of replace</span>
+    <span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> <span class="hljs-keyword">inline</span> replace&lt; <span class="hljs-symbol">^a</span>, <span class="hljs-symbol">^b</span>, <span class="hljs-symbol">^c</span>, <span class="hljs-symbol">^d</span>, <span class="hljs-symbol">^e</span> <span class="hljs-keyword">when</span> <span class="hljs-symbol">^a</span> <span class="hljs-operator">:&gt;</span> CFunctor <span class="hljs-keyword">and</span> (<span class="hljs-symbol">^a</span> <span class="hljs-keyword">or</span> <span class="hljs-symbol">^d</span>): (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> fmap: (<span class="hljs-symbol">^b</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^c</span>) * <span class="hljs-symbol">^d</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^e</span>) &gt; (a, f) =
+        ((<span class="hljs-symbol">^a</span> <span class="hljs-keyword">or</span> <span class="hljs-symbol">^d</span>) : (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> fmap : (<span class="hljs-symbol">^b</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^c</span>) * <span class="hljs-symbol">^d</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^e</span>) (konst a, f))
+
+    <span class="hljs-comment">// call overridden replace if present</span>
+    <span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> <span class="hljs-keyword">inline</span> replace&lt; <span class="hljs-symbol">^a</span>, <span class="hljs-symbol">^b</span>, <span class="hljs-symbol">^c</span> <span class="hljs-keyword">when</span> <span class="hljs-symbol">^b</span>: (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> replace: <span class="hljs-symbol">^a</span> * <span class="hljs-symbol">^b</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^c</span>)&gt;(a: <span class="hljs-symbol">^a</span>, f: <span class="hljs-symbol">^b</span>) =
+        (<span class="hljs-symbol">^b</span> : (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> replace: <span class="hljs-symbol">^a</span> * <span class="hljs-symbol">^b</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^c</span>) (a, f))
+
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> replace_instance&lt; <span class="hljs-symbol">^a</span>, <span class="hljs-symbol">^b</span>, <span class="hljs-symbol">^c</span>, <span class="hljs-symbol">^d</span> <span class="hljs-keyword">when</span> (<span class="hljs-symbol">^a</span> <span class="hljs-keyword">or</span> <span class="hljs-symbol">^c</span>): (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> replace: <span class="hljs-symbol">^b</span> * <span class="hljs-symbol">^c</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^d</span>)&gt; (a: <span class="hljs-symbol">^b</span>, f: <span class="hljs-symbol">^c</span>) =
+        ((<span class="hljs-symbol">^a</span> <span class="hljs-keyword">or</span> <span class="hljs-symbol">^c</span>): (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> replace: <span class="hljs-symbol">^b</span> * <span class="hljs-symbol">^c</span> <span class="hljs-operator">-&gt;</span> <span class="hljs-symbol">^d</span>) (a, f))
+
+<span class="hljs-comment">// Note the concrete type &#x27;CFunctor&#x27; specified in the signature</span>
+<span class="hljs-keyword">let</span> <span class="hljs-keyword">inline</span> replace (a: <span class="hljs-symbol">^a</span>) (f: <span class="hljs-symbol">^b</span>): <span class="hljs-symbol">^a0</span> <span class="hljs-keyword">when</span> (CFunctor <span class="hljs-keyword">or</span>  <span class="hljs-symbol">^b</span>): (<span class="hljs-keyword">static</span> <span class="hljs-keyword">member</span> replace: <span class="hljs-symbol">^a</span> *  <span class="hljs-symbol">^b</span> <span class="hljs-operator">-&gt;</span>  <span class="hljs-symbol">^a0</span>) =
+    replace_instance&lt;CFunctor, _, _, _&gt; (a, f)

--- a/test/markup/fsharp/generic-types.txt
+++ b/test/markup/fsharp/generic-types.txt
@@ -1,0 +1,36 @@
+// Primarily testing for generic parameters highlighting...
+
+type Ref<'a> =
+{ mutable contents: 'a }
+
+type Bla<'a> = {X: string}
+let inline asdf x: Bla<'a> = {X = ""}
+
+let inline asdf x: Bla<^a> = {X = ""}
+let inline asdf x: Bla< ^a > = {X = ""}
+
+let genericSumUnits ( x : float<'u>) (y: float<'u>) = x + y
+
+let inline konst x _ = x
+
+type CFunctor() =
+    static member inline fmap (f: ^a -> ^b, a: ^a list) = List.map f a
+    static member inline fmap (f: ^a -> ^b, a: ^a option) =
+        match a with
+        | None -> None
+        | Some x -> Some (f x)
+
+    // default implementation of replace
+    static member inline replace< ^a, ^b, ^c, ^d, ^e when ^a :> CFunctor and (^a or ^d): (static member fmap: (^b -> ^c) * ^d -> ^e) > (a, f) =
+        ((^a or ^d) : (static member fmap : (^b -> ^c) * ^d -> ^e) (konst a, f))
+
+    // call overridden replace if present
+    static member inline replace< ^a, ^b, ^c when ^b: (static member replace: ^a * ^b -> ^c)>(a: ^a, f: ^b) =
+        (^b : (static member replace: ^a * ^b -> ^c) (a, f))
+
+let inline replace_instance< ^a, ^b, ^c, ^d when (^a or ^c): (static member replace: ^b * ^c -> ^d)> (a: ^b, f: ^c) =
+        ((^a or ^c): (static member replace: ^b * ^c -> ^d) (a, f))
+
+// Note the concrete type 'CFunctor' specified in the signature
+let inline replace (a: ^a) (f: ^b): ^a0 when (CFunctor or  ^b): (static member replace: ^a *  ^b ->  ^a0) =
+    replace_instance<CFunctor, _, _, _> (a, f)

--- a/test/markup/fsharp/numbers.expect.txt
+++ b/test/markup/fsharp/numbers.expect.txt
@@ -1,0 +1,40 @@
+<span class="hljs-comment">// There are multiple ways to write numbers.</span>
+<span class="hljs-comment">// Suffixes are currently not highlighted...</span>
+
+<span class="hljs-number">0xbabe</span>
+<span class="hljs-number">0xBABE</span>un
+<span class="hljs-number">0xf</span>lf
+<span class="hljs-number">0xf</span>LF
+
+<span class="hljs-number">0b1001</span>
+<span class="hljs-number">0b1001</span>y
+<span class="hljs-number">0b1001</span>uy
+
+<span class="hljs-number">42</span>
+<span class="hljs-number">1.5</span>
+<span class="hljs-number">2.3E+32</span>
+<span class="hljs-number">2.3e-32</span>
+<span class="hljs-number">4.14</span>F
+<span class="hljs-number">4.14</span>f
+<span class="hljs-number">0.7833</span>M
+<span class="hljs-number">0.7833</span>m
+
+<span class="hljs-number">86</span>y
+<span class="hljs-number">86</span>uy
+<span class="hljs-number">86</span>s
+<span class="hljs-number">86</span>us
+<span class="hljs-number">86</span>l
+<span class="hljs-number">86</span>u
+<span class="hljs-number">86</span>ul
+<span class="hljs-number">86</span>L
+<span class="hljs-number">86</span>UL
+<span class="hljs-number">9999999999999999999999999999</span>I
+
+<span class="hljs-comment">// Distance, meters.</span>
+[&lt;<span class="hljs-meta">Measure</span>&gt;] <span class="hljs-title class_"><span class="hljs-keyword">type</span> <span class="hljs-title">m</span></span>
+<span class="hljs-comment">// Time, seconds.</span>
+[&lt;<span class="hljs-meta">Measure</span>&gt;] <span class="hljs-title class_"><span class="hljs-keyword">type</span> <span class="hljs-title">s</span></span>
+
+<span class="hljs-keyword">let</span> v1 = <span class="hljs-number">3.1</span>&lt;m/s&gt;
+<span class="hljs-keyword">let</span> x1 = <span class="hljs-number">1.2</span>&lt;m&gt;
+<span class="hljs-keyword">let</span> t1 = <span class="hljs-number">1.0</span>&lt;s&gt;

--- a/test/markup/fsharp/numbers.txt
+++ b/test/markup/fsharp/numbers.txt
@@ -1,0 +1,40 @@
+// There are multiple ways to write numbers.
+// Suffixes are currently not highlighted...
+
+0xbabe
+0xBABEun
+0xflf
+0xfLF
+
+0b1001
+0b1001y
+0b1001uy
+
+42
+1.5
+2.3E+32
+2.3e-32
+4.14F
+4.14f
+0.7833M
+0.7833m
+
+86y
+86uy
+86s
+86us
+86l
+86u
+86ul
+86L
+86UL
+9999999999999999999999999999I
+
+// Distance, meters.
+[<Measure>] type m
+// Time, seconds.
+[<Measure>] type s
+
+let v1 = 3.1<m/s>
+let x1 = 1.2<m>
+let t1 = 1.0<s>

--- a/test/markup/fsharp/operators.expect.txt
+++ b/test/markup/fsharp/operators.expect.txt
@@ -1,0 +1,30 @@
+<span class="hljs-comment">// To simplify parsing and avoid a christmas tree effect,</span>
+<span class="hljs-comment">// only non-arithmetic operators that we can confidently match are currently highlighted.</span>
+
+ &gt;=   &lt;=   &lt;&gt;   &gt;   &lt;   =   +   -   *   /   %
+ &gt;=?  &lt;=?  &lt;&gt;?  &gt;?  &lt;?  =?  +?  -?  *?  /?  %?
+?&gt;=? ?&lt;=? ?&lt;&gt;? ?&gt;? ?&lt;? ?=? ?+? ?-? ?*? ?/? ?%?
+?&gt;=  ?&lt;=  ?&lt;&gt;  ?&gt;  ?&lt;  ?=  ?+  ?-  ?*  ?/  ?%
+
+**
+
+<span class="hljs-operator">&lt;-</span> <span class="hljs-operator">-&gt;</span>
+<span class="hljs-operator">..</span>
+<span class="hljs-operator">::</span>
+<span class="hljs-operator">:&gt;</span> <span class="hljs-operator">:?</span> <span class="hljs-operator">:?&gt;</span>
+<span class="hljs-operator">&lt;&lt;</span> <span class="hljs-operator">&gt;&gt;</span>
+&lt;&lt;&lt; &gt;&gt;&gt; ~~~ ^^^ &amp;&amp;&amp; |||
+<span class="hljs-operator">|</span> ||
+<span class="hljs-operator">&lt;|</span> <span class="hljs-operator">&lt;||</span> <span class="hljs-operator">&lt;|||</span>
+<span class="hljs-operator">|&gt;</span> <span class="hljs-operator">||&gt;</span> <span class="hljs-operator">|||&gt;</span>
+~~ ~- ~+
+
+? ^ !
+!= ==
+&amp; &amp;&amp;
+
+<span class="hljs-keyword">open</span> Microsoft.FSharp.Quotations
+<span class="hljs-comment">// A typed code quotation.</span>
+<span class="hljs-keyword">let</span> expr : Expr&lt;int&gt; = &lt;@ <span class="hljs-number">1</span> + <span class="hljs-number">1</span> @&gt;
+<span class="hljs-comment">// An untyped code quotation.</span>
+<span class="hljs-keyword">let</span> expr2 : Expr = &lt;@@ <span class="hljs-number">1</span> + <span class="hljs-number">1</span> @@&gt;

--- a/test/markup/fsharp/operators.txt
+++ b/test/markup/fsharp/operators.txt
@@ -1,0 +1,30 @@
+// To simplify parsing and avoid a christmas tree effect,
+// only non-arithmetic operators that we can confidently match are currently highlighted.
+
+ >=   <=   <>   >   <   =   +   -   *   /   %
+ >=?  <=?  <>?  >?  <?  =?  +?  -?  *?  /?  %?
+?>=? ?<=? ?<>? ?>? ?<? ?=? ?+? ?-? ?*? ?/? ?%?
+?>=  ?<=  ?<>  ?>  ?<  ?=  ?+  ?-  ?*  ?/  ?%
+
+**
+
+<- ->
+..
+::
+:> :? :?>
+<< >>
+<<< >>> ~~~ ^^^ &&& |||
+| ||
+<| <|| <|||
+|> ||> |||>
+~~ ~- ~+
+
+? ^ !
+!= ==
+& &&
+
+open Microsoft.FSharp.Quotations
+// A typed code quotation.
+let expr : Expr<int> = <@ 1 + 1 @>
+// An untyped code quotation.
+let expr2 : Expr = <@@ 1 + 1 @@>

--- a/test/markup/fsharp/preprocessor.expect.txt
+++ b/test/markup/fsharp/preprocessor.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-meta">#<span class="hljs-keyword">if</span> foo</span>
+<span class="hljs-meta">#<span class="hljs-keyword">else</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">endif</span></span>
+
+<span class="hljs-meta">#<span class="hljs-keyword">light</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">line</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">nowarn</span></span>

--- a/test/markup/fsharp/preprocessor.txt
+++ b/test/markup/fsharp/preprocessor.txt
@@ -1,0 +1,7 @@
+#if foo
+#else
+#endif
+
+#light
+#line
+#nowarn

--- a/test/markup/fsharp/strings.expect.txt
+++ b/test/markup/fsharp/strings.expect.txt
@@ -1,0 +1,56 @@
+<span class="hljs-comment">// Different definitions of strings and character literals,</span>
+<span class="hljs-comment">// some with prefixes and suffixes (not all are currently highlighted)</span>
+
+<span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-string">&quot;fo\&quot;o&quot;</span>
+<span class="hljs-string">&quot;foo\
+bar&quot;</span>
+<span class="hljs-string">&quot;foo&quot;</span>B
+
+<span class="hljs-string">@&quot;&quot;</span>
+<span class="hljs-string">@&quot;foo&quot;</span>
+<span class="hljs-string">@&quot;fo&quot;&quot;o&quot;</span>
+<span class="hljs-string">@&quot;foo&quot;</span>B
+
+<span class="hljs-string">&quot;&quot;&quot;&quot;&quot;&quot;</span>
+<span class="hljs-string">&quot;&quot;&quot;fo&quot;&quot;o&quot;
+bar&quot;&quot;&quot;</span>
+<span class="hljs-string">&quot;&quot;&quot;foo&quot;&quot;&quot;</span>B
+
+<span class="hljs-string">&#x27;a&#x27;</span>
+<span class="hljs-string">&#x27;a&#x27;</span>B
+<span class="hljs-string">&#x27;\&#x27;&#x27;</span>
+<span class="hljs-string">&#x27;\\&#x27;</span>
+<span class="hljs-string">&#x27;\231&#x27;</span>
+<span class="hljs-string">&#x27;\x41&#x27;</span>
+<span class="hljs-string">&#x27;\u0041&#x27;</span>
+<span class="hljs-string">&#x27;\U0001F47D&#x27;</span>
+
+$<span class="hljs-string">&quot;{1+1}&quot;</span>
+
+<span class="hljs-string">&quot;&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&quot;fo\&quot;o&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&quot;foo\ // part of the string
+bar&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&quot;foo&quot;</span>B <span class="hljs-comment">// end</span>
+
+<span class="hljs-string">@&quot;&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">@&quot;foo&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">@&quot;fo&quot;&quot;o&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">@&quot;foo&quot;</span>B <span class="hljs-comment">// end</span>
+
+<span class="hljs-string">&quot;&quot;&quot;&quot;&quot;&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&quot;&quot;&quot;fo&quot;&quot;o&quot; // part of the string
+bar&quot;&quot;&quot;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&quot;&quot;&quot;foo&quot;&quot;&quot;</span>B <span class="hljs-comment">// end</span>
+
+<span class="hljs-string">&#x27;a&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;a&#x27;</span>B <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\&#x27;&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\\&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\231&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\x41&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\u0041&#x27;</span> <span class="hljs-comment">// end</span>
+<span class="hljs-string">&#x27;\U0001F47D&#x27;</span> <span class="hljs-comment">// end</span>
+
+$<span class="hljs-string">&quot;{1+1}&quot;</span> <span class="hljs-comment">// end</span>

--- a/test/markup/fsharp/strings.txt
+++ b/test/markup/fsharp/strings.txt
@@ -1,0 +1,56 @@
+// Different definitions of strings and character literals,
+// some with prefixes and suffixes (not all are currently highlighted)
+
+""
+"fo\"o"
+"foo\
+bar"
+"foo"B
+
+@""
+@"foo"
+@"fo""o"
+@"foo"B
+
+""""""
+"""fo""o"
+bar"""
+"""foo"""B
+
+'a'
+'a'B
+'\''
+'\\'
+'\231'
+'\x41'
+'\u0041'
+'\U0001F47D'
+
+$"{1+1}"
+
+"" // end
+"fo\"o" // end
+"foo\ // part of the string
+bar" // end
+"foo"B // end
+
+@"" // end
+@"foo" // end
+@"fo""o" // end
+@"foo"B // end
+
+"""""" // end
+"""fo""o" // part of the string
+bar""" // end
+"""foo"""B // end
+
+'a' // end
+'a'B // end
+'\'' // end
+'\\' // end
+'\231' // end
+'\x41' // end
+'\u0041' // end
+'\U0001F47D' // end
+
+$"{1+1}" // end


### PR DESCRIPTION
Fixes #3347 as well as a lot of other things F# related.

### Changes
Here is the high level list of things that changed (Also listed in the commit description):
* Fix character literals not being parsed
* Add missing keywords
* Fix parsing of generic type symbols
* Fix parsing of ML comments without space within
* Improve attributes parsing
* Add parsing of computation expressions
* Add parsing of preprocessor and FSI directives
* Add parsing for many operators
* Add parsing of binary number literals
* Add unit tests


### Checklist
- [x] Added markup tests
- [ ] Updated the changelog at `CHANGES.md`

---

I have two questions left:
- What should I put in the changelog?
- It seems I have broken some language auto-detection tests. What's the best way to fix it? (I suspect it's part of the "`relevance` black magic", but I'm not sure where to start)