### PR TITLE
(chore) apply lint to our tooling scripts also

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,9 +28,10 @@ module.exports = {
     // for now ignore diff between types of quoting
     quotes: "off",
     // this is the style we are already using
-    "operator-linebreak": ["error", "before", { overrides: {
-      "=": "after"
-    }
+    "operator-linebreak": ["error", "before", {
+      overrides: {
+        "=": "after"
+      }
     }],
     // sometimes we declare variables with extra spacing
     indent: ["error", 2, { VariableDeclarator: 2 }],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "mocha": "mocha",
-    "lint": "eslint src/*.js src/lib/*.js demo/*.js",
+    "lint": "eslint src/*.js src/lib/*.js demo/*.js tools/**/*.js --ignore-pattern vendor",
     "lint-languages": "eslint --no-eslintrc -c .eslintrc.lang.js src/languages/**/*.js",
     "build_and_test": "npm run build && npm run test",
     "build_and_test_browser": "npm run build-browser && npm run test-browser",

--- a/tools/build.js
+++ b/tools/build.js
@@ -62,7 +62,7 @@
 
 const commander = require('commander');
 const path = require('path');
-const { clean } = require("./lib/makestuff");
+const { clean } = require("./lib/makestuff.js");
 const log = (...args) => console.log(...args);
 
 const TARGETS = ["cdn", "browser", "node"];
@@ -73,8 +73,8 @@ commander
   .option('-n, --no-minify', 'Disable minification')
   .option('-ne, --no-esm', 'Disable building ESM')
   .option('-t, --target <name>',
-    'Build for target ' +
-    '[all, browser, cdn, node]',
+    'Build for target '
+    + '[all, browser, cdn, node]',
     'browser')
   .parse(process.argv);
 

--- a/tools/build_browser.js
+++ b/tools/build_browser.js
@@ -6,10 +6,10 @@ const path = require("path");
 const zlib = require('zlib');
 const Terser = require("terser");
 const child_process = require('child_process');
-const { getLanguages } = require("./lib/language");
-const { filter } = require("./lib/dependencies");
-const config = require("./build_config");
-const { install, installCleanCSS, mkdir, renderTemplate } = require("./lib/makestuff");
+const { getLanguages } = require("./lib/language.js");
+const { filter } = require("./lib/dependencies.js");
+const config = require("./build_config.js");
+const { install, installCleanCSS, mkdir, renderTemplate } = require("./lib/makestuff.js");
 const log = (...args) => console.log(...args);
 const { rollupCode } = require("./lib/bundling.js");
 const bundling = require('./lib/bundling.js');
@@ -17,16 +17,16 @@ const Table = require('cli-table');
 
 const getDefaultHeader = () => ({
   ...require('../package.json'),
-  git_sha : child_process
+  git_sha: child_process
     .execSync("git rev-parse --short=10 HEAD")
-    .toString().trim(),
+    .toString().trim()
 });
 function buildHeader(args = getDefaultHeader()) {
-  return "/*!\n" +
-  `  Highlight.js v${args.version} (git: ${args.git_sha})\n` +
-  `  (c) ${config.copyrightYears} ${args.author.name} and other contributors\n` +
-  `  License: ${args.license}\n` +
-  ` */`;
+  return "/*!\n"
+  + `  Highlight.js v${args.version} (git: ${args.git_sha})\n`
+  + `  (c) ${config.copyrightYears} ${args.author.name} and other contributors\n`
+  + `  License: ${args.license}\n`
+  + ` */`;
 }
 
 function sortByKey(array, key) {
@@ -41,9 +41,9 @@ function detailedGrammarSizes(languages) {
   if (languages.length > 180) return;
 
   const resultTable = new Table({
-    head: ['lang','minified'],
+    head: ['lang', 'minified'],
     // colWidths: [20,20,10,20,10,20],
-    chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
+    chars: { mid: '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
     style: {
       head: ['grey']
     }
@@ -230,19 +230,19 @@ async function buildCore(name, languages, options) {
   const sizeInfo = { shas: [] };
   const writePromises = [];
   if (options.minify) {
-    const { code } = await Terser.minify(index, {...config.terser, module: (options.format === "es") });
+    const { code } = await Terser.minify(index, { ...config.terser, module: (options.format === "es") });
     const src = `${header}\n${code}`;
     writePromises.push(fs.writeFile(output.file.replace(/js$/, "min.js"), src));
     sizeInfo.minified = src.length;
     sizeInfo.minifiedSrc = src;
-    sizeInfo.shas[`${relativePath}${name}.min.js`] = bundling.sha384(src)
+    sizeInfo.shas[`${relativePath}${name}.min.js`] = bundling.sha384(src);
   }
   {
     const src = `${header}\n${index}`;
     writePromises.push(fs.writeFile(output.file, src));
     sizeInfo.fullSize = src.length;
     sizeInfo.fullSrc = src;
-    sizeInfo.shas[`${relativePath}${name}.js`] = bundling.sha384(src)
+    sizeInfo.shas[`${relativePath}${name}.js`] = bundling.sha384(src);
   }
   await Promise.all(writePromises);
   return sizeInfo;

--- a/tools/build_cdn.js
+++ b/tools/build_cdn.js
@@ -57,7 +57,7 @@ async function buildCDN(options) {
   if (options.esm) {
     mkdir("es");
     await fs.writeFile(`${process.env.BUILD_DIR}/es/package.json`, `{ "type": "module" }`);
-    esmCoreSize = await buildCore("core", [], {minify: options.minify, format: "es"});
+    esmCoreSize = await buildCore("core", [], { minify: options.minify, format: "es" });
     esmCommonSize = await buildCore("highlight", embedLanguages, { minify: options.minify, format: "es" });
   }
   shas = {
@@ -157,7 +157,7 @@ async function buildDistributable(language, options) {
   await fs.mkdir(distDir, { recursive: true });
   await fs.writeFile(path.join(language.moduleDir, "dist", filename), language.minified);
   if (options.esm) {
-    await fs.writeFile(path.join(language.moduleDir, "dist", filename.replace(".min.js",".es.min.js")), language.minifiedESM);
+    await fs.writeFile(path.join(language.moduleDir, "dist", filename.replace(".min.js", ".es.min.js")), language.minifiedESM);
   }
 }
 

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -1,29 +1,29 @@
 const fs = require("fs").promises;
 const fss = require("fs");
-const config = require("./build_config");
+const config = require("./build_config.js");
 const glob = require("glob-promise");
-const { getLanguages } = require("./lib/language");
-const { install, mkdir, installCleanCSS } = require("./lib/makestuff");
-const { filter } = require("./lib/dependencies");
+const { getLanguages } = require("./lib/language.js");
+const { install, mkdir, installCleanCSS } = require("./lib/makestuff.js");
+const { filter } = require("./lib/dependencies.js");
 const { rollupWrite } = require("./lib/bundling.js");
 const log = (...args) => console.log(...args);
 
 // https://nodejs.org/api/packages.html#packages_writing_dual_packages_while_avoiding_or_minimizing_hazards
 async function buildESMStub(name) {
   const code =
-    `// https://nodejs.org/api/packages.html#packages_writing_dual_packages_while_avoiding_or_minimizing_hazards\n` +
-    `import HighlightJS from '../lib/${name}.js';\n` +
-    `export { HighlightJS };\n` +
-    `export default HighlightJS;\n`;
+    `// https://nodejs.org/api/packages.html#packages_writing_dual_packages_while_avoiding_or_minimizing_hazards\n`
+    + `import HighlightJS from '../lib/${name}.js';\n`
+    + `export { HighlightJS };\n`
+    + `export default HighlightJS;\n`;
   await fs.writeFile(`${process.env.BUILD_DIR}/es/${name}.js`, code);
 }
 
 async function buildCJSIndex(name, languages) {
   const header = "var hljs = require('./core');";
   const footer =
-    `hljs.HighlightJS = hljs\n` +
-    `hljs.default = hljs\n` +
-    `module.exports = hljs;`;
+    `hljs.HighlightJS = hljs\n`
+    + `hljs.default = hljs\n`
+    + `module.exports = hljs;`;
 
   const registration = languages.map((lang) => {
     const require = `require('./languages/${lang.name}')`;
@@ -57,7 +57,8 @@ async function buildNodeLanguage(language, options) {
   if (options.esm) {
     await fs.writeFile(`${process.env.BUILD_DIR}/es/languages/${language.name}.js.js`,
       ES_STUB.replace(/%%%%/g, language.name));
-    await rollupWrite(input, {...output,
+    await rollupWrite(input, {
+      ...output,
       format: "es",
       file: output.file.replace("/lib/", "/es/")
     });
@@ -108,7 +109,7 @@ const generatePackageExports = () => ({
   "./lib/languages/*": dual("./lib/languages/*.js"),
   "./scss/*": "./scss/*",
   "./styles/*": "./styles/*",
-  "./types/*": "./types/*",
+  "./types/*": "./types/*"
 });
 function buildPackageJSON(options) {
   const packageJson = require("../package.json");

--- a/tools/checkAutoDetect.js
+++ b/tools/checkAutoDetect.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 
-let fs       = require('fs')
-let hljs     = require('../build');
-let path     = require('path');
-let utility  = require('../test/utility');
-let Table    = require('cli-table');
-let colors   = require('colors/safe');
+const fs = require('fs');
+const hljs = require('../build.js');
+const path = require('path');
+const utility = require('../test/utility.js');
+const Table = require('cli-table');
+const colors = require('colors/safe.js');
 
-let resultTable = new Table({
-  head: ['expected', 'actual', 'score', '2nd best', 'score','info'],
-  colWidths: [20,20,10,20,10,20],
+const resultTable = new Table({
+  head: ['expected', 'actual', 'score', '2nd best', 'score', 'info'],
+  colWidths: [20, 20, 10, 20, 10, 20],
   style: {
     head: ['grey']
   }
@@ -24,8 +24,8 @@ function testAutoDetection(language, index, languages) {
       return fs.readFileSync(filename, 'utf-8');
     })
     .forEach(function(content) {
-      const expected = language,
-            actual   = hljs.highlightAuto(content);
+      const expected = language;
+      const actual = hljs.highlightAuto(content);
       if (actual.language !== expected && actual.secondBest.language !== expected) {
         return resultTable.push([
           expected,
@@ -45,7 +45,7 @@ function testAutoDetection(language, index, languages) {
         ]);
       }
       // equal relevance is flagged
-      if (actual.relevance == actual.secondBest.relevance) {
+      if (actual.relevance === actual.secondBest.relevance) {
         return resultTable.push([
           expected,
           actual.language,
@@ -68,18 +68,16 @@ if (process.env.ONLY_LANGUAGES) {
 console.log('Checking auto-highlighting for ' + colors.grey(languages.length) + ' languages...');
 languages.forEach((lang, index) => {
   if (index % 60 === 0) { console.log(""); }
-  testAutoDetection(lang)
+  testAutoDetection(lang);
   process.stdout.write(".");
 });
-console.log("\n")
+console.log("\n");
 
 if (resultTable.length === 0) {
-  console.log(colors.green('SUCCESS') + ' - ' + colors.green(languages.length) + ' of ' + colors.gray(languages.length) + ' languages passed auto-highlight check!')
+  console.log(colors.green('SUCCESS') + ' - ' + colors.green(languages.length) + ' of ' + colors.gray(languages.length) + ' languages passed auto-highlight check!');
 } else {
   console.log(
-    colors.red('ISSUES') + ' - ' + colors.red(resultTable.length) + ' of ' + colors.gray(languages.length) + ' languages have potential issues.' +
-    '\n' +
-    resultTable.toString());
+    colors.red('ISSUES') + ' - ' + colors.red(resultTable.length) + ' of ' + colors.gray(languages.length) + ' languages have potential issues.'
+    + '\n'
+    + resultTable.toString());
 }
-
-

--- a/tools/checkTheme.js
+++ b/tools/checkTheme.js
@@ -2,7 +2,6 @@
 
 const fs = require("fs");
 const css = require("css");
-const { match } = require("assert");
 require("colors");
 
 const CODE = {
@@ -166,19 +165,19 @@ function check_group(group, rules) {
   });
 
 
-  let doesNotSupport = has_rules.map(x => x[1]).includes(false);
-  let skipped = has_rules.find(x => x[2]);
+  const doesNotSupport = has_rules.map(x => x[1]).includes(false);
+  const skipped = has_rules.find(x => x[2]);
   if (doesNotSupport || skipped) {
     console.log(group.name.yellow);
     if (doesNotSupport) {
       console.log(`- Theme does not fully support.`.brightMagenta);
     }
 
-    has_rules.filter(x => !x[1]).forEach(([scope,_]) => {
+    has_rules.filter(x => !x[1]).forEach(([scope, _]) => {
       const selector = scopeToSelector(scope);
       console.log(`- scope ${scope.cyan} is not highlighted\n  (css: ${selector.green})`);
     });
-    has_rules.filter(x => x[2]).forEach(([scope,_]) => {
+    has_rules.filter(x => x[2]).forEach(([scope, _]) => {
       console.log(` - scope ${scope.cyan} [purposely] un-highlighted.`.cyan);
     });
     console.log();

--- a/tools/lib/bundling.js
+++ b/tools/lib/bundling.js
@@ -1,8 +1,8 @@
-const rollup = require('rollup')
+const rollup = require('rollup');
 const crypto = require("crypto");
 
 async function rollupCode(inputOptions, outputOptions) {
-  const output = await generate(inputOptions, outputOptions)
+  const output = await generate(inputOptions, outputOptions);
   return output[0].code;
 }
 

--- a/tools/lib/dependencies.js
+++ b/tools/lib/dependencies.js
@@ -6,20 +6,19 @@ const DependencyResolver = require('dependency-resolver');
  *
  * @param {array<Language>} languages list of languages to be reordered
  * @returns {array<Language>} ordered list of languages
-*/
-
+ */
 const reorderDependencies = (languages) => {
-  let resolver = new DependencyResolver();
-  for (let lang of languages) {
+  const resolver = new DependencyResolver();
+  for (const lang of languages) {
     resolver.add(lang.name);
-    for (let required of lang.requires) {
+    for (const required of lang.requires) {
       resolver.setDependency(lang.name, required);
     }
   }
   return resolver.sort().map((name) =>
-    languages.find((l) => l.name == name)
+    languages.find((l) => l.name === name)
   );
-}
+};
 
 /**
  * Filters languages by group (common, etc)
@@ -28,14 +27,13 @@ const reorderDependencies = (languages) => {
  *
  * @param {array<Language>} languages full list of languages
  * @returns {array<Language>} filtered list
-*/
-
+ */
 const languagesByGroup = (languages, groupIdentifier) => {
-  let groupName = groupIdentifier.replace(":","");
+  const groupName = groupIdentifier.replace(":", "");
   return languages.filter((el) => el.categories.includes(groupName));
-}
+};
 // :common is a group identifier, "common" is the group name
-const isGroup = (id) => id[0] == ":"
+const isGroup = (id) => id[0] === ":";
 
 
 /**
@@ -48,39 +46,36 @@ const isGroup = (id) => id[0] == ":"
  * @param {array<name|group_name>} includes - which languages or groups to include
  *   example: ":common elixir ruby"
  * @returns {array<Language>} filtered list if languages
-*/
+ */
 const filter = (allLanguages, includes) => {
-  if (includes==undefined || includes.length==0)
-    return reorderDependencies(allLanguages);
+  if (!includes || includes.length === 0) { return reorderDependencies(allLanguages); }
 
   let languages = [];
-  for (let item of includes) {
+  for (const item of includes) {
     if (isGroup(item)) {
-      languages = languages.concat(languagesByGroup(allLanguages, item))
+      languages = languages.concat(languagesByGroup(allLanguages, item));
     } else {
-      let languageName = item;
-      let found = allLanguages.find((el) => el.name == languageName )
-      if (found)
-        languages.push(found)
-      else {
-        console.error(`[ERROR] Language '${languageName}' could not be found.`)
-        process.exit(1)
+      const languageName = item;
+      const found = allLanguages.find((el) => el.name === languageName);
+      if (found) { languages.push(found); } else {
+        console.error(`[ERROR] Language '${languageName}' could not be found.`);
+        process.exit(1);
       }
     }
   }
 
   // resolve requires
-  for (let lang of languages) {
+  for (const lang of languages) {
     lang.requires.forEach(needed => {
-      if (!languages.find((el) => el.name == needed)) {
-        console.info(`[INFO] Adding ${needed}... ${lang.name} requires ${needed}.`)
-        languages.push(allLanguages.find((el) => el.name == needed))
+      if (!languages.find((el) => el.name === needed)) {
+        console.info(`[INFO] Adding ${needed}... ${lang.name} requires ${needed}.`);
+        languages.push(allLanguages.find((el) => el.name === needed));
       }
     });
   }
 
   // make sure our dependencies are in the correct order
   return reorderDependencies(languages);
-}
+};
 
-module.exports = { reorderDependencies, filter }
+module.exports = { reorderDependencies, filter };

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -1,37 +1,35 @@
-const fs = require("fs")
-const fsProm = require("fs").promises
+const fs = require("fs");
 const Terser = require("terser");
-const glob = require("glob")
-const path = require("path")
-const build_config = require("../build_config")
+const glob = require("glob");
+const path = require("path");
+const build_config = require("../build_config.js");
 
-const packageJSON = require("../../package.json")
-const REQUIRES_REGEX = /\/\*.*?Requires: (.*?)\r?\n/s
-const CATEGORY_REGEX = /\/\*.*?Category: (.*?)\r?\n/s
-const LANGUAGE_REGEX = /\/\*.*?Language: (.*?)\r?\n/s
-const {rollupCode} = require("./bundling.js")
-const { getThirdPartyPackages } = require("./external_language")
+const packageJSON = require("../../package.json");
+const REQUIRES_REGEX = /\/\*.*?Requires: (.*?)\r?\n/s;
+const CATEGORY_REGEX = /\/\*.*?Category: (.*?)\r?\n/s;
+const LANGUAGE_REGEX = /\/\*.*?Language: (.*?)\r?\n/s;
+const { rollupCode } = require("./bundling.js");
+const { getThirdPartyPackages } = require("./external_language.js");
 
 class Language {
-
   constructor(name, path) {
-    this.name = name
-    this.prettyName = name
-    this.requires = []
-    this.categories = []
-    this.third_party = false
+    this.name = name;
+    this.prettyName = name;
+    this.requires = [];
+    this.categories = [];
+    this.third_party = false;
 
     // compiled code
-    this.module = ""
-    this.minified = ""
+    this.module = "";
+    this.minified = "";
 
-    this.path = path
-    this.data = fs.readFileSync(path, {encoding: "utf8"})
-    this.loadMetadata()
+    this.path = path;
+    this.data = fs.readFileSync(path, { encoding: "utf8" });
+    this.loadMetadata();
   }
 
   async compile(options) {
-    await compileLanguage(this,options);
+    await compileLanguage(this, options);
     return this;
   }
 
@@ -39,8 +37,7 @@ class Language {
     if (this._sample) return this._sample;
 
     this._sample = "";
-    if (fs.existsSync(this.samplePath))
-      this._sample = fs.readFileSync(this.samplePath, {encoding: "utf8"});
+    if (fs.existsSync(this.samplePath)) { this._sample = fs.readFileSync(this.samplePath, { encoding: "utf8" }); }
     return this._sample;
   }
 
@@ -48,38 +45,34 @@ class Language {
     if (this.moduleDir) {
       // this is the 'extras' case.
       return `${this.moduleDir}/test/detect/${this.name}/default.txt`;
-    }
-    else {
+    } else {
       // this is the common/built-in case.
       return `./test/detect/${this.name}/default.txt`;
     }
   }
 
   loadMetadata() {
-    var requiresMatch = REQUIRES_REGEX.exec(this.data)
-    var categoryMatch = CATEGORY_REGEX.exec(this.data)
-    var languageMatch = LANGUAGE_REGEX.exec(this.data)
+    const requiresMatch = REQUIRES_REGEX.exec(this.data);
+    const categoryMatch = CATEGORY_REGEX.exec(this.data);
+    const languageMatch = LANGUAGE_REGEX.exec(this.data);
 
-    if (requiresMatch)
-      this.requires = requiresMatch[1].split(", ").map((n) => n.replace(".js",""))
+    if (requiresMatch) { this.requires = requiresMatch[1].split(", ").map((n) => n.replace(".js", "")); }
 
-    if (categoryMatch)
-      this.categories = categoryMatch[1].split(/,\s?/)
+    if (categoryMatch) { this.categories = categoryMatch[1].split(/,\s?/); }
 
-    if (languageMatch)
-      this.prettyName = languageMatch[1]
+    if (languageMatch) { this.prettyName = languageMatch[1]; }
   }
 
   static fromFile(filename) {
     return new Language(
-      path.basename(filename).replace(".js",""),
+      path.basename(filename).replace(".js", ""),
       filename
     );
   }
 }
 
 
-async function compileLanguage (language, options) {
+async function compileLanguage(language, options) {
   const HEADER = `/*! \`${language.name}\` grammar compiled for Highlight.js ${packageJSON.version} */`;
 
   // TODO: cant we use the source we already have?
@@ -105,14 +98,14 @@ async function compileLanguage (language, options) {
 }
 
 async function getLanguages() {
-  let languages = [];
+  const languages = [];
   glob.sync("./src/languages/*.js").forEach((file) => {
     languages.push(Language.fromFile(file));
   });
-  let extraPackages = await getThirdPartyPackages();
-  for (let ext of extraPackages) {
-    for (let file of ext.files) {
-      let l = Language.fromFile(file);
+  const extraPackages = await getThirdPartyPackages();
+  for (const ext of extraPackages) {
+    for (const file of ext.files) {
+      const l = Language.fromFile(file);
       l.loader = ext.loader;
       l.third_party = true;
       l.moduleDir = ext.dir;

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -2,8 +2,8 @@ const fs = require("fs");
 const CleanCSS = require('clean-css');
 const path = require('path');
 const _ = require('lodash');
-const config = require("../build_config");
 const del = require('del');
+const config = require("../build_config.js");
 
 async function clean(directory) {
   del.sync([directory]);

--- a/tools/perf.js
+++ b/tools/perf.js
@@ -20,7 +20,7 @@ const timeTest = (name, func) => {
   func();
   const t1 = performance.now();
   console.log(` done! [${((t1 - t0) / 1000).toFixed(2)}s elapsed]`);
-}
+};
 
 const oneLanguageMarkupTests = (lang) => {
   for (let i = 0; i < 50; i++) {
@@ -52,10 +52,10 @@ const globalCheckAutoDetect = () => {
 };
 
 const highlightFile = (lang) => {
-  const source = fs.readFileSync(`./tools/sample_files/${lang}.txt`, { encoding:'utf8' });
-  const hljs = require('../build');
+  const source = fs.readFileSync(`./tools/sample_files/${lang}.txt`, { encoding: 'utf8' });
+  const hljs = require('../build.js');
   for (let i = 0; i < 2000; i++) {
-    hljs.highlight(source, {language: lang});
+    hljs.highlight(source, { language: lang });
   }
 };
 


### PR DESCRIPTION
Add linting for `tools/**/*.js` with the exception of the `vendor` folder.

Does not change any rules, but fixes an ESLint style violation in the `.eslintrc.js` file itself.

Most changes were autofixed, I only manually added `.js` file endings, changed `==` to `===`, and removed two unused imports.