### PR TITLE
enh(php) add PHP 8.1 keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
+- enh(php) add PHP 8.1 keywords [Wojciech Kania][]
 - enh(php) support First-class Callable Syntax (#3427) [Wojciech Kania][]
 - enh(php) support class constructor call (#3427) [Wojciech Kania][]
 - enh(php) support function invoke (#3427) [Wojciech Kania][]

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -151,11 +151,13 @@ export default function(hljs) {
     "match|0",
     "mixed",
     "new",
+    "never",
     "object",
     "or",
     "private",
     "protected",
     "public",
+    "readonly",
     "real",
     "return",
     "string",
@@ -245,7 +247,9 @@ export default function(hljs) {
     // Reserved interfaces:
     // <https://www.php.net/manual/en/reserved.interfaces.php>
     "ArrayAccess",
+    "BackedEnum",
     "Closure",
+    "Fiber",
     "Generator",
     "Iterator",
     "IteratorAggregate",
@@ -253,6 +257,7 @@ export default function(hljs) {
     "Stringable",
     "Throwable",
     "Traversable",
+    "UnitEnum",
     "WeakReference",
     "WeakMap",
     // Reserved classes:

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -13,14 +13,14 @@ Category: common
 export default function(hljs) {
   const regex = hljs.regex;
   const VARIABLE = {
-    className: 'variable',
-    begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
+    scope: 'variable',
+    match: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*' +
       // negative look-ahead tries to avoid matching patterns that are not
       // Perl at all like $ident$, @ident@, etc.
       `(?![A-Za-z0-9])(?![$])`
   };
   const PREPROCESSOR = {
-    className: 'meta',
+    scope: 'meta',
     variants: [
       { begin: /<\?php/, relevance: 10 }, // boost for obvious PHP
       { begin: /<\?[=]?/ },
@@ -28,7 +28,7 @@ export default function(hljs) {
     ]
   };
   const SUBST = {
-    className: 'subst',
+    scope: 'subst',
     variants: [
       { begin: /\$\w+/ },
       { begin: /\{\$/, end: /\}/ }
@@ -49,7 +49,7 @@ export default function(hljs) {
   // list of valid whitespaces because non-breaking space might be part of a name
   const WHITESPACE = '[ \t\n]';
   const STRING = {
-    className: 'string',
+    scope: 'string',
     variants: [
       DOUBLE_QUOTED,
       SINGLE_QUOTED,
@@ -57,7 +57,7 @@ export default function(hljs) {
     ]
   };
   const NUMBER = {
-    className: 'number',
+    scope: 'number',
     variants: [
       { begin: `\\b0[bB][01]+(?:_[01]+)*\\b` }, // Binary w/ underscore support
       { begin: `\\b0[oO][0-7]+(?:_[0-7]+)*\\b` }, // Octals w/ underscore support
@@ -374,8 +374,8 @@ export default function(hljs) {
       },
       PREPROCESSOR,
       {
-        className: 'variable.language',
-        begin: /\$this\b/
+        scope: 'variable.language',
+        match: /\$this\b/
       },
       VARIABLE,
       FUNCTION_INVOKE,
@@ -390,7 +390,7 @@ export default function(hljs) {
       },
       CONSTRUCTOR_CALL,
       {
-        className: 'function',
+        scope: 'function',
         relevance: 0,
         beginKeywords: 'fn function', end: /[;{]/, excludeEnd: true,
         illegal: '[$%\\[]',
@@ -404,7 +404,7 @@ export default function(hljs) {
             endsParent: true
           },
           {
-            className: 'params',
+            scope: 'params',
             begin: '\\(', end: '\\)',
             excludeBegin: true,
             excludeEnd: true,
@@ -420,7 +420,7 @@ export default function(hljs) {
         ]
       },
       {
-        className: 'class',
+        scope: 'class',
         variants: [
           { beginKeywords: "enum", illegal: /[($"]/ },
           { beginKeywords: "class interface trait", illegal: /[:($"]/ }


### PR DESCRIPTION
Extracted from [PR](https://github.com/highlightjs/highlight.js/pull/3422).

### Changes
New keywords list:
[BackedEnum, Fiber, UnitEnum](https://www.php.net/manual/en/reserved.interfaces.php)
[readonly](https://www.php.net/releases/8.1/en.php#readonly_properties)
[never](https://www.php.net/releases/8.1/en.php#never_return_type)


### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`

@joshgoebel pls review
