### PR TITLE
fix(clojure) Regex mode not allowing backslash escape

### DIFF
--- a/src/languages/clojure.js
+++ b/src/languages/clojure.js
@@ -73,7 +73,8 @@ export default function(hljs) {
   const REGEX = {
     scope: 'regex',
     begin: /#"/,
-    end: /"/
+    end: /"/,
+    contains: [hljs.BACKSLASH_ESCAPE]
   }
   const STRING = hljs.inherit(hljs.QUOTE_STRING_MODE, {
     illegal: null

--- a/test/markup/clojure/globals_definition.expect.txt
+++ b/test/markup/clojure/globals_definition.expect.txt
@@ -14,6 +14,12 @@
       (<span class="hljs-name"><span class="hljs-built_in">-&gt;&gt;</span></span>
         (<span class="hljs-name"><span class="hljs-built_in">list</span></span> [vector] {<span class="hljs-symbol">:map</span> map} #{&#x27;set})))))
 
+<span class="hljs-regex">#&quot;\&quot;abc\\&quot;</span>
+
+<span class="hljs-string">&quot;real
+multiline
+string&quot;</span>
+
 #:person{<span class="hljs-symbol">:first</span> <span class="hljs-string">&quot;Han&quot;</span>
          <span class="hljs-symbol">:last</span> <span class="hljs-string">&quot;Solo&quot;</span>
          <span class="hljs-symbol">:ship</span> #:ship{<span class="hljs-symbol">:name</span> <span class="hljs-string">&quot;Millenium Falcon&quot;</span>}}

--- a/test/markup/clojure/globals_definition.txt
+++ b/test/markup/clojure/globals_definition.txt
@@ -14,6 +14,12 @@
       (->>
         (list [vector] {:map map} #{'set})))))
 
+#"\"abc\\"
+
+"real
+multiline
+string"
+
 #:person{:first "Han"
          :last "Solo"
          :ship #:ship{:name "Millenium Falcon"}}


### PR DESCRIPTION
Hey @joshgoebel,
It's me again.
I forgot to add backslash escaping to the regex mode

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
