### PR TITLE
Add grep to bash keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,11 @@
 
 Grammars:
 
+- enh(bash) Match `grep` keyword [Spencer Churchill][]
 - enh(php) named arguments [Wojciech Kania][]
 - fix(php) PHP constants [Wojciech Kania][]
 
+[Spencer Churchill]: https://github.com/splch
 [Wojciech Kania]: https://github.com/wkania
 
 ## Version 11.4.0

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -315,6 +315,7 @@ export default function(hljs) {
     "expr",
     "factor",
     // "false", // keyword literal already
+    "grep",
     "groups",
     "hostid",
     "id",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

grep is a very common bash command, so I'm adding to the list.

### Checklist
- [ ] Markup tests don't apply since it's a single word being added
- [x ] Updated the changelog at `CHANGES.md`
