### PR TITLE
Add graphql to supported languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ New Language:
 
 - Added 3rd party Pine Script grammar to SUPPORTED_LANGUAGES [Jeylani B][]
 - Added 3rd party cURL grammar to SUPPORTED_LANGUAGES [highlightjs-curl](https://github.com/highlightjs/highlightjs-curl)
-- Added 3rd party GraphQL grammar to SUPPORTED_LANGUAGES [highlightjs-graphql][https://github.com/jf990/highlightjs-graphql]
+- Added GraphQL to SUPPORTED_LANGUAGES [jf990][]
 
 Themes:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ New Language:
 
 - Added 3rd party Pine Script grammar to SUPPORTED_LANGUAGES [Jeylani B][]
 - Added 3rd party cURL grammar to SUPPORTED_LANGUAGES [highlightjs-curl](https://github.com/highlightjs/highlightjs-curl)
+- Added 3rd party GraphQL grammar to SUPPORTED_LANGUAGES [highlightjs-graphql][https://github.com/jf990/highlightjs-graphql]
 
 Themes:
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -87,6 +87,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Grammatical Framework   | gf                     | [highlightjs-gf](https://github.com/johnjcamilleri/highlightjs-gf) |
 | Golo                    | golo, gololang         |         |
 | Gradle                  | gradle                 |         |
+| GraphQL                 | graphql                | [highlightjs-graphql](https://github.com/jf990/highlightjs-graphql) |
 | Groovy                  | groovy                 |         |
 | GSQL                    | gsql                   | [highlightjs-gsql](https://github.com/DanBarkus/highlightjs-gsql) |
 | HTML, XML               | xml, html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg | |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -87,7 +87,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Grammatical Framework   | gf                     | [highlightjs-gf](https://github.com/johnjcamilleri/highlightjs-gf) |
 | Golo                    | golo, gololang         |         |
 | Gradle                  | gradle                 |         |
-| GraphQL                 | graphql                | [highlightjs-graphql](https://github.com/jf990/highlightjs-graphql) |
+| GraphQL                 | graphql                |         |
 | Groovy                  | groovy                 |         |
 | GSQL                    | gsql                   | [highlightjs-gsql](https://github.com/DanBarkus/highlightjs-gsql) |
 | HTML, XML               | xml, html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg | |

--- a/src/languages/graphql.js
+++ b/src/languages/graphql.js
@@ -1,0 +1,79 @@
+/*
+ Language: graphql
+ Category: scripting
+ Author:
+ Description: Highlight GraphQL queries with highligh.js.
+*/
+/** @type LanguageFn */
+export default function(hljs) {
+  const GQL_NAME = '[_A-Za-z][_0-9A-Za-z]*';
+  const GQL_PUNCTUATION = '[\\!\\(\\)\\:\\=\\[\\]\\{\\|\\}]{1}';
+  return {
+    name: "graphql",
+    aliases: [ "gql" ],
+    case_insensitive: true,
+    disableAutodetect: false,
+    keywords: {
+      keyword: [
+        "query",
+        "mutation",
+        "subscription|10",
+        "type",
+        "input",
+        "schema",
+        "directive",
+        "interface",
+        "union",
+        "scalar",
+        "fragment|10",
+        "enum",
+        "on"
+      ],
+      literal: "true false null"
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      hljs.NUMBER_MODE,
+      {
+        className: "punctuation",
+        begin: "[.]{2}",
+        end: "\\.",
+        relevance: 0
+      },
+      {
+        className: "punctuation",
+        begin: GQL_PUNCTUATION,
+        relevance: 0
+      },
+      {
+        className: "variable",
+        begin: "\\$",
+        end: "\\W",
+        excludeEnd: true,
+        relevance: 0
+      },
+      {
+        className: "meta",
+        begin: "@",
+        end: "\\W",
+        excludeEnd: true
+      },
+      {
+        className: "symbol",
+        begin: GQL_NAME + '\\s*:',
+        returnBegin: true,
+        contains: [
+          {
+            className: 'symbol',
+            begin: GQL_NAME,
+            end: '\\s*:',
+            excludeEnd: true
+          }
+        ],
+        relevance: 0
+      }
+    ],
+    illegal: /([;<']|BEGIN)/
+  };
+}

--- a/test/detect/graphql/default.txt
+++ b/test/detect/graphql/default.txt
@@ -1,0 +1,51 @@
+type Project {
+  name: String
+  tagline: String
+  contributors: [User]
+}
+
+# Example mutation
+
+mutation updateMyUrbanEvent($studyArea: PolygonInput!, $myDescription: String!) {
+  updateProjects(
+    urbanDatabaseId: "9c3ba6c054f945acabd1256bcbcf8XXX"
+    projects: [{ attributes: { GlobalID: "078D217A-1764-4AA2-9D23-6FCDA01F0XXX", Description: $myDescription }, geometry: $studyArea }]
+  ) {
+    attributes {
+      GlobalID
+      CustomID
+      Description
+    }
+    geometry {
+      rings
+    }
+  }
+}
+
+# Example of a query:
+
+query HeroForEpisode($ep: Episode!) {
+  hero(episode: $ep) {
+    name
+    ... on Droid {
+      primaryFunction
+    }
+    ... on Human {
+      height
+    }
+  }
+}
+
+# Example fragment:
+
+fragment comparisonFields on Character {
+  name
+  friendsConnection(first: $first) {
+    totalCount
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}

--- a/test/markup/graphql/default.expect.txt
+++ b/test/markup/graphql/default.expect.txt
@@ -1,0 +1,51 @@
+<span class="hljs-keyword">type</span> Project <span class="hljs-punctuation">{</span>
+  <span class="hljs-symbol"><span class="hljs-symbol">name</span>:</span> String
+  <span class="hljs-symbol"><span class="hljs-symbol">tagline</span>:</span> String
+  <span class="hljs-symbol"><span class="hljs-symbol">contributors</span>:</span> <span class="hljs-punctuation">[</span>User<span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span>
+
+<span class="hljs-comment"># Example mutation</span>
+
+<span class="hljs-keyword">mutation</span> updateMyUrbanEvent<span class="hljs-punctuation">(</span><span class="hljs-variable">$studyArea</span>: PolygonInput<span class="hljs-punctuation">!</span>, <span class="hljs-variable">$myDescription</span>: String<span class="hljs-punctuation">!</span><span class="hljs-punctuation">)</span> <span class="hljs-punctuation">{</span>
+  updateProjects<span class="hljs-punctuation">(</span>
+    <span class="hljs-symbol"><span class="hljs-symbol">urbanDatabaseId</span>:</span> <span class="hljs-string">&quot;9c3ba6c054f945acabd1256bcbcf8XXX&quot;</span>
+    <span class="hljs-symbol"><span class="hljs-symbol">projects</span>:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span> <span class="hljs-symbol"><span class="hljs-symbol">attributes</span>:</span> <span class="hljs-punctuation">{</span> <span class="hljs-symbol"><span class="hljs-symbol">GlobalID</span>:</span> <span class="hljs-string">&quot;078D217A-1764-4AA2-9D23-6FCDA01F0XXX&quot;</span>, <span class="hljs-symbol"><span class="hljs-symbol">Description</span>:</span> <span class="hljs-variable">$myDescription</span> <span class="hljs-punctuation">}</span>, <span class="hljs-symbol"><span class="hljs-symbol">geometry</span>:</span> <span class="hljs-variable">$studyArea</span> <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span>
+  <span class="hljs-punctuation">)</span> <span class="hljs-punctuation">{</span>
+    attributes <span class="hljs-punctuation">{</span>
+      GlobalID
+      CustomID
+      Description
+    <span class="hljs-punctuation">}</span>
+    geometry <span class="hljs-punctuation">{</span>
+      rings
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+
+<span class="hljs-comment"># Example of a query:</span>
+
+<span class="hljs-keyword">query</span> HeroForEpisode<span class="hljs-punctuation">(</span><span class="hljs-variable">$ep</span>: Episode<span class="hljs-punctuation">!</span><span class="hljs-punctuation">)</span> <span class="hljs-punctuation">{</span>
+  hero<span class="hljs-punctuation">(</span><span class="hljs-symbol"><span class="hljs-symbol">episode</span>:</span> <span class="hljs-variable">$ep</span>) <span class="hljs-punctuation">{</span>
+    name
+    <span class="hljs-punctuation">...</span> <span class="hljs-keyword">on</span> Droid <span class="hljs-punctuation">{</span>
+      primaryFunction
+    <span class="hljs-punctuation">}</span>
+    <span class="hljs-punctuation">...</span> <span class="hljs-keyword">on</span> Human <span class="hljs-punctuation">{</span>
+      height
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>
+
+<span class="hljs-comment"># Example fragment:</span>
+
+<span class="hljs-keyword">fragment</span> comparisonFields <span class="hljs-keyword">on</span> Character <span class="hljs-punctuation">{</span>
+  name
+  friendsConnection<span class="hljs-punctuation">(</span><span class="hljs-symbol"><span class="hljs-symbol">first</span>:</span> <span class="hljs-variable">$first</span>) <span class="hljs-punctuation">{</span>
+    totalCount
+    edges <span class="hljs-punctuation">{</span>
+      node <span class="hljs-punctuation">{</span>
+        name
+      <span class="hljs-punctuation">}</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span>
+<span class="hljs-punctuation">}</span>

--- a/test/markup/graphql/default.txt
+++ b/test/markup/graphql/default.txt
@@ -1,0 +1,51 @@
+type Project {
+  name: String
+  tagline: String
+  contributors: [User]
+}
+
+# Example mutation
+
+mutation updateMyUrbanEvent($studyArea: PolygonInput!, $myDescription: String!) {
+  updateProjects(
+    urbanDatabaseId: "9c3ba6c054f945acabd1256bcbcf8XXX"
+    projects: [{ attributes: { GlobalID: "078D217A-1764-4AA2-9D23-6FCDA01F0XXX", Description: $myDescription }, geometry: $studyArea }]
+  ) {
+    attributes {
+      GlobalID
+      CustomID
+      Description
+    }
+    geometry {
+      rings
+    }
+  }
+}
+
+# Example of a query:
+
+query HeroForEpisode($ep: Episode!) {
+  hero(episode: $ep) {
+    name
+    ... on Droid {
+      primaryFunction
+    }
+    ... on Human {
+      height
+    }
+  }
+}
+
+# Example fragment:
+
+fragment comparisonFields on Character {
+  name
+  friendsConnection(first: $first) {
+    totalCount
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add graphql to supported languages

Related to v11 update https://github.com/jf990/highlightjs-graphql/pull/1

### Changes
Include graphql in SUPPORTED_LANGUAGES.md

### Checklist
- [x] Added markup tests, verified language detection didn't break
- [x] Updated the changelog at `CHANGES.md`
