### PR TITLE
enh(nsis) Update defines pattern

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Themes:
 [Björn Ebbinghaus]: https://github.com/MrEbbinghaus
 [Josh Goebel]: https://github.com/joshgoebel
 [Samia Ali]: https://github.com/samiaab1990
-
+[idleberg]: https://github.com/idleberg
 
 ## Version 11.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Grammars:
 - enh(swift) add SE-0290 unavailability condition (#3382) [Bradley Mackey][]
 - fix(fsharp) Highlight operators, match type names only in type annotations, support quoted identifiers, and other smaller fixes. [Melvyn Laïly][]
 - enh(java) add `sealed` and `non-sealed` keywords (#3386) [Bradley Mackey][]
+- enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
 - fix(clojure) Several issues with Clojure highlighting (#3397) [Björn Ebbinghaus][]
   - fix(clojure) `comment` macro catches more than it should (#3395)
   - fix(clojure) `$` in symbol breaks highlighting
@@ -16,7 +17,6 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
-  - enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
 
 Developer Tools:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
+  - enh(nsis) Update defines pattern (#3417) [idleberg][]
 
 Developer Tools:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
-  - enh(nsis) Update defines pattern (#3417) [idleberg][]
+- enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
 
 Developer Tools:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Grammars:
   - enh(clojure) Add `regex` mode to regex literal
   - fix(clojure) Remove inconsistent/broken highlighting for metadata
   - enh(clojure) Add `punctuation` mode for commas.
-- enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
+  - enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
 
 Developer Tools:
 

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -153,7 +153,7 @@ export default function(hljs) {
   const DEFINES = {
     // ${defines}
     className: 'variable',
-    begin: /\$+\{[\w.:-]+\}/
+    begin: /\$+\{[\!\w.:-]+\}/
   };
 
   const VARIABLES = {


### PR DESCRIPTION
Updates pattern for NSIS defines to allow `!`-characters. This example from the NSIS wiki has an [example](https://nsis.sourceforge.io/Check_if_a_file_exists_at_compile_time) that uses this.

### Changes

Allow `!` in defines regex pattern

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
