### PR TITLE
enh(php) Left and right-side of double colon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
+- enh(php) Left and right-side of double colon [Wojciech Kania][]
+- enh(php) add PHP constants [Wojciech Kania][]
 - enh(php) add PHP 8.1 keywords [Wojciech Kania][]
 - fix(cpp) fix `vector<<` template false positive (#3437) [Josh Goebel][]
 - enh(php) support First-class Callable Syntax (#3427) [Wojciech Kania][]

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -317,8 +317,8 @@ export default function(hljs) {
           regex.concat(WHITESPACE, "+"),
           // to prevent built ins from being confused as the class constructor call
           regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-          regex.concat("\\\\?", IDENT_RE),
-          regex.concat(WHITESPACE, "*\\("),
+          regex.concat(/\\?/, IDENT_RE),
+          regex.concat(WHITESPACE, "*", /\(/),
         ],
         scope: {
           1: "keyword",

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -447,15 +447,6 @@ export default function(hljs) {
           3: "variable.constant",
         },
       },
-      {
-        // swallow composed identifiers to avoid parsing them as keywords
-        match: regex.concat(
-          /->+/,
-          IDENT_RE,
-          regex.concat("(?!", WHITESPACE, "*\\()")
-        ),
-        // scope:"wrong"
-      },
       CONSTRUCTOR_CALL,
       {
         scope: 'function',

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -12,12 +12,13 @@ Category: common
  * */
 export default function(hljs) {
   const regex = hljs.regex;
+  const IDENT_RE = '([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
+    // negative look-ahead tries to avoid matching patterns that are not
+    // Perl at all like $ident$, @ident@, etc.
+    '(?![A-Za-z0-9])(?![$]))';
   const VARIABLE = {
     scope: 'variable',
-    match: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
-      // negative look-ahead tries to avoid matching patterns that are not
-      // Perl at all like $ident$, @ident@, etc.
-      `(?![A-Za-z0-9])(?![$])`
+    match: '\\$+' + IDENT_RE,
   };
   const PREPROCESSOR = {
     scope: 'meta',
@@ -313,7 +314,7 @@ export default function(hljs) {
           regex.concat(WHITESPACE, "+"),
           // to prevent built ins from being confused as the class constructor call
           regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-          /\\?\w+/,
+          regex.concat("\\\\?", IDENT_RE, "+"),
           regex.concat(WHITESPACE, "*\\("),
         ],
         scope: {
@@ -330,7 +331,7 @@ export default function(hljs) {
       /\b/,
       // to prevent keywords from being confused as the function title
       regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-      /\w+/,
+      regex.concat(IDENT_RE, "+"),
       regex.concat(WHITESPACE, "*"),
       regex.lookahead(/(?=\()/)
     ],
@@ -351,8 +352,8 @@ export default function(hljs) {
         {
           contains: [
             {
-              className: 'doctag',
-              begin: '@[A-Za-z]+'
+              scope: 'doctag',
+              match: '@[A-Za-z]+'
             }
           ]
         }
@@ -382,9 +383,9 @@ export default function(hljs) {
       {
         // swallow composed identifiers to avoid parsing them as keywords
         match: regex.concat(
-          /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,
-          regex.concat("(?!", WHITESPACE, "*\\()"),
-          /(?![a-zA-Z0-9_\x7f-\xff])/
+          /(::|->)+/,
+          IDENT_RE,
+          regex.concat("(?!", WHITESPACE, "*\\()")
         ),
         // scope:"wrong"
       },

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -12,10 +12,13 @@ Category: common
  * */
 export default function(hljs) {
   const regex = hljs.regex;
-  const IDENT_RE = '([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
+  const IDENT_RE_CORE = '[a-zA-Z0-9_\x7f-\xff]*' +
     // negative look-ahead tries to avoid matching patterns that are not
     // Perl at all like $ident$, @ident@, etc.
     '(?![A-Za-z0-9])(?![$]))';
+  const IDENT_RE = regex.concat("([a-zA-Z_\\x7f-\\xff]", IDENT_RE_CORE);
+  // Will not detect camelCase classes
+  const PASCAL_CASE_CLASS_NAME_RE = regex.concat("([A-Z]", IDENT_RE_CORE);
   const VARIABLE = {
     scope: 'variable',
     match: '\\$+' + IDENT_RE,
@@ -47,7 +50,7 @@ export default function(hljs) {
     end: /[ \t]*(\w+)\b/,
     contains: hljs.QUOTE_STRING_MODE.contains.concat(SUBST),
   });
-  // list of valid whitespaces because non-breaking space might be part of a name
+  // list of valid whitespaces because non-breaking space might be part of a IDENT_RE
   const WHITESPACE = '[ \t\n]';
   const STRING = {
     scope: 'string',
@@ -314,7 +317,7 @@ export default function(hljs) {
           regex.concat(WHITESPACE, "+"),
           // to prevent built ins from being confused as the class constructor call
           regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-          regex.concat("\\\\?", IDENT_RE, "+"),
+          regex.concat("\\\\?", IDENT_RE),
           regex.concat(WHITESPACE, "*\\("),
         ],
         scope: {
@@ -331,13 +334,64 @@ export default function(hljs) {
       /\b/,
       // to prevent keywords from being confused as the function title
       regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-      regex.concat(IDENT_RE, "+"),
+      IDENT_RE,
       regex.concat(WHITESPACE, "*"),
       regex.lookahead(/(?=\()/)
     ],
     scope: {
       3: "title.function.invoke",
     }
+  };
+
+  const CONSTANT_REFERENCE = regex.concat(IDENT_RE, "\\b(?!\\()");
+
+  const LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON = {
+    variants: [
+      {
+        match: [
+          regex.concat(
+            /::/,
+            regex.lookahead(/(?!class\b)/)
+          ),
+          CONSTANT_REFERENCE,
+        ],
+        scope: {
+          2: "variable.constant",
+        },
+      },
+      {
+        match: [
+          /::/,
+          /class/,
+        ],
+        scope: {
+          2: "variable.language",
+        },
+      },
+      {
+        match: [
+          PASCAL_CASE_CLASS_NAME_RE,
+          regex.concat(
+            "::",
+            regex.lookahead(/(?!class\b)/)
+          ),
+        ],
+        scope: {
+          1: "title.class",
+        },
+      },
+      {
+        match: [
+          PASCAL_CASE_CLASS_NAME_RE,
+          /::/,
+          /class/,
+        ],
+        scope: {
+          1: "title.class",
+          3: "variable.language",
+        },
+      }
+    ]
   };
 
   return {
@@ -380,16 +434,17 @@ export default function(hljs) {
       },
       VARIABLE,
       FUNCTION_INVOKE,
+      LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
       {
         match: [
           /const/,
-          regex.concat(WHITESPACE, "+"),
+          /\s/,
           IDENT_RE,
-          regex.concat(WHITESPACE, "*="),
+          /\s*=/,
         ],
         scope: {
           1: "keyword",
-          3: "variable",
+          3: "variable.constant",
         },
       },
       {
@@ -425,6 +480,7 @@ export default function(hljs) {
             contains: [
               'self',
               VARIABLE,
+              LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
               hljs.C_BLOCK_COMMENT_MODE,
               STRING,
               NUMBER

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -450,7 +450,7 @@ export default function(hljs) {
       {
         // swallow composed identifiers to avoid parsing them as keywords
         match: regex.concat(
-          /(::|->)+/,
+          /->+/,
           IDENT_RE,
           regex.concat("(?!", WHITESPACE, "*\\()")
         ),

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -381,6 +381,18 @@ export default function(hljs) {
       VARIABLE,
       FUNCTION_INVOKE,
       {
+        match: [
+          /const/,
+          regex.concat(WHITESPACE, "+"),
+          IDENT_RE,
+          regex.concat(WHITESPACE, "*="),
+        ],
+        scope: {
+          1: "keyword",
+          3: "variable",
+        },
+      },
+      {
         // swallow composed identifiers to avoid parsing them as keywords
         match: regex.concat(
           /(::|->)+/,

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -13,7 +13,7 @@
 <span class="hljs-variable">$date</span> = <span class="hljs-keyword">new</span> <span class="hljs-title class_">DateTimeImmutable</span> ();
 <span class="hljs-variable">$date</span>-&gt;<span class="hljs-title function_ invoke__">format</span>(<span class="hljs-string">&#x27;Y-m-d&#x27;</span>);
 
-DateTimeImmutable::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>(<span class="hljs-string">&#x27;now&#x27;</span>));
+<span class="hljs-title class_">DateTimeImmutable</span>::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>(<span class="hljs-string">&#x27;now&#x27;</span>));
 
 <span class="hljs-title function_ invoke__">str_contains</span> (\<span class="hljs-title function_ invoke__">strtoupper</span>(<span class="hljs-title function_ invoke__">substr</span>(<span class="hljs-string">&#x27;abcdef&#x27;</span>, -<span class="hljs-number">2</span>), <span class="hljs-string">&#x27;f&#x27;</span>));
 

--- a/test/markup/php/titles.expect.txt
+++ b/test/markup/php/titles.expect.txt
@@ -1,8 +1,8 @@
-<span class="hljs-keyword">final</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Example</span> </span>{
-    <span class="hljs-keyword">const</span> <span class="hljs-variable">FOO</span>=<span class="hljs-string">&#x27;foo&#x27;</span>;
+<span class="hljs-keyword">final</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Example</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Foo</span> </span>{
+    <span class="hljs-keyword">const</span> <span class="hljs-variable constant_">FOO</span>=<span class="hljs-string">&#x27;foo&#x27;</span>;
 
     <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">__construct</span>(<span class="hljs-params">
-        <span class="hljs-keyword">public</span> <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">string</span> <span class="hljs-variable">$name</span> = <span class="hljs-built_in">self</span>::<span class="hljs-variable">FOO</span>
+        <span class="hljs-keyword">public</span> <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">string</span> <span class="hljs-variable">$name</span> = <span class="hljs-built_in">self</span>::<span class="hljs-variable constant_">FOO</span>
     </span>) </span>{}
 
     <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getClass</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
@@ -16,7 +16,11 @@
     <span class="hljs-keyword">public</span> <span class="hljs-built_in">static</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getClassFromStatic</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
         <span class="hljs-keyword">return</span> <span class="hljs-built_in">static</span>::<span class="hljs-variable language_">class</span>;
     }
+
+    <span class="hljs-keyword">public</span> <span class="hljs-built_in">static</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getParentClass</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">parent</span>::<span class="hljs-variable language_">class</span>;
+    }
 }
 
-<span class="hljs-variable">$date</span> = DateTimeImmutable::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>());
+<span class="hljs-variable">$date</span> = <span class="hljs-title class_">DateTimeImmutable</span>::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>());
 <span class="hljs-keyword">echo</span> <span class="hljs-variable">$date</span>::<span class="hljs-variable language_">class</span>;

--- a/test/markup/php/titles.expect.txt
+++ b/test/markup/php/titles.expect.txt
@@ -1,0 +1,22 @@
+<span class="hljs-keyword">final</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Example</span> </span>{
+    <span class="hljs-keyword">const</span> <span class="hljs-variable">FOO</span>=<span class="hljs-string">&#x27;foo&#x27;</span>;
+
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">__construct</span>(<span class="hljs-params">
+        <span class="hljs-keyword">public</span> <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">string</span> <span class="hljs-variable">$name</span> = <span class="hljs-built_in">self</span>::<span class="hljs-variable">FOO</span>
+    </span>) </span>{}
+
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getClass</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-title class_">DateTimeImmutable</span>::<span class="hljs-variable language_">class</span>;
+    }
+
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getClassFromSelf</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">self</span>::<span class="hljs-variable language_">class</span>;
+    }
+
+    <span class="hljs-keyword">public</span> <span class="hljs-built_in">static</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getClassFromStatic</span>(<span class="hljs-params"></span>): <span class="hljs-title">string</span> </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">static</span>::<span class="hljs-variable language_">class</span>;
+    }
+}
+
+<span class="hljs-variable">$date</span> = DateTimeImmutable::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>());
+<span class="hljs-keyword">echo</span> <span class="hljs-variable">$date</span>::<span class="hljs-variable language_">class</span>;

--- a/test/markup/php/titles.txt
+++ b/test/markup/php/titles.txt
@@ -1,4 +1,4 @@
-final class Example {
+final class Example extends Foo {
     const FOO='foo';
 
     public function __construct(
@@ -15,6 +15,10 @@ final class Example {
 
     public static function getClassFromStatic(): string {
         return static::class;
+    }
+
+    public static function getParentClass(): string {
+        return parent::class;
     }
 }
 

--- a/test/markup/php/titles.txt
+++ b/test/markup/php/titles.txt
@@ -1,0 +1,22 @@
+final class Example {
+    const FOO='foo';
+
+    public function __construct(
+        public readonly string $name = self::FOO
+    ) {}
+
+    public function getClass(): string {
+        return DateTimeImmutable::class;
+    }
+
+    public function getClassFromSelf(): string {
+        return self::class;
+    }
+
+    public static function getClassFromStatic(): string {
+        return static::class;
+    }
+}
+
+$date = DateTimeImmutable::createFromMutable(new \DateTime());
+echo $date::class;


### PR DESCRIPTION
Double colon aka [Scope Resolution Operator](https://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php) is used in a few contexts:
- access static variable or method of the class: `Example::$uuid;  self::$a;  Example::test();  $a::test();` 
- constant reference: `Foo::Test;`
- access overridden properties or methods of a class: `parent::$a;  parent::__construct();`
- enum value reference: `Foo::Test;`
- class name reference: `self::class;  static::class;  parent::class;  Foo::class; $a::class`


### Changes
- declare and use `IDENT_RE` for valid labels instead of `w+`
- declaration of PHP [constants](https://www.php.net/manual/en/language.oop5.constants.php) were not highlighted. Now they use the same class as variables. 
- enum and constant reference were not highlighted. Now they use the same class as variables. 
- Class name references are highlighted as `variable.language`.
[class](https://wiki.php.net/rfc/class_name_literal_on_object) is a special case of the constant, it's also a reserved keyword.
- left-side class name highlighting

Info about rules for valid labels ([variables](https://www.php.net/manual/en/language.variables.basics.php), [constants](https://www.php.net/manual/en/language.constants.php), and other names).

> The name of a constant follows the same rules as any label in PHP. A valid constant name starts with a letter or underscore, followed by any number of letters, numbers, or underscores. As a regular expression, it would be expressed thusly: ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`

