### PR TITLE
enh(php) named arguments and fix php constants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 11.4.1
+
+Grammars:
+
+- enh(php) named arguments [Wojciech Kania][]
+- fix(php) PHP constants [Wojciech Kania][]
+
+[Wojciech Kania]: https://github.com/wkania
+
 ## Version 11.4.0
 
 New Language:
@@ -16,7 +25,6 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
-- enh(php) named arguments [Wojciech Kania][]
 - enh(arcade) updated to ArcGIS Arcade version 1.16 [John Foster][]
 - enh(php) Left and right-side of double colon [Wojciech Kania][]
 - enh(php) add PHP constants [Wojciech Kania][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ These changes should be for the better and should not be super noticeable but if
 
 Grammars:
 
+- enh(php) named arguments [Wojciech Kania][]
 - enh(arcade) updated to ArcGIS Arcade version 1.16 [John Foster][]
 - enh(php) Left and right-side of double colon [Wojciech Kania][]
 - enh(php) add PHP constants [Wojciech Kania][]

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -393,16 +393,17 @@ export default function(hljs) {
     ]
   };
 
+  const NAMED_ARGUMENT = {
+    scope: 'attr',
+    match: regex.concat(IDENT_RE, regex.lookahead(':'), regex.lookahead(/(?!::)/)),
+  };
   const PARAMS_MODE = {
     relevance: 0,
     begin: /\(/,
     end: /\)/,
     keywords: KEYWORDS,
     contains: [
-      {
-        scope: 'attr',
-        match: regex.concat(IDENT_RE, regex.lookahead(':'), regex.lookahead(/(?!::)/)),
-      },
+      NAMED_ARGUMENT,
       VARIABLE,
       LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
       hljs.C_BLOCK_COMMENT_MODE,

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -328,21 +328,6 @@ export default function(hljs) {
     ]
   };
 
-  const FUNCTION_INVOKE = {
-    relevance: 0,
-    match: [
-      /\b/,
-      // to prevent keywords from being confused as the function title
-      regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
-      IDENT_RE,
-      regex.concat(WHITESPACE, "*"),
-      regex.lookahead(/(?=\()/)
-    ],
-    scope: {
-      3: "title.function.invoke",
-    }
-  };
-
   const CONSTANT_REFERENCE = regex.concat(IDENT_RE, "\\b(?!\\()");
 
   const LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON = {
@@ -393,6 +378,42 @@ export default function(hljs) {
       }
     ]
   };
+
+  const FUNCTION_INVOKE = {
+    relevance: 0,
+    match: [
+      /\b/,
+      // to prevent keywords from being confused as the function title
+      regex.concat("(?!fn\\b|function\\b|", normalizeKeywords(KWS).join("\\b|"), "|", normalizeKeywords(BUILT_INS).join("\\b|"), "\\b)"),
+      IDENT_RE,
+      regex.concat(WHITESPACE, "*"),
+      regex.lookahead(/(?=\()/)
+    ],
+    scope: {
+      3: "title.function.invoke",
+    }
+  };
+  FUNCTION_INVOKE.contains = [
+    {
+      relevance: 0,
+      begin: /\(/,
+      end: /\)/,
+      keywords: KEYWORDS,
+      contains: [
+        {
+          scope: 'attr',
+          match: IDENT_RE + regex.lookahead(':') + regex.lookahead(/(?!::)/),
+        },
+        VARIABLE,
+        LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
+        hljs.C_BLOCK_COMMENT_MODE,
+        STRING,
+        NUMBER,
+        CONSTRUCTOR_CALL,
+        FUNCTION_INVOKE,
+      ],
+    },
+  ];
 
   return {
     case_insensitive: false,
@@ -476,7 +497,7 @@ export default function(hljs) {
               STRING,
               NUMBER
             ]
-          }
+          },
         ]
       },
       {
@@ -520,7 +541,7 @@ export default function(hljs) {
         ]
       },
       STRING,
-      NUMBER
+      NUMBER,
     ]
   };
 }

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -357,6 +357,20 @@ export default function(hljs) {
         match: [
           PASCAL_CASE_CLASS_NAME_RE,
           regex.concat(
+            /::/,
+            regex.lookahead(/(?!class\b)/)
+          ),
+          CONSTANT_REFERENCE,
+        ],
+        scope: {
+          1: "title.class",
+          3: "variable.constant",
+        },
+      },
+      {
+        match: [
+          PASCAL_CASE_CLASS_NAME_RE,
+          regex.concat(
             "::",
             regex.lookahead(/(?!class\b)/)
           ),
@@ -379,6 +393,24 @@ export default function(hljs) {
     ]
   };
 
+  const PARAMS_MODE = {
+    relevance: 0,
+    begin: /\(/,
+    end: /\)/,
+    keywords: KEYWORDS,
+    contains: [
+      {
+        scope: 'attr',
+        match: regex.concat(IDENT_RE, regex.lookahead(':'), regex.lookahead(/(?!::)/)),
+      },
+      VARIABLE,
+      LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
+      hljs.C_BLOCK_COMMENT_MODE,
+      STRING,
+      NUMBER,
+      CONSTRUCTOR_CALL,
+    ],
+  };
   const FUNCTION_INVOKE = {
     relevance: 0,
     match: [
@@ -391,29 +423,12 @@ export default function(hljs) {
     ],
     scope: {
       3: "title.function.invoke",
-    }
-  };
-  FUNCTION_INVOKE.contains = [
-    {
-      relevance: 0,
-      begin: /\(/,
-      end: /\)/,
-      keywords: KEYWORDS,
-      contains: [
-        {
-          scope: 'attr',
-          match: IDENT_RE + regex.lookahead(':') + regex.lookahead(/(?!::)/),
-        },
-        VARIABLE,
-        LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
-        hljs.C_BLOCK_COMMENT_MODE,
-        STRING,
-        NUMBER,
-        CONSTRUCTOR_CALL,
-        FUNCTION_INVOKE,
-      ],
     },
-  ];
+    contains: [
+      PARAMS_MODE
+    ]
+  };
+  PARAMS_MODE.contains.push(FUNCTION_INVOKE);
 
   return {
     case_insensitive: false,
@@ -461,7 +476,6 @@ export default function(hljs) {
           /const/,
           /\s/,
           IDENT_RE,
-          /\s*=/,
         ],
         scope: {
           1: "keyword",

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -41,3 +41,11 @@
  */</span>
 <span class="hljs-variable">$fun</span> = <span class="hljs-title function_ invoke__">mb_strlen</span>();
 <span class="hljs-variable">$fun</span>();
+
+<span class="hljs-comment">/**
+ * Named arguments
+ */</span>
+<span class="hljs-title function_ invoke__">setAlarm</span>(
+    <span class="hljs-attr">label</span>: <span class="hljs-string">&#x27;foo&#x27;</span>,
+    <span class="hljs-attr">time</span>:<span class="hljs-title function_ invoke__">time</span>() + <span class="hljs-keyword">array</span>(<span class="hljs-number">5</span>)[<span class="hljs-number">0</span>],
+);

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -47,5 +47,5 @@
  */</span>
 <span class="hljs-title function_ invoke__">setAlarm</span>(
     <span class="hljs-attr">label</span>: <span class="hljs-string">&#x27;foo&#x27;</span>,
-    <span class="hljs-attr">time</span>:<span class="hljs-title function_ invoke__">time</span>() + <span class="hljs-keyword">array</span>(<span class="hljs-number">5</span>)[<span class="hljs-number">0</span>],
+    <span class="hljs-attr">time</span>:<span class="hljs-title function_ invoke__">time</span>() + <span class="hljs-keyword">array</span>(<span class="hljs-number">5</span>)[<span class="hljs-number">0</span>] + <span class="hljs-title class_">Foo</span>::<span class="hljs-variable constant_">HOUR</span>,
 );

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -41,3 +41,11 @@ function testMe(string|int $name): int
  */
 $fun = mb_strlen();
 $fun();
+
+/**
+ * Named arguments
+ */
+setAlarm(
+    label: 'foo',
+    time:time() + array(5)[0],
+);

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -47,5 +47,5 @@ $fun();
  */
 setAlarm(
     label: 'foo',
-    time:time() + array(5)[0],
+    time:time() + array(5)[0] + Foo::HOUR,
 );


### PR DESCRIPTION
We have a new release so I added a new version.

### Changes
[Named Arguments](https://wiki.php.net/rfc/named_params)
There was no test for the most basic type of constant reference and it didn't work :(, so I fixed it.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
