### PR TITLE
Add highlighting support for evalfilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@ Grammars:
 - enh(php) named arguments [Wojciech Kania][]
 - fix(php) PHP constants [Wojciech Kania][]
 
+New Language:
+
+- Added evalfilter support [Steve Kemp][]
+
+[Steve Kemp]: https://github.com/skx
 [Wojciech Kania]: https://github.com/wkania
 
 ## Version 11.4.0

--- a/src/languages/evalfilter.js
+++ b/src/languages/evalfilter.js
@@ -1,0 +1,33 @@
+/*
+  Language: evalfilter
+  Description: evalfilter is an embedded scripting language for golang hosts.
+  Author: Steve Kemp <steve@steve.fi>
+  Category: common, scripting
+  Website: https://github.com/skx/evalfilter
+*/
+
+export default function(hljs) {
+
+    const LINE_COMMENT = hljs.COMMENT('//', '$', {
+        contains: [{
+            begin: /\\\n/
+        }]
+    });
+
+    return {
+        name: 'evalfilter',
+        keywords: {
+            $pattern: hljs.UNDERSCORE_IDENT_RE,
+            literal: "true false nil",
+            keyword: "case default else for foreach function if in local return switch while",
+            built_in: "between day float getenv hour int keys len lower match max min minute month now panic printf print reverse seconds sort split sprintf string time trim type upper weekday year",
+        },
+    contains: [
+        hljs.C_NUMBER_MODE,
+        hljs.APOS_STRING_MODE,
+        hljs.QUOTE_STRING_MODE,
+        LINE_COMMENT,
+        hljs.C_BLOCK_COMMENT_MODE,
+    ]
+    };
+}

--- a/test/markup/evalfilter/default.expect.txt
+++ b/test/markup/evalfilter/default.expect.txt
@@ -1,0 +1,46 @@
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">// This script is a very example of using `switch` and `case`.</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">// You can run this via the `evalfilter` command like so:</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">//    $ evalfilter run switch.script</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">// Once you do so you&#x27;ll see the output, and the return-code displayed:</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">//    $ evalfilter run switch.script</span>
+<span class="hljs-comment">//    I know you Steve - expression-match!</span>
+<span class="hljs-comment">//    I know you Steven - literal-match!</span>
+<span class="hljs-comment">//    I know you steve - regexp-match!</span>
+<span class="hljs-comment">//    I don&#x27;t know who you are steven</span>
+<span class="hljs-comment">//    I don&#x27;t know who you are bob</span>
+<span class="hljs-comment">//    I don&#x27;t know who you are test</span>
+<span class="hljs-comment">//    Script gave result type:NULL value:null - which is &#x27;false&#x27;.</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span>  Only the FIRST matching case statement will run.</span>
+<span class="hljs-comment">//</span>
+
+<span class="hljs-keyword">function</span> test( name ) {
+
+  <span class="hljs-keyword">switch</span>( name ) {
+    <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;Ste&quot;</span> + <span class="hljs-string">&quot;ve&quot;</span> {
+	<span class="hljs-built_in">printf</span>(<span class="hljs-string">&quot;I know you %s - expression-match!\n&quot;</span>, name );
+    }
+    <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;Steven&quot;</span> {
+	<span class="hljs-built_in">printf</span>(<span class="hljs-string">&quot;I know you %s - literal-match!\n&quot;</span>, name );
+    }
+    <span class="hljs-keyword">case</span> /^steve$/ {
+        <span class="hljs-built_in">printf</span>(<span class="hljs-string">&quot;I know you %s - regexp-match!\n&quot;</span>, name );
+    }
+    <span class="hljs-keyword">default</span> {
+	<span class="hljs-built_in">printf</span>(<span class="hljs-string">&quot;I don&#x27;t know who you are %s\n&quot;</span>, name );
+    }
+  }
+}
+
+
+<span class="hljs-comment">//</span>
+<span class="hljs-comment">// Now try a bunch of names</span>
+<span class="hljs-comment">//</span>
+<span class="hljs-keyword">foreach</span> name <span class="hljs-keyword">in</span> [ <span class="hljs-string">&quot;Steve&quot;</span>, <span class="hljs-string">&quot;Steven&quot;</span>, <span class="hljs-string">&quot;steve&quot;</span>, <span class="hljs-string">&quot;steven&quot;</span>, <span class="hljs-string">&quot;bob&quot;</span>, <span class="hljs-string">&quot;test&quot;</span> ] {
+  test( name );
+}

--- a/test/markup/evalfilter/default.txt
+++ b/test/markup/evalfilter/default.txt
@@ -1,0 +1,46 @@
+//
+// This script is a very example of using `switch` and `case`.
+//
+// You can run this via the `evalfilter` command like so:
+//
+//    $ evalfilter run switch.script
+//
+// Once you do so you'll see the output, and the return-code displayed:
+//
+//    $ evalfilter run switch.script
+//    I know you Steve - expression-match!
+//    I know you Steven - literal-match!
+//    I know you steve - regexp-match!
+//    I don't know who you are steven
+//    I don't know who you are bob
+//    I don't know who you are test
+//    Script gave result type:NULL value:null - which is 'false'.
+//
+// NOTE:  Only the FIRST matching case statement will run.
+//
+
+function test( name ) {
+
+  switch( name ) {
+    case "Ste" + "ve" {
+	printf("I know you %s - expression-match!\n", name );
+    }
+    case "Steven" {
+	printf("I know you %s - literal-match!\n", name );
+    }
+    case /^steve$/ {
+        printf("I know you %s - regexp-match!\n", name );
+    }
+    default {
+	printf("I don't know who you are %s\n", name );
+    }
+  }
+}
+
+
+//
+// Now try a bunch of names
+//
+foreach name in [ "Steve", "Steven", "steve", "steven", "bob", "test" ] {
+  test( name );
+}


### PR DESCRIPTION
Evalfilter is an embedded scripting language for golang host applications.

### Changes
<!--- Describe your changes -->

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
