### PR TITLE
(chore) add gzip size compression report

### DIFF
--- a/.github/workflows/compressed_size.yml
+++ b/.github/workflows/compressed_size.yml
@@ -1,0 +1,21 @@
+# This workflow computes the size of a CDN build's output on all Javascript files.
+# Reported file sizes are after the result of gzip compression.
+# Compression action used: https://github.com/preactjs/compressed-size-action
+
+name: CDN Size (gzip)
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compute Compressed Size
+        uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build-cdn"
+          compression: "gzip"
+          pattern: "./build/**/*.js"

--- a/.github/workflows/size_report.yml
+++ b/.github/workflows/size_report.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           build-script: "build-cdn"
           compression: "gzip"
-          pattern: "./build/**/*.js"
+          pattern: "./build/{*.min.js,es/*.min.js,languages/*.min.js,es/languages/*.min.js}"

--- a/.github/workflows/size_report.yml
+++ b/.github/workflows/size_report.yml
@@ -2,7 +2,7 @@
 # Reported file sizes are after the result of gzip compression.
 # Compression action used: https://github.com/preactjs/compressed-size-action
 
-name: CDN Size (gzip)
+name: Size Report (gzip)
 
 on: [pull_request]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Grammars:
 
 Developer Tools:
 
-- (chore) add gzip compression action (#3400) [Bradley Mackey][]
+- (chore) add gzip size compression report (#3400) [Bradley Mackey][]
 
 [Richard Gibson]: https://github.com/gibson042
 [Bradley Mackey]: https://github.com/bradleymackey

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
+
+Developer Tools:
+
 - (chore) add gzip compression action (#3400) [Bradley Mackey][]
 
 [Richard Gibson]: https://github.com/gibson042

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
+- (chore) add gzip compression action (#3400) [Bradley Mackey][]
 
 [Richard Gibson]: https://github.com/gibson042
 [Bradley Mackey]: https://github.com/bradleymackey


### PR DESCRIPTION
This will report the gzip'd size of the CDN build output on every pull request, being run via GitHub actions.
Currently is applied to all Javascript output files.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- Add new GitHub actions workflow to report compressed size changes.
- Resolves #3097

### Checklist
- [x] Markup tests not needed
- [x] Updated the changelog at `CHANGES.md`
