### PR TITLE
Fix highlighting of int8, int16, int32, int64 in Angelscript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Grammars:
 
 - enh(php) named arguments [Wojciech Kania][]
 - fix(php) PHP constants [Wojciech Kania][]
+- fix(angelscript) incomplete int8, int16, int32, int64 highlighting [Melissa Geels][]
 
 [Wojciech Kania]: https://github.com/wkania
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Grammars:
 - fix(angelscript) incomplete int8, int16, int32, int64 highlighting [Melissa Geels][]
 
 [Wojciech Kania]: https://github.com/wkania
+[Melissa Geels]: https://github.com/codecat
 
 ## Version 11.4.0
 

--- a/src/languages/angelscript.js
+++ b/src/languages/angelscript.js
@@ -9,7 +9,7 @@ Website: https://www.angelcode.com/angelscript/
 export default function(hljs) {
   const builtInTypeMode = {
     className: 'built_in',
-    begin: '\\b(void|bool|int|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|string|ref|array|double|float|auto|dictionary)'
+    begin: '\\b(void|bool|int8|int16|int32|int64|int|uint8|uint16|uint32|uint64|uint|string|ref|array|double|float|auto|dictionary)'
   };
 
   const objectHandleMode = {

--- a/test/detect/angelscript/default.txt
+++ b/test/detect/angelscript/default.txt
@@ -15,7 +15,7 @@ namespace MyApplication
         array<SomeClass@> m_children;
         array<array<SomeClass@>> m_subChildren; // Nested templates
 
-        int m_thing;
+        uint64 m_thing;
 
         SomeClass()
         {

--- a/test/markup/angelscript/default.expect.txt
+++ b/test/markup/angelscript/default.expect.txt
@@ -15,7 +15,7 @@
         <span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-symbol">SomeClass@</span>&gt;</span></span> m_children;
         <span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-symbol">SomeClass@</span>&gt;</span></span>&gt;</span></span> m_subChildren; <span class="hljs-comment">// Nested templates</span>
 
-        <span class="hljs-built_in">int</span> m_thing;
+        <span class="hljs-built_in">uint64</span> m_thing;
 
         SomeClass()
         {

--- a/test/markup/angelscript/default.expect.txt
+++ b/test/markup/angelscript/default.expect.txt
@@ -15,7 +15,8 @@
         <span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-symbol">SomeClass@</span>&gt;</span></span> m_children;
         <span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-built_in">array<span class="hljs-keyword">&lt;<span class="hljs-symbol">SomeClass@</span>&gt;</span></span>&gt;</span></span> m_subChildren; <span class="hljs-comment">// Nested templates</span>
 
-        <span class="hljs-built_in">uint64</span> m_thing;
+        <span class="hljs-built_in">int</span> m_thing;
+        <span class="hljs-built_in">uint64</span> m_thing2;
 
         SomeClass()
         {

--- a/test/markup/angelscript/default.txt
+++ b/test/markup/angelscript/default.txt
@@ -15,7 +15,8 @@ namespace MyApplication
         array<SomeClass@> m_children;
         array<array<SomeClass@>> m_subChildren; // Nested templates
 
-        uint64 m_thing;
+        int m_thing;
+        uint64 m_thing2;
 
         SomeClass()
         {

--- a/test/markup/angelscript/default.txt
+++ b/test/markup/angelscript/default.txt
@@ -15,7 +15,7 @@ namespace MyApplication
         array<SomeClass@> m_children;
         array<array<SomeClass@>> m_subChildren; // Nested templates
 
-        int m_thing;
+        uint64 m_thing;
 
         SomeClass()
         {


### PR DESCRIPTION
### Changes
This fixes types such as `int64` and `uint64` only coloring the `int` and `uint` parts of the type in Angelscript.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
