### PR TITLE
 (Typescript) highlight obvious user defined type names (interface, etc) #3269 

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -45,16 +45,12 @@ export default function(hljs) {
       1: "keyword",
       3: "title"
     },
-    end: /\{/,
     end: /\{|\s/,
     excludeEnd: true,
     keywords: {
       keyword: 'interface extends',
       built_in: TYPES
-    },
-    contains: [
-      tsLanguage.exports.CLASS_REFERENCE
-    ]
+    }
   };
 
   const USE_STRICT = {

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -15,6 +15,7 @@ export default function(hljs) {
   const tsLanguage = javascript(hljs);
 
   const IDENT_RE = ECMAScript.IDENT_RE;
+  const IDENT_GEN = /[a-zA-Z]\w*/;
   const TYPES = [
     "any",
     "void",
@@ -33,8 +34,17 @@ export default function(hljs) {
       tsLanguage.exports.CLASS_REFERENCE
     ]
   };
+
   const INTERFACE = {
-    beginKeywords: 'interface',
+    begin: [
+      /interface/,
+      /\s+/,
+      IDENT_GEN
+    ],
+    beginScope: {
+      1: "keyword",
+      3: "title"
+    },
     end: /\{/,
     excludeEnd: true,
     keywords: {
@@ -45,6 +55,7 @@ export default function(hljs) {
       tsLanguage.exports.CLASS_REFERENCE
     ]
   };
+
   const USE_STRICT = {
     className: 'meta',
     relevance: 10,
@@ -74,6 +85,7 @@ export default function(hljs) {
     className: 'meta',
     begin: '@' + IDENT_RE,
   };
+
 
   const swapMode = (mode, label, replacement) => {
     const indx = mode.contains.findIndex(m => m.label === label);

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -36,20 +36,49 @@ export default function(hljs) {
   };
 
   const INTERFACE = {
-    match: [
-      /interface/,
-      /\s+/,
-      IDENT_GEN
+    variants: [
+      {
+        match: [
+          /interface/,
+          /\s+/,
+          IDENT_GEN,
+          /\s+/,
+          /extends/,
+          /\s+/,
+          IDENT_GEN
+        ]
+      },
+      {
+        match: [
+          /interface/,
+          /\s+/,
+          IDENT_GEN
+        ]
+      }
     ],
     scope: {
       1: "keyword",
-      3: "title"
+      3: "title",
+      5: "keyword",
+      7: "title"
     },
     keywords: {
       keyword: 'interface extends',
       built_in: TYPES
     }
   };
+
+  const IMPORT = {
+    begin: [
+      /import/,
+      /s+/,
+      IDENT_GEN
+    ],
+    beginScope: {
+      1: "keyword",
+      3: "title"
+    }
+  }
 
   const USE_STRICT = {
     className: 'meta',

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -36,17 +36,15 @@ export default function(hljs) {
   };
 
   const INTERFACE = {
-    begin: [
+    match: [
       /interface/,
       /\s+/,
       IDENT_GEN
     ],
-    beginScope: {
+    scope: {
       1: "keyword",
       3: "title"
     },
-    end: /\{|\s/,
-    excludeEnd: true,
     keywords: {
       keyword: 'interface extends',
       built_in: TYPES

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -46,6 +46,7 @@ export default function(hljs) {
       3: "title"
     },
     end: /\{/,
+    end: /\{|\s/,
     excludeEnd: true,
     keywords: {
       keyword: 'interface extends',

--- a/test/markup/typescript/interface.expect.txt
+++ b/test/markup/typescript/interface.expect.txt
@@ -1,0 +1,17 @@
+<span class="hljs-keyword">interface</span> <span class="hljs-title">myInterface</span> {
+  <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>;
+}
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title">lowercase</span> {
+  <span class="hljs-attr">isLowercase</span>: <span class="hljs-built_in">boolean</span>;
+}
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title">thisInterface</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">OtherName</span> {
+  <span class="hljs-attr">length</span>: <span class="hljs-built_in">number</span>;
+  <span class="hljs-attr">width</span>: <span class="hljs-built_in">number</span>;
+}
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title">newline</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">ALLCAPS</span>
+{
+  <span class="hljs-attr">isSpace</span>: <span class="hljs-built_in">boolean</span>;
+}

--- a/test/markup/typescript/interface.txt
+++ b/test/markup/typescript/interface.txt
@@ -1,0 +1,17 @@
+interface myInterface {
+  name: string;
+}
+
+interface lowercase {
+  isLowercase: boolean;
+}
+
+interface thisInterface extends OtherName {
+  length: number;
+  width: number;
+}
+
+interface newline extends ALLCAPS
+{
+  isSpace: boolean;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #3269`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Starting an implementation for recognizing user-defined titles and type names for Typescript interfaces. Typescript.js should recognize any valid identifier (previously worked based solely on the assumption identifier was in camelcase) and highlight it as a "title." 


### Checklist
- [x] Implemented for interface identifiers
- [ ] Implemented for other user-defined types
- [x] Added markup tests
- [ ] Updated the changelog at `CHANGES.md`
