### PR TITLE
enh(swift) add SE-0290 unavailability condition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 Grammars:
 
 - fix(python) Fix recognition of numeric literals followed by keywords without whitespace (#2985) [Richard Gibson][]
+- enh(swift) add SE-0290 unavailability condition (#3382) [Bradley Mackey][]
 
 [Richard Gibson]: https://github.com/gibson042
+[Bradley Mackey]: https://github.com/bradleymackey
 
 ## Version 11.3.1
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -141,7 +141,7 @@ export const precedencegroupKeywords = [
 ];
 
 // Keywords that start with a number sign (#).
-// #available is handled separately.
+// #(un)available is handled separately.
 export const numberSignKeywords = [
   '#colorLiteral',
   '#column',
@@ -307,7 +307,7 @@ export const keywordAttributes = [
   'usableFromInline'
 ];
 
-// Contextual keywords used in @available and #available.
+// Contextual keywords used in @available and #(un)available.
 export const availabilityKeywords = [
   'iOS',
   'iOSApplicationExtension',

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -221,7 +221,7 @@ export default function(hljs) {
 
   // https://docs.swift.org/swift-book/ReferenceManual/Attributes.html
   const AVAILABLE_ATTRIBUTE = {
-    match: /(@|#)available/,
+    match: /(@|#(un)?)available/,
     className: "keyword",
     starts: {
       contains: [

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -1,4 +1,3 @@
-<span class="hljs-keyword">@available</span>(<span class="hljs-keyword">iOS</span> <span class="hljs-number">14</span>, deprecated: <span class="hljs-string">&quot;reason&quot;</span>, <span class="hljs-operator">*</span>)
 <span class="hljs-keyword">@convention(swift)</span>
 <span class="hljs-keyword">@objc</span>
 <span class="hljs-keyword">@objc(name)</span>

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -1,4 +1,3 @@
-@available(iOS 14, deprecated: "reason", *)
 @convention(swift)
 @objc
 @objc(name)

--- a/test/markup/swift/availability.expect.txt
+++ b/test/markup/swift/availability.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-keyword">#available</span>()
+<span class="hljs-keyword">#available</span>(<span class="hljs-keyword">iOS</span> <span class="hljs-number">15.0</span>, <span class="hljs-operator">*</span>)
+<span class="hljs-keyword">@available</span>()
+<span class="hljs-keyword">@available</span>(<span class="hljs-keyword">iOS</span> <span class="hljs-number">15.0</span>, <span class="hljs-operator">*</span>)
+<span class="hljs-keyword">@available</span>(<span class="hljs-keyword">iOS</span> <span class="hljs-number">14</span>, deprecated: <span class="hljs-string">&quot;reason&quot;</span>, <span class="hljs-operator">*</span>)
+
+<span class="hljs-keyword">#unavailable</span>()
+<span class="hljs-keyword">#unavailable</span>(<span class="hljs-keyword">iOS</span> <span class="hljs-number">15.0</span>, <span class="hljs-operator">*</span>)
+<span class="hljs-comment">// not a keyword</span>
+<span class="hljs-meta">@unavailable</span>()
+<span class="hljs-meta">@unavailable</span>(iOS <span class="hljs-number">15.0</span>, <span class="hljs-operator">*</span>)

--- a/test/markup/swift/availability.txt
+++ b/test/markup/swift/availability.txt
@@ -1,0 +1,11 @@
+#available()
+#available(iOS 15.0, *)
+@available()
+@available(iOS 15.0, *)
+@available(iOS 14, deprecated: "reason", *)
+
+#unavailable()
+#unavailable(iOS 15.0, *)
+// not a keyword
+@unavailable()
+@unavailable(iOS 15.0, *)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New language feature implemented in Swift 5.6, this conforms to the specification described in [SE-0290](https://github.com/apple/swift-evolution/blob/main/proposals/0290-negative-availability.md). Note this only includes `#unavailable`, not `@unavailable`.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- Adds `#unavailable` keyword, using the same keyword rules as existing availability attribute.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
