### PR TITLE
(chore) min change threshold for size report

### DIFF
--- a/.github/workflows/size_report.yml
+++ b/.github/workflows/size_report.yml
@@ -18,4 +18,5 @@ jobs:
         with:
           build-script: "build-cdn"
           compression: "gzip"
+          minimum-change-threshold: 5 # bytes
           pattern: "./build/{*.min.js,es/*.min.js,languages/*.min.js,es/languages/*.min.js}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
±5 byte threshold to avoid reports for hash changes and tiny edits.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

- GitHub workflow change only.

### Checklist
- [x] markup tests don't apply
- [x] CHANGES.md change unneeded? Consider hotfix to #3400
