### PR TITLE
fix(clojure) comment macro should not be `comment` scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,11 @@ Grammars:
 - fix(python) Fix recognition of numeric literals followed by keywords without whitespace (#2985) [Richard Gibson][]
 - enh(swift) add SE-0290 unavailability condition (#3382) [Bradley Mackey][]
 - enh(java) add `sealed` and `non-sealed` keywords (#3386) [Bradley Mackey][]
+- fix(clojure) `comment` macro catches more than it should [Björn Ebbinghaus][]
 
 [Richard Gibson]: https://github.com/gibson042
 [Bradley Mackey]: https://github.com/bradleymackey
+[Björn Ebbinghaus]: https://github.com/MrEbbinghaus
 
 ## Version 11.3.1
 

--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -132,7 +132,6 @@ export default function(hljs) {
   };
 
   LIST.contains = [
-    hljs.COMMENT('comment', ''),
     GLOBAL,
     NAME,
     BODY

--- a/test/markup/clojure/comment-macro.expect.txt
+++ b/test/markup/clojure/comment-macro.expect.txt
@@ -1,0 +1,2 @@
+(<span class="hljs-name">comment</span> <span class="hljs-string">&quot;comment is a macro that emits no code. It can contain clojure code in itself.&quot;</span>)
+(<span class="hljs-name">comment-and-something</span> <span class="hljs-string">&quot;This is a valid function name&quot;</span>)

--- a/test/markup/clojure/comment-macro.txt
+++ b/test/markup/clojure/comment-macro.txt
@@ -1,0 +1,2 @@
+(comment "comment is a macro that emits no code. It can contain clojure code in itself.")
+(comment-and-something "This is a valid function name")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Changes
Clojure has a macro `comment`, which evaluates to nothing. It is not a special language feature. 
The current grammar highlights every list beginning with "comment" (See screenshot)
![image](https://user-images.githubusercontent.com/2965273/140814299-42c23794-8081-441d-9a00-ead32a455f63.png)

I guess the intention behind that mode was at some point that _some_ editor themes highlight the whole blocks (not just the name) like comments. 

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
