### PR TITLE
enh(php) Switch highlighter to partially case-insensitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
+- enh(php) support First-class Callable Syntax (#3427) [Wojciech Kania][]
 - enh(php) support class constructor call (#3427) [Wojciech Kania][]
 - enh(php) support function invoke (#3427) [Wojciech Kania][]
 - enh(php) Switch highlighter to partially case-insensitive (#3427) [Wojciech Kania][]
@@ -49,6 +50,7 @@ Themes:
 
 - Modified background color in css for Gradient Light and Gradient Dark themes [Samia Ali][]
 
+[Wojciech Kania]: https://github.com/wkania
 [Jeylani B]: https://github.com/jeyllani
 [Richard Gibson]: https://github.com/gibson042
 [Bradley Mackey]: https://github.com/bradleymackey

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
+- enh(php) support class constructor call (#3427) [Wojciech Kania][]
+- enh(php) support function invoke (#3427) [Wojciech Kania][]
+- enh(php) Switch highlighter to partially case-insensitive (#3427) [Wojciech Kania][]
 - enh(php) improve `namespace` and `use` highlighting (#3427) [Josh Goebel][]
 - enh(php) `$this` is a `variable.language` now (#3427) [Josh Goebel][]
 - enh(php) add `__COMPILER_HALT_OFFSET__` (#3427) [Josh Goebel][]

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -70,6 +70,8 @@ in mind so a better choice (for best theme support) might possibly be ``string``
 +--------------------------+-------------------------------------------------------------+
 | title.function           | name of a function                                          |
 +--------------------------+-------------------------------------------------------------+
+| title.function.invoke    | name of a function (when being invoked)                     |
++--------------------------+-------------------------------------------------------------+
 | params                   | block of function arguments (parameters) at the             |
 |                          | place of declaration                                        |
 +--------------------------+-------------------------------------------------------------+

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -303,11 +303,11 @@ export default function(hljs) {
       {
         match: [
           /new/,
-          /\s+/,
+          / +/,
           // to prevent built ins from being confused as the class constructor call
           regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
           /\\?\w+/,
-          /\s*\(/,
+          / *\(/,
         ],
         scope: {
           1: "keyword",
@@ -320,11 +320,11 @@ export default function(hljs) {
   const FUNCTION_INVOKE = {
     relevance: 0,
     match: [
-      /(?:->|::|\s|\(|\\)/,
+      /\b/,
       // to prevent keywords from being confused as the function title
       regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
       /\w+/,
-      /\s*/,
+      / */,
       regex.lookahead(/(?=\()/)
     ],
     scope: {
@@ -374,7 +374,8 @@ export default function(hljs) {
       FUNCTION_INVOKE,
       {
         // swallow composed identifiers to avoid parsing them as keywords
-        begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/
+        begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?! *\()(?![a-zA-Z0-9_\x7f-\xff])/,
+        // scope:"wrong"
       },
       CONSTRUCTOR_CALL,
       {

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -288,11 +288,31 @@ export default function(hljs) {
     built_in: BUILT_INS.concat([ "Error|0" ]),
   };
 
+  const CONSTRUCTOR_CALL = {
+    variants: [
+      {
+        match: [
+          /new/,
+          /\s+/,
+          // to prevent built ins from being confused as the class constructor call
+          regex.concat("(?!", BUILT_INS.join("\\b|"), "\\b)"),
+          /\\?\w+/,
+          /\s*\(/,
+        ],
+        scope: {
+          1: "keyword",
+          4: "title.class",
+        },
+      }
+    ]
+  };
+
   const FUNCTION_INVOKE = {
     relevance: 0,
     match: [
       /(?:->|::|\s|\(|\\)/,
-      regex.concat("(?!fn\\b|function\\b|match\\b|", KWS.join("\\b|"), "|", BUILT_INS.join("\\b|"), "\\b)"),
+      // to prevent keywords from being confused as the function title
+      regex.concat("(?!fn\\b|function\\b|match\\b|Error\\b|", KWS.join("\\b|"), "|", BUILT_INS.join("\\b|"), "\\b)"),
       /\w+/,
       /\s*/,
       regex.lookahead(/(?=\()/)
@@ -301,6 +321,7 @@ export default function(hljs) {
       3: "function.title.invoke",
     }
   };
+
   return {
     case_insensitive: false,
     keywords: KEYWORDS,
@@ -343,12 +364,9 @@ export default function(hljs) {
       FUNCTION_INVOKE,
       {
         // swallow composed identifiers to avoid parsing them as keywords
-        begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?!\()/
+        begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/
       },
-      {
-        // swallow create object
-        begin: /new\s\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\s?\(/
-      },
+      CONSTRUCTOR_CALL,
       {
         className: 'function',
         relevance: 0,

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -46,6 +46,8 @@ export default function(hljs) {
     end: /[ \t]*(\w+)\b/,
     contains: hljs.QUOTE_STRING_MODE.contains.concat(SUBST),
   });
+  // list of valid whitespaces because non-breaking space might be part of a name
+  const WHITESPACE = '[ \t\n]';
   const STRING = {
     className: 'string',
     variants: [
@@ -303,11 +305,11 @@ export default function(hljs) {
       {
         match: [
           /new/,
-          / +/,
+          regex.concat(WHITESPACE, "+"),
           // to prevent built ins from being confused as the class constructor call
           regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
           /\\?\w+/,
-          / *\(/,
+          regex.concat(WHITESPACE, "*\\("),
         ],
         scope: {
           1: "keyword",
@@ -324,7 +326,7 @@ export default function(hljs) {
       // to prevent keywords from being confused as the function title
       regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
       /\w+/,
-      / */,
+      regex.concat(WHITESPACE, "*"),
       regex.lookahead(/(?=\()/)
     ],
     scope: {
@@ -374,7 +376,11 @@ export default function(hljs) {
       FUNCTION_INVOKE,
       {
         // swallow composed identifiers to avoid parsing them as keywords
-        begin: /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?! *\()(?![a-zA-Z0-9_\x7f-\xff])/,
+        match: regex.concat(
+          /(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,
+          regex.concat("(?!", WHITESPACE, "*\\()"),
+          /(?![a-zA-Z0-9_\x7f-\xff])/
+        ),
         // scope:"wrong"
       },
       CONSTRUCTOR_CALL,

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -56,11 +56,11 @@ export default function(hljs) {
   const NUMBER = {
     className: 'number',
     variants: [
-      { begin: `\\b0b[01]+(?:_[01]+)*\\b` }, // Binary w/ underscore support
-      { begin: `\\b0o[0-7]+(?:_[0-7]+)*\\b` }, // Octals w/ underscore support
-      { begin: `\\b0x[\\da-f]+(?:_[\\da-f]+)*\\b` }, // Hex w/ underscore support
+      { begin: `\\b0[bB][01]+(?:_[01]+)*\\b` }, // Binary w/ underscore support
+      { begin: `\\b0[oO][0-7]+(?:_[0-7]+)*\\b` }, // Octals w/ underscore support
+      { begin: `\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b` }, // Hex w/ underscore support
       // Decimals w/ underscore support, with optional fragments and scientific exponent (e) suffix.
-      { begin: `(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:e[+-]?\\d+)?` }
+      { begin: `(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?` }
     ],
     relevance: 0
   };
@@ -269,7 +269,7 @@ export default function(hljs) {
     built_in: BUILT_INS
   };
   return {
-    case_insensitive: true,
+    case_insensitive: false,
     keywords: KEYWORDS,
     contains: [
       hljs.HASH_COMMENT_MODE,

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -330,7 +330,7 @@ export default function(hljs) {
       regex.lookahead(/(?=\()/)
     ],
     scope: {
-      3: "function.title.invoke",
+      3: "title.function.invoke",
     }
   };
 

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -146,6 +146,7 @@ export default function(hljs) {
     "isset",
     "iterable",
     "list",
+    "match|0",
     "mixed",
     "new",
     "object",
@@ -172,6 +173,7 @@ export default function(hljs) {
   const BUILT_INS = [
     // Standard PHP library:
     // <https://www.php.net/manual/en/book.spl.php>
+    "Error|0",
     "AppendIterator",
     "ArgumentCountError",
     "ArithmeticError",
@@ -283,9 +285,17 @@ export default function(hljs) {
   };
 
   const KEYWORDS = {
-    keyword: KWS.concat([ "match|0" ]),
+    keyword: KWS,
     literal: dualCase(LITERALS),
-    built_in: BUILT_INS.concat([ "Error|0" ]),
+    built_in: BUILT_INS,
+  };
+
+  /**
+   * @param {string[]} items */
+  const normalizeKeywords = (items) => {
+    return items.map(item => {
+      return item.replace(/\|\d+$/, "");
+    });
   };
 
   const CONSTRUCTOR_CALL = {
@@ -295,7 +305,7 @@ export default function(hljs) {
           /new/,
           /\s+/,
           // to prevent built ins from being confused as the class constructor call
-          regex.concat("(?!", BUILT_INS.join("\\b|"), "\\b)"),
+          regex.concat("(?!", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
           /\\?\w+/,
           /\s*\(/,
         ],
@@ -312,7 +322,7 @@ export default function(hljs) {
     match: [
       /(?:->|::|\s|\(|\\)/,
       // to prevent keywords from being confused as the function title
-      regex.concat("(?!fn\\b|function\\b|match\\b|Error\\b|", KWS.join("\\b|"), "|", BUILT_INS.join("\\b|"), "\\b)"),
+      regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
       /\w+/,
       /\s*/,
       regex.lookahead(/(?=\()/)

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -263,9 +263,30 @@ export default function(hljs) {
     "stdClass"
   ];
 
+  /** Dual-case keywords
+   *
+   * ["then","FILE"] =>
+   *     ["then", "THEN", "FILE", "file"]
+   *
+   * @param {string[]} items */
+  const dualCase = (items) => {
+    /** @type string[] */
+    const result = [];
+    items.forEach(item => {
+      if (item.toLowerCase() === item) {
+        result.push(item);
+        result.push(item.toUpperCase());
+      } else {
+        result.push(item);
+        result.push(item.toLowerCase());
+      }
+    });
+    return result;
+  };
+
   const KEYWORDS = {
     keyword: KWS,
-    literal: LITERALS,
+    literal: dualCase(LITERALS),
     built_in: BUILT_INS
   };
   return {

--- a/test/markup/php/case.expect.txt
+++ b/test/markup/php/case.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-variable">$test</span> = <span class="hljs-literal">true</span>
+<span class="hljs-variable">$test</span> = <span class="hljs-literal">TRUE</span>
+
+<span class="hljs-variable">$a</span> = <span class="hljs-literal">false</span>
+<span class="hljs-variable">$a</span> = <span class="hljs-literal">FALSE</span>
+
+<span class="hljs-variable">$b</span> = <span class="hljs-literal">null</span>
+<span class="hljs-variable">$b</span> = <span class="hljs-literal">NULL</span>

--- a/test/markup/php/case.txt
+++ b/test/markup/php/case.txt
@@ -1,0 +1,8 @@
+$test = true
+$test = TRUE
+
+$a = false
+$a = FALSE
+
+$b = null
+$b = NULL

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -35,3 +35,9 @@ DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable
             <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-title class_">\Exception</span>(<span class="hljs-string">&#x27;error&#x27;</span>);
     }
 }
+
+<span class="hljs-comment">/**
+ * First-class Callable Syntax
+ */</span>
+<span class="hljs-variable">$fun</span> = <span class="hljs-function title_ invoke__">mb_strlen</span>();
+<span class="hljs-variable">$fun</span>();

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -11,11 +11,11 @@
  * Function invoke
  */</span>
 <span class="hljs-variable">$date</span> = <span class="hljs-keyword">new</span> <span class="hljs-title class_">DateTimeImmutable</span> ();
-<span class="hljs-variable">$date</span>-&gt;<span class="hljs-function title_ invoke__">format</span>(<span class="hljs-string">&#x27;Y-m-d&#x27;</span>);
+<span class="hljs-variable">$date</span>-&gt;<span class="hljs-title function_ invoke__">format</span>(<span class="hljs-string">&#x27;Y-m-d&#x27;</span>);
 
-DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>(<span class="hljs-string">&#x27;now&#x27;</span>));
+DateTimeImmutable::<span class="hljs-title function_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>(<span class="hljs-string">&#x27;now&#x27;</span>));
 
-<span class="hljs-function title_ invoke__">str_contains</span> (\<span class="hljs-function title_ invoke__">strtoupper</span>(<span class="hljs-function title_ invoke__">substr</span>(<span class="hljs-string">&#x27;abcdef&#x27;</span>, -<span class="hljs-number">2</span>), <span class="hljs-string">&#x27;f&#x27;</span>));
+<span class="hljs-title function_ invoke__">str_contains</span> (\<span class="hljs-title function_ invoke__">strtoupper</span>(<span class="hljs-title function_ invoke__">substr</span>(<span class="hljs-string">&#x27;abcdef&#x27;</span>, -<span class="hljs-number">2</span>), <span class="hljs-string">&#x27;f&#x27;</span>));
 
 <span class="hljs-comment">/**
  * Function declaration
@@ -39,5 +39,5 @@ DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable
 <span class="hljs-comment">/**
  * First-class Callable Syntax
  */</span>
-<span class="hljs-variable">$fun</span> = <span class="hljs-function title_ invoke__">mb_strlen</span>();
+<span class="hljs-variable">$fun</span> = <span class="hljs-title function_ invoke__">mb_strlen</span>();
 <span class="hljs-variable">$fun</span>();

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -6,3 +6,13 @@
 <span class="hljs-variable">$fn2</span> = <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"><span class="hljs-variable">$x</span></span>) <span class="hljs-keyword">use</span> (<span class="hljs-params"><span class="hljs-variable">$y</span></span>) </span>{
     <span class="hljs-keyword">return</span> <span class="hljs-variable">$x</span> + <span class="hljs-variable">$y</span>;
 };
+
+<span class="hljs-comment">/**
+ * Function invoke
+ */</span>
+<span class="hljs-variable">$date</span> = new DateTimeImmutable ();
+<span class="hljs-variable">$date</span>-&gt;<span class="hljs-function title_ invoke__">format</span>(<span class="hljs-string">&#x27;Y-m-d&#x27;</span>);
+
+DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable</span>(new \DateTime());
+
+<span class="hljs-function title_ invoke__">str_contains</span> (\<span class="hljs-function title_ invoke__">strtoupper</span>(<span class="hljs-function title_ invoke__">substr</span>(<span class="hljs-string">&#x27;abcdef&#x27;</span>, -<span class="hljs-number">2</span>), <span class="hljs-string">&#x27;f&#x27;</span>));

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -10,9 +10,28 @@
 <span class="hljs-comment">/**
  * Function invoke
  */</span>
-<span class="hljs-variable">$date</span> = new DateTimeImmutable ();
+<span class="hljs-variable">$date</span> = <span class="hljs-keyword">new</span> <span class="hljs-title class_">DateTimeImmutable</span> ();
 <span class="hljs-variable">$date</span>-&gt;<span class="hljs-function title_ invoke__">format</span>(<span class="hljs-string">&#x27;Y-m-d&#x27;</span>);
 
-DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable</span>(new \DateTime());
+DateTimeImmutable::<span class="hljs-function title_ invoke__">createFromMutable</span>(<span class="hljs-keyword">new</span> <span class="hljs-title class_">\DateTime</span>(<span class="hljs-string">&#x27;now&#x27;</span>));
 
 <span class="hljs-function title_ invoke__">str_contains</span> (\<span class="hljs-function title_ invoke__">strtoupper</span>(<span class="hljs-function title_ invoke__">substr</span>(<span class="hljs-string">&#x27;abcdef&#x27;</span>, -<span class="hljs-number">2</span>), <span class="hljs-string">&#x27;f&#x27;</span>));
+
+<span class="hljs-comment">/**
+ * Function declaration
+ */</span>
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">testMe</span>(<span class="hljs-params"><span class="hljs-keyword">string</span>|<span class="hljs-keyword">int</span> <span class="hljs-variable">$name</span></span>): <span class="hljs-title">int</span>
+</span>{
+    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">empty</span>(<span class="hljs-variable">$name</span>)) {
+        <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;
+    } <span class="hljs-keyword">elseif</span> (<span class="hljs-variable">$name</span> === <span class="hljs-number">1</span>) {
+        <span class="hljs-keyword">return</span> (<span class="hljs-keyword">int</span>) <span class="hljs-variable">$name</span>;
+    }
+
+    <span class="hljs-keyword">switch</span>(<span class="hljs-variable">$name</span>) {
+        <span class="hljs-keyword">case</span> <span class="hljs-string">&#x27;2&#x27;</span>:
+            <span class="hljs-keyword">return</span> <span class="hljs-number">2</span>;
+        <span class="hljs-keyword">default</span>:
+            <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-title class_">\Exception</span>(<span class="hljs-string">&#x27;error&#x27;</span>);
+    }
+}

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -6,3 +6,13 @@ $fn1 = fn($x) => $x + $y;
 $fn2 = function ($x) use ($y) {
     return $x + $y;
 };
+
+/**
+ * Function invoke
+ */
+$date = new DateTimeImmutable ();
+$date->format('Y-m-d');
+
+DateTimeImmutable::createFromMutable(new \DateTime());
+
+str_contains (\strtoupper(substr('abcdef', -2), 'f'));

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -35,3 +35,9 @@ function testMe(string|int $name): int
             throw new \Exception('error');
     }
 }
+
+/**
+ * First-class Callable Syntax
+ */
+$fun = mb_strlen();
+$fun();

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -13,6 +13,25 @@ $fn2 = function ($x) use ($y) {
 $date = new DateTimeImmutable ();
 $date->format('Y-m-d');
 
-DateTimeImmutable::createFromMutable(new \DateTime());
+DateTimeImmutable::createFromMutable(new \DateTime('now'));
 
 str_contains (\strtoupper(substr('abcdef', -2), 'f'));
+
+/**
+ * Function declaration
+ */
+function testMe(string|int $name): int
+{
+    if (empty($name)) {
+        return 0;
+    } elseif ($name === 1) {
+        return (int) $name;
+    }
+
+    switch($name) {
+        case '2':
+            return 2;
+        default:
+            throw new \Exception('error');
+    }
+}

--- a/test/markup/php/strings.expect.txt
+++ b/test/markup/php/strings.expect.txt
@@ -12,12 +12,12 @@ MSG</span>);
 
 <span class="hljs-comment">// heredoc syntax</span>
 
-<span class="hljs-function title_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
+<span class="hljs-title function_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
     SELECT *
     FROM table
 SQL</span>);
 
-<span class="hljs-function title_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
+<span class="hljs-title function_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
     SELECT *
     FROM table
     SQL</span>);

--- a/test/markup/php/strings.expect.txt
+++ b/test/markup/php/strings.expect.txt
@@ -12,12 +12,12 @@ MSG</span>);
 
 <span class="hljs-comment">// heredoc syntax</span>
 
-var_dump(<span class="hljs-string">&lt;&lt;&lt;SQL
+<span class="hljs-function title_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
     SELECT *
     FROM table
 SQL</span>);
 
-var_dump(<span class="hljs-string">&lt;&lt;&lt;SQL
+<span class="hljs-function title_ invoke__">var_dump</span>(<span class="hljs-string">&lt;&lt;&lt;SQL
     SELECT *
     FROM table
     SQL</span>);


### PR DESCRIPTION
### Changes
After [discussion](https://github.com/highlightjs/highlight.js/pull/3422#discussion_r766006060) related to PHP partial case-insensitive .
- [x] Numbers ([case-insensitive](https://www.php.net/manual/en/language.types.integer.php))
- [x] Variables ([case-sensitive](https://www.php.net/manual/en/language.variables.basics.php))
- [x] class names (case-insensitive)
- [x] function names (case-insensitive)
- [x] keywords (both)

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
