### PR TITLE
fix(python) `def`, `class keywords detected mid-identifier

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -378,7 +378,7 @@ export default function(hljs) {
       hljs.HASH_COMMENT_MODE,
       {
         match: [
-          /def/, /\s+/,
+          /\bdef/, /\s+/,
           IDENT_RE,
         ],
         scope: {
@@ -391,14 +391,14 @@ export default function(hljs) {
         variants: [
           {
             match: [
-              /class/, /\s+/,
+              /\bclass/, /\s+/,
               IDENT_RE, /\s*/,
               /\(\s*/, IDENT_RE,/\s*\)/
             ],
           },
           {
             match: [
-              /class/, /\s+/,
+              /\bclass/, /\s+/,
               IDENT_RE
             ],
           }

--- a/test/markup/python/false_positives.expect.txt
+++ b/test/markup/python/false_positives.expect.txt
@@ -1,0 +1,5 @@
+foo = _undef
+bar
+
+booger = _unclass
+burger

--- a/test/markup/python/false_positives.txt
+++ b/test/markup/python/false_positives.txt
@@ -1,0 +1,5 @@
+foo = _undef
+bar
+
+booger = _unclass
+burger


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
