### PR TITLE
enh(nsis) Update variables pattern

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
+  - enh(nsis) Update variables pattern (#3416) [idleberg][]
 
 Developer Tools:
 

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -8,6 +8,7 @@ Website: https://nsis.sourceforge.io/Main_Page
 import * as regex from '../lib/regex.js';
 
 export default function(hljs) {
+  const regex = hljs.regex;
   const LANGUAGE_CONSTANTS = [
     "ADMINTOOLS",
     "APPDATA",
@@ -493,7 +494,7 @@ export default function(hljs) {
     "zlib"
   ];
 
-  const FUNCTION_DEF = {
+  const FUNCTION_DEFINITION = {
     match: [
       /Function/,
       /\s+/,
@@ -502,6 +503,21 @@ export default function(hljs) {
     scope: {
       1: "keyword",
       3: "title.function"
+    }
+  };
+
+  const VARIABLE_NAME_RE = regex.concat(hljs.IDENT_RE, "(\.", hljs.IDENT_RE, ")*");
+  const VARIABLE_DEFINITION = {
+    match: [
+      /Var/,
+      /\s+/,
+      /(?:\/GLOBAL\s+)?/,
+      VARIABLE_NAME_RE
+    ],
+    scope: {
+      1: "keyword",
+      3: "params",
+      4: "variable"
     }
   };
 
@@ -522,7 +538,8 @@ export default function(hljs) {
           relevance: 0
         }
       ),
-      FUNCTION_DEF,
+      VARIABLE_DEFINITION,
+      FUNCTION_DEFINITION,
       {
         beginKeywords: 'Function PageEx Section SectionGroup FunctionEnd SectionEnd',
       },

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -506,7 +506,9 @@ export default function(hljs) {
     }
   };
 
-  const VARIABLE_NAME_RE = regex.concat(hljs.IDENT_RE, "(\.", hljs.IDENT_RE, ")*");
+  // Var Custom.Variable.Name.Item
+  // Var /GLOBAL Custom.Variable.Name.Item
+  const VARIABLE_NAME_RE = /[A-Za-z][\w.]*/;
   const VARIABLE_DEFINITION = {
     match: [
       /Var/,

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -184,9 +184,9 @@ export default function(hljs) {
     )
   };
 
-  const METACHARS = {
+  const ESCAPE_CHARS = {
     // $\n, $\r, $\t, $$
-    className: 'meta',
+    className: 'char.escape',
     begin: /\$(\\[nrt]|\$)/
   };
 
@@ -214,7 +214,7 @@ export default function(hljs) {
     ],
     illegal: /\n/,
     contains: [
-      METACHARS,
+      ESCAPE_CHARS,
       CONSTANTS,
       DEFINES,
       VARIABLES,

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -159,7 +159,7 @@ export default function(hljs) {
   const VARIABLES = {
     // $variables
     className: 'variable',
-    begin: /\$+\w+/,
+    begin: /\$+\w[\w\.]*/,
     illegal: /\(\)\{\}/
   };
 

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -32,6 +32,6 @@
 <span class="hljs-comment">; Functions</span>
 <span class="hljs-keyword">Function</span> <span class="hljs-title function_">.onInit</span>
   <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">&quot;The install button reads <span class="hljs-variable">$(^InstallBtn)</span>&quot;</span>
-  <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">&#x27;Here comes a<span class="hljs-meta">$\n</span><span class="hljs-meta">$\r</span>line-break!&#x27;</span>
-  <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">`Escape the dollar-sign: <span class="hljs-meta">$$</span>`</span>
+  <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">&#x27;Here comes a<span class="hljs-char escape_">$\n</span><span class="hljs-char escape_">$\r</span>line-break!&#x27;</span>
+  <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">`Escape the dollar-sign: <span class="hljs-char escape_">$$</span>`</span>
 <span class="hljs-keyword">FunctionEnd</span>

--- a/test/markup/nsis/variables.expect.txt
+++ b/test/markup/nsis/variables.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-keyword">Var</span> CustomVariable
+<span class="hljs-keyword">StrCpy</span> <span class="hljs-variable">$CustomVariable</span> <span class="hljs-string">&quot;Hello World&quot;</span>
+<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-meta">$$</span>CustomVariable is: <span class="hljs-variable">$CustomVariable</span>&quot;</span>
+
+<span class="hljs-keyword">Var</span> Variable.With.Dots
+<span class="hljs-keyword">StrCpy</span> <span class="hljs-variable">$Variable.With.Dots</span> <span class="hljs-string">&quot;Hello World&quot;</span>
+<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-meta">$$</span>Variable.With.Dots is: <span class="hljs-variable">$Variable.With.Dots</span>&quot;</span>

--- a/test/markup/nsis/variables.expect.txt
+++ b/test/markup/nsis/variables.expect.txt
@@ -1,7 +1,7 @@
-<span class="hljs-keyword">Var</span> CustomVariable
+<span class="hljs-keyword">Var</span> <span class="hljs-variable">CustomVariable</span>
 <span class="hljs-keyword">StrCpy</span> <span class="hljs-variable">$CustomVariable</span> <span class="hljs-string">&quot;Hello World&quot;</span>
-<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-meta">$$</span>CustomVariable is: <span class="hljs-variable">$CustomVariable</span>&quot;</span>
+<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-char escape_">$$</span>CustomVariable is: <span class="hljs-variable">$CustomVariable</span>&quot;</span>
 
-<span class="hljs-keyword">Var</span> Variable.With.Dots
+<span class="hljs-keyword">Var</span> <span class="hljs-variable">Variable.With.Dots</span>
 <span class="hljs-keyword">StrCpy</span> <span class="hljs-variable">$Variable.With.Dots</span> <span class="hljs-string">&quot;Hello World&quot;</span>
-<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-meta">$$</span>Variable.With.Dots is: <span class="hljs-variable">$Variable.With.Dots</span>&quot;</span>
+<span class="hljs-keyword">MessageBox</span> <span class="hljs-params">MB_OK</span> <span class="hljs-string">&quot;<span class="hljs-char escape_">$$</span>Variable.With.Dots is: <span class="hljs-variable">$Variable.With.Dots</span>&quot;</span>

--- a/test/markup/nsis/variables.txt
+++ b/test/markup/nsis/variables.txt
@@ -1,0 +1,7 @@
+Var CustomVariable
+StrCpy $CustomVariable "Hello World"
+MessageBox MB_OK "$$CustomVariable is: $CustomVariable"
+
+Var Variable.With.Dots
+StrCpy $Variable.With.Dots "Hello World"
+MessageBox MB_OK "$$Variable.With.Dots is: $Variable.With.Dots"


### PR DESCRIPTION
Updates pattern for NSIS variable to allow `.`-characters. The bundled MUI2 header has been [making use of this](https://github.com/kichik/nsis/blob/master/Contrib/Modern%20UI%202/Interface.nsh#L11-L25) for years.

### Changes

Allow `.` in variables regex pattern

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
