### PR TITLE
enh(java) add `sealed` and `non-sealed` keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Grammars:
 
 - fix(python) Fix recognition of numeric literals followed by keywords without whitespace (#2985) [Richard Gibson][]
 - enh(swift) add SE-0290 unavailability condition (#3382) [Bradley Mackey][]
+- enh(java) add `sealed` and `non-sealed` keywords (#3386) [Bradley Mackey][]
 
 [Richard Gibson]: https://github.com/gibson042
 [Bradley Mackey]: https://github.com/bradleymackey

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -73,7 +73,8 @@ export default function(hljs) {
     'module',
     'requires',
     'exports',
-    'do'
+    'do',
+    'sealed'
   ];
 
   const BUILT_INS = [
@@ -177,6 +178,15 @@ export default function(hljs) {
         className: {
           1: "keyword",
           3: "title.class"
+        }
+      },
+      {
+        // Hypenated keywords
+        match: [
+          /non-sealed/
+        ],
+        className: {
+          1: "keyword"
         }
       },
       {

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -181,7 +181,7 @@ export default function(hljs) {
         }
       },
       {
-        // Hypenated keywords
+        // Exceptions for hyphenated keywords
         match: [
           /non-sealed/
         ],

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -182,12 +182,8 @@ export default function(hljs) {
       },
       {
         // Exceptions for hyphenated keywords
-        match: [
-          /non-sealed/
-        ],
-        className: {
-          1: "keyword"
-        }
+        match: /non-sealed/,
+        scope: "keyword"
       },
       {
         begin: [

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -8,3 +8,11 @@
         }
     }
 }
+
+<span class="hljs-keyword">sealed</span> <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Command</span> permits LoginCommand {
+    <span class="hljs-keyword">void</span> <span class="hljs-title function_">run</span><span class="hljs-params">()</span>;
+}
+
+<span class="hljs-keyword">non-sealed</span> <span class="hljs-keyword">abstract</span> <span class="hljs-keyword">class</span> <span class="hljs-title class_">UserPluginCommand</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Command</span> {
+    <span class="hljs-keyword">void</span> <span class="hljs-title function_">runAsUser</span><span class="hljs-params">()</span>;
+}

--- a/test/markup/java/titles.txt
+++ b/test/markup/java/titles.txt
@@ -8,3 +8,11 @@ public class Greet {
         }
     }
 }
+
+sealed interface Command permits LoginCommand {
+    void run();
+}
+
+non-sealed abstract class UserPluginCommand extends Command {
+    void runAsUser();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds support for these missing keywords, using a different matching pattern for hyphenated keywords as a workaround. [Source for suggested workaround](https://github.com/thiccaxe/highlight.js/commit/e285198f222a48a363338b54e3c077b6a18db18d#r57401045).

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- Adds `sealed` and `non-sealed` keywords
- Fixes #3346

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
