### PR TITLE
Minor change to TypeScript types and TypeScript-specific keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,11 @@ Grammars:
 - enh(php) named arguments [Wojciech Kania][]
 - fix(php) PHP constants [Wojciech Kania][]
 - fix(angelscript) incomplete int8, int16, int32, int64 highlighting [Melissa Geels][]
+- enh(ts) modify TypeScript-specific keywords and types list [anydonym][]
 
 [Wojciech Kania]: https://github.com/wkania
 [Melissa Geels]: https://github.com/codecat
+[anydonym]: https://github.com/anydonym
 
 ## Version 11.4.0
 

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -23,7 +23,11 @@ export default function(hljs) {
     "string",
     "object",
     "never",
-    "enum"
+    "enum",
+    "null",
+    "undefined",
+    "symbol",
+    "bigint"
   ];
   const NAMESPACE = {
     beginKeywords: 'namespace',
@@ -53,7 +57,6 @@ export default function(hljs) {
   const TS_SPECIFIC_KEYWORDS = [
     "type",
     "namespace",
-    "typedef",
     "interface",
     "public",
     "private",

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -23,10 +23,9 @@ export default function(hljs) {
     "string",
     "object",
     "never",
-    "null",
-    "undefined",
     "symbol",
-    "bigint"
+    "bigint",
+    "unknown"
   ];
   const NAMESPACE = {
     beginKeywords: 'namespace',
@@ -65,7 +64,7 @@ export default function(hljs) {
     "abstract",
     "readonly",
     "enum",
-    "keyof"
+    "override"
   ];
   const KEYWORDS = {
     $pattern: ECMAScript.IDENT_RE,

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -23,7 +23,6 @@ export default function(hljs) {
     "string",
     "object",
     "never",
-    "enum",
     "null",
     "undefined",
     "symbol",
@@ -64,7 +63,9 @@ export default function(hljs) {
     "implements",
     "declare",
     "abstract",
-    "readonly"
+    "readonly",
+    "enum",
+    "keyof"
   ];
   const KEYWORDS = {
     $pattern: ECMAScript.IDENT_RE,


### PR DESCRIPTION
Basically some minor modifications to the current TypeScript types and TypeScript-specific keywords list.

### Changes
+ Add `override`, move `enum` to and remove `typedef` TypeScript-specific keywords list.
+ Add various primitive types to the TypeScript types list, which are `unknown`, `symbol` and `bigint`.

### Checklist
+ [x] Updated the changelogs at `CHANGES.md`