### PR TITLE
enh(nsis) Update language string pattern

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Grammars:
 - fix(fsharp) Highlight operators, match type names only in type annotations, support quoted identifiers, and other smaller fixes. [Melvyn Laïly][]
 - enh(java) add `sealed` and `non-sealed` keywords (#3386) [Bradley Mackey][]
 - enh(nsis) Update defines pattern to allow `!` (#3417) [idleberg][]
+- enh(nsis) Update language strings pattern to allow `!` (#3420) [idleberg][]
 - fix(clojure) Several issues with Clojure highlighting (#3397) [Björn Ebbinghaus][]
   - fix(clojure) `comment` macro catches more than it should (#3395)
   - fix(clojure) `$` in symbol breaks highlighting

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -166,7 +166,7 @@ export default function(hljs) {
   const LANGUAGES = {
     // $(language_strings)
     className: 'variable',
-    begin: /\$+\([\w^.:-]+\)/
+    begin: /\$+\([\!\w^.:-]+\)/
   };
 
   const PARAMETERS = {

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -166,7 +166,7 @@ export default function(hljs) {
   const LANGUAGES = {
     // $(language_strings)
     className: 'variable',
-    begin: /\$+\([\!\w^.:-]+\)/
+    begin: /\$+\([\w^.:!-]+\)/
   };
 
   const PARAMETERS = {


### PR DESCRIPTION
Updates pattern for NSIS language strings to allow `!`-characters. This is basically the same as #3417, but for language strings. Unfortunately, I can't produce any example to back this up.

### Changes

Allow `!` in language strings regex pattern

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
