### PR TITLE
enh(php) Add support for Attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Themes:
 
 Grammars:
 
+- enh(php) add support for PHP Attributes [Wojciech Kania][]
 - fix(java) prevent false positive variable init on `else` [Josh Goebel][]
 - enh(php) named arguments [Wojciech Kania][]
 - fix(php) PHP constants [Wojciech Kania][]

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -12,15 +12,16 @@ Category: common
  * */
 export default function(hljs) {
   const regex = hljs.regex;
-  const IDENT_RE = '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
-    // negative look-ahead tries to avoid matching patterns that are not
-    // Perl at all like $ident$, @ident@, etc.
-    '(?![A-Za-z0-9])(?![$])';
-  // Will not detect camelCase classes
-  const PASCAL_CASE_CLASS_NAME_RE = '([\\\\?A-Z][a-zA-Z0-9_\x7f-\xff]*' +
   // negative look-ahead tries to avoid matching patterns that are not
   // Perl at all like $ident$, @ident@, etc.
-  '(?![A-Za-z0-9])(?![$])){1,}';
+  const NOT_PERL_ETC = /(?![A-Za-z0-9])(?![$])/;
+  const IDENT_RE = regex.concat(
+    /[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,
+    NOT_PERL_ETC);
+  // Will not detect camelCase classes
+  const PASCAL_CASE_CLASS_NAME_RE = regex.concat(
+    /(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[^A-Z])){1,}/,
+    NOT_PERL_ETC);
   const VARIABLE = {
     scope: 'variable',
     match: '\\$+' + IDENT_RE,

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -20,7 +20,7 @@ export default function(hljs) {
     NOT_PERL_ETC);
   // Will not detect camelCase classes
   const PASCAL_CASE_CLASS_NAME_RE = regex.concat(
-    /(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[^A-Z])){1,}/,
+    /(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,
     NOT_PERL_ETC);
   const VARIABLE = {
     scope: 'variable',

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -433,6 +433,15 @@ export default function(hljs) {
   };
   PARAMS_MODE.contains.push(FUNCTION_INVOKE);
 
+  const ATTRIBUTE_CONTAINS = [
+    NAMED_ARGUMENT,
+    LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
+    hljs.C_BLOCK_COMMENT_MODE,
+    STRING,
+    NUMBER,
+    CONSTRUCTOR_CALL,
+  ];
+
   const ATTRIBUTES = {
     begin: regex.concat(/#\[\s*/, PASCAL_CASE_CLASS_NAME_RE),
     beginScope: "meta",
@@ -458,20 +467,10 @@ export default function(hljs) {
         },
         contains: [
           'self',
-          NAMED_ARGUMENT,
-          LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
-          hljs.C_BLOCK_COMMENT_MODE,
-          STRING,
-          NUMBER,
-          CONSTRUCTOR_CALL,
+          ...ATTRIBUTE_CONTAINS,
         ]
       },
-      NAMED_ARGUMENT,
-      LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
-      hljs.C_BLOCK_COMMENT_MODE,
-      STRING,
-      NUMBER,
-      CONSTRUCTOR_CALL,
+      ...ATTRIBUTE_CONTAINS,
       {
         scope: 'meta',
         match: PASCAL_CASE_CLASS_NAME_RE

--- a/test/markup/php/attributes.expect.txt
+++ b/test/markup/php/attributes.expect.txt
@@ -4,6 +4,7 @@
 <span class="hljs-meta">#[\MyExample\MyAttribute</span><span class="hljs-meta">]</span>
 <span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-number">1234</span>)<span class="hljs-meta">]</span>
 <span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-attr">value</span>: <span class="hljs-number">1234</span>)<span class="hljs-meta">]</span>
+<span class="hljs-meta">#[HTMLAttribute</span>(<span class="hljs-attr">tag</span>: <span class="hljs-string">&quot;h1&quot;</span>)<span class="hljs-meta">]</span>
 <span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-title class_">MyAttribute</span>::<span class="hljs-variable constant_">VALUE</span>)<span class="hljs-meta">]</span>
 <span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-keyword">array</span>(<span class="hljs-string">&quot;key&quot;</span> =&gt; <span class="hljs-string">&quot;value&quot;</span>))<span class="hljs-meta">]</span>
 <span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-number">100</span> + <span class="hljs-number">200</span>)<span class="hljs-meta">]</span>

--- a/test/markup/php/attributes.expect.txt
+++ b/test/markup/php/attributes.expect.txt
@@ -1,0 +1,57 @@
+<span class="hljs-keyword">namespace</span> <span class="hljs-title class_">Entity</span>;
+
+<span class="hljs-meta">#[MyAttribute</span><span class="hljs-meta">]</span>
+<span class="hljs-meta">#[\MyExample\MyAttribute</span><span class="hljs-meta">]</span>
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-number">1234</span>)<span class="hljs-meta">]</span>
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-attr">value</span>: <span class="hljs-number">1234</span>)<span class="hljs-meta">]</span>
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-title class_">MyAttribute</span>::<span class="hljs-variable constant_">VALUE</span>)<span class="hljs-meta">]</span>
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-keyword">array</span>(<span class="hljs-string">&quot;key&quot;</span> =&gt; <span class="hljs-string">&quot;value&quot;</span>))<span class="hljs-meta">]</span>
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-number">100</span> + <span class="hljs-number">200</span>)<span class="hljs-meta">]</span>
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span> </span>{}
+
+<span class="hljs-meta">#[MyAttribute</span>(<span class="hljs-number">1234</span>), <span class="hljs-meta">MyAttribute</span>(<span class="hljs-number">5678</span>)<span class="hljs-meta">]</span>
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Bar</span>
+</span>{
+    <span class="hljs-meta">#[Assert\IsTrue</span>(<span class="hljs-attr">message</span>: <span class="hljs-string">&#x27;The password cannot match your given name&#x27;</span>)<span class="hljs-meta">]</span>
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">isPasswordSafe</span>(<span class="hljs-params"></span>)
+    </span>{
+    }
+
+    <span class="hljs-meta">#[Assert\AtLeastOneOf</span>([
+        <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\Count</span>(<span class="hljs-attr">min</span>: <span class="hljs-number">2</span>),
+        <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\All</span>(
+           <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\GreaterThanOrEqual</span>(<span class="hljs-number">7</span>)
+        ),
+    ])<span class="hljs-meta">]</span>
+    <span class="hljs-keyword">public</span> <span class="hljs-variable">$stuff</span>;
+}
+
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Book</span>
+</span>{
+    <span class="hljs-meta">#[Assert\Choice</span>(
+        <span class="hljs-attr">choices</span>: [<span class="hljs-string">&#x27;blue&#x27;</span>, <span class="hljs-string">&#x27;green&#x27;</span>],
+        <span class="hljs-attr">message</span>: <span class="hljs-string">&#x27;Choose a valid color.&#x27;</span>,
+    )<span class="hljs-meta">]</span>
+    <span class="hljs-keyword">private</span> <span class="hljs-variable">$color</span>;
+
+    <span class="hljs-meta">#[Assert\Choice</span>([<span class="hljs-string">&#x27;Hardcover&#x27;</span>, <span class="hljs-string">&#x27;Paperback&#x27;</span>])<span class="hljs-meta">]</span>
+    <span class="hljs-keyword">private</span> <span class="hljs-variable">$format</span>;
+
+    <span class="hljs-meta">#[
+         Assert\Collection</span>(
+             <span class="hljs-attr">fields</span>: [
+                 <span class="hljs-string">&#x27;authorEmail&#x27;</span> =&gt; <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\Email</span>,
+                 <span class="hljs-string">&#x27;shortDesc&#x27;</span> =&gt; [
+                     <span class="hljs-comment">/*something*/</span>
+                     <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\NotBlank</span>,
+                     <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\Length</span>(
+                         <span class="hljs-attr">max</span>: <span class="hljs-number">200</span>,
+                         <span class="hljs-attr">maxMessage</span>: <span class="hljs-string">&#x27;Your short desc is too long&#x27;</span>
+                     )
+                 ],
+             ],
+             <span class="hljs-attr">allowMissingFields</span>: <span class="hljs-literal">true</span>,
+        )
+    <span class="hljs-meta">]</span>
+    <span class="hljs-keyword">protected</span> <span class="hljs-variable">$additionalData</span>;
+}

--- a/test/markup/php/attributes.txt
+++ b/test/markup/php/attributes.txt
@@ -1,0 +1,57 @@
+namespace Entity;
+
+#[MyAttribute]
+#[\MyExample\MyAttribute]
+#[MyAttribute(1234)]
+#[MyAttribute(value: 1234)]
+#[MyAttribute(MyAttribute::VALUE)]
+#[MyAttribute(array("key" => "value"))]
+#[MyAttribute(100 + 200)]
+class Foo {}
+
+#[MyAttribute(1234), MyAttribute(5678)]
+class Bar
+{
+    #[Assert\IsTrue(message: 'The password cannot match your given name')]
+    public function isPasswordSafe()
+    {
+    }
+
+    #[Assert\AtLeastOneOf([
+        new Assert\Count(min: 2),
+        new Assert\All(
+           new Assert\GreaterThanOrEqual(7)
+        ),
+    ])]
+    public $stuff;
+}
+
+class Book
+{
+    #[Assert\Choice(
+        choices: ['blue', 'green'],
+        message: 'Choose a valid color.',
+    )]
+    private $color;
+
+    #[Assert\Choice(['Hardcover', 'Paperback'])]
+    private $format;
+
+    #[
+         Assert\Collection(
+             fields: [
+                 'authorEmail' => new Assert\Email,
+                 'shortDesc' => [
+                     /*something*/
+                     new Assert\NotBlank,
+                     new Assert\Length(
+                         max: 200,
+                         maxMessage: 'Your short desc is too long'
+                     )
+                 ],
+             ],
+             allowMissingFields: true,
+        )
+    ]
+    protected $additionalData;
+}

--- a/test/markup/php/attributes.txt
+++ b/test/markup/php/attributes.txt
@@ -4,6 +4,7 @@ namespace Entity;
 #[\MyExample\MyAttribute]
 #[MyAttribute(1234)]
 #[MyAttribute(value: 1234)]
+#[HTMLAttribute(tag: "h1")]
 #[MyAttribute(MyAttribute::VALUE)]
 #[MyAttribute(array("key" => "value"))]
 #[MyAttribute(100 + 200)]


### PR DESCRIPTION
### Changes
PHP 8 added support for [Attributes](https://www.php.net/releases/8.0/en.php#attributes).  Nested attributes were added to PHP 8.1.
They are similar to the ones from [Rust](https://github.com/highlightjs/highlight.js/blob/main/src/languages/rust.js#L240).

![image](https://user-images.githubusercontent.com/57155526/151719303-92b04076-74e6-4556-957e-6a444277d74b.png)


### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
