### PR TITLE
(docs) make demo page more keyboard accessible

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,20 +1,13 @@
 hljs.debugMode();
 hljs.highlightAll();
 
-const addEventListeners = (element, listener) => {
-  element.addEventListener("click", listener);
-  element.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-      listener(event);
-    }
-  });
-};
+document.querySelectorAll(".categories a").forEach((category) => {
+  category.addEventListener("click", (event) => {
+    event.preventDefault();
 
-document.querySelectorAll(".categories > li").forEach((category) => {
-  addEventListeners(category, (event) => {
     const current = document.querySelector(".categories .current");
-    const currentCategory = current.dataset.category;
-    const nextCategory = event.target.dataset.category;
+    const currentCategory = current.name;
+    const nextCategory = event.target.name;
 
     if (currentCategory !== nextCategory) {
       current.classList.remove("current");
@@ -32,8 +25,10 @@ document.querySelectorAll(".categories > li").forEach((category) => {
   });
 });
 
-document.querySelectorAll(".styles > li").forEach((style) => {
-  addEventListeners(style, (event) => {
+document.querySelectorAll(".styles a").forEach((style) => {
+  style.addEventListener("click", (event) => {
+    event.preventDefault();
+
     const current = document.querySelector(".styles .current");
     const currentStyle = current.textContent;
     const nextStyle = event.target.textContent;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,7 +1,7 @@
 hljs.debugMode();
 hljs.highlightAll();
 
-document.querySelectorAll(".categories a").forEach((category) => {
+document.querySelectorAll(".categories li a").forEach((category) => {
   category.addEventListener("click", (event) => {
     event.preventDefault();
 
@@ -25,7 +25,7 @@ document.querySelectorAll(".categories a").forEach((category) => {
   });
 });
 
-document.querySelectorAll(".styles a").forEach((style) => {
+document.querySelectorAll(".styles li a").forEach((style) => {
   style.addEventListener("click", (event) => {
     event.preventDefault();
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -6,8 +6,8 @@ document.querySelectorAll(".categories a").forEach((category) => {
     event.preventDefault();
 
     const current = document.querySelector(".categories .current");
-    const currentCategory = current.name;
-    const nextCategory = event.target.name;
+    const currentCategory = current.dataset.category;
+    const nextCategory = event.target.dataset.category;
 
     if (currentCategory !== nextCategory) {
       current.classList.remove("current");

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,8 +1,17 @@
 hljs.debugMode();
 hljs.highlightAll();
 
+const addEventListeners = (element, listener) => {
+  element.addEventListener("click", listener);
+  element.addEventListener("keydown", (event) => {
+    if (event.key === " " || event.key === "Enter") {
+      listener(event);
+    }
+  });
+};
+
 document.querySelectorAll(".categories > li").forEach((category) => {
-  category.addEventListener("click", (event) => {
+  addEventListeners(category, (event) => {
     const current = document.querySelector(".categories .current");
     const currentCategory = current.dataset.category;
     const nextCategory = event.target.dataset.category;
@@ -24,14 +33,18 @@ document.querySelectorAll(".categories > li").forEach((category) => {
 });
 
 document.querySelectorAll(".styles > li").forEach((style) => {
-  style.addEventListener("click", (event) => {
+  addEventListeners(style, (event) => {
     const current = document.querySelector(".styles .current");
     const currentStyle = current.textContent;
     const nextStyle = event.target.textContent;
 
     if (currentStyle !== nextStyle) {
-      document.querySelector(`link[title="${nextStyle}"]`).removeAttribute("disabled");
-      document.querySelector(`link[title="${currentStyle}"]`).setAttribute("disabled", "disabled");
+      document
+        .querySelector(`link[title="${nextStyle}"]`)
+        .removeAttribute("disabled");
+      document
+        .querySelector(`link[title="${currentStyle}"]`)
+        .setAttribute("disabled", "disabled");
 
       current.classList.remove("current");
       event.target.classList.add("current");

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,7 +4,7 @@ hljs.highlightAll();
 const addEventListeners = (element, listener) => {
   element.addEventListener("click", listener);
   element.addEventListener("keydown", (event) => {
-    if (event.key === " " || event.key === "Enter") {
+    if (event.key === "Enter") {
       listener(event);
     }
   });

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,14 +23,14 @@
     <h2>Language Categories</h2>
     <ul class="categories">
       <% categories.forEach(({category, count}, i) => {%>
-      <li <%= i ? '' : 'class="current"'%> data-category="<%= category %>"><%= `${category} (${count})` %></li>
+      <li <%= i ? '' : 'class="current"'%> data-category="<%= category %>" tabindex="0"><%= `${category} (${count})` %></li>
       <% }); %>
     </ul>
     <h2>Themes</h2>
     <ul class="styles">
-      <li class="current">Default</li>
+      <li class="current" tabindex="0">Default</li>
       <% styles.forEach(({name}) => {%>
-      <li><%= name %></li>
+      <li tabindex="0"><%= name %></li>
       <% }); %>
     </ul>
   </aside>

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,7 @@
     <h2>Language Categories</h2>
     <ul class="categories">
       <% categories.forEach(({category, count}, i) => {%>
-      <li><a <%= i ? '' : 'class="current"'%> name="<%= category %>" href="#<%= category %>"><%= `${category} (${count})` %></a></li>
+      <li><a <%= i ? '' : 'class="current"'%> data-category="<%= category %>" href="#<%= category %>"><%= `${category} (${count})` %></a></li>
       <% }); %>
     </ul>
     <h2>Themes</h2>

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,14 +23,14 @@
     <h2>Language Categories</h2>
     <ul class="categories">
       <% categories.forEach(({category, count}, i) => {%>
-      <li <%= i ? '' : 'class="current"'%> data-category="<%= category %>" tabindex="0"><%= `${category} (${count})` %></li>
+      <li><a <%= i ? '' : 'class="current"'%> name="<%= category %>" href="#<%= category %>"><%= `${category} (${count})` %></a></li>
       <% }); %>
     </ul>
     <h2>Themes</h2>
     <ul class="styles">
-      <li class="current" tabindex="0">Default</li>
+      <li><a class="current" href="#default">Default</a></li>
       <% styles.forEach(({name}) => {%>
-      <li tabindex="0"><%= name %></li>
+      <li><a href="#<%= name %>"><%= name %></a></li>
       <% }); %>
     </ul>
   </aside>

--- a/demo/style.css
+++ b/demo/style.css
@@ -102,18 +102,19 @@ aside ul::-webkit-scrollbar-thumb:active {
   background: #5d3333;
 }
 
-aside li {
-  padding: 1px 1em;
-  cursor: pointer;
+aside ul a {
+  display: block;
+  padding: 1px 0.5em 1px 1em;
+  text-decoration: none;
 }
 
-aside li:focus,
-aside li:hover {
+aside ul a:focus,
+aside ul a:hover {
   background: #500;
   outline: none;
 }
 
-aside li.current:before {
+aside ul a.current:before {
   content: "▶";
   font-size: smaller;
   position: absolute;

--- a/demo/style.css
+++ b/demo/style.css
@@ -107,8 +107,10 @@ aside li {
   cursor: pointer;
 }
 
+aside li:focus,
 aside li:hover {
   background: #500;
+  outline: none;
 }
 
 aside li.current:before {


### PR DESCRIPTION
### Changes
Adds basic keyboard accessibility to the [demo page](https://highlightjs.org/static/demo) by adding `a`-tags to react to keydown events.

![hljs-demo-keyboard](https://user-images.githubusercontent.com/2564094/138618195-e14a9bbe-4090-4e13-bb6a-90114c728606.gif)

### Checklist
- [ ] ~Added markup tests~, or they don't apply here because no highlight changes
- [ ] ~Updated the changelog at `CHANGES.md`~ No published changes
