### PR TITLE
(enh) named lang exports index candidate impl for Node & bundler builds (#3470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ For the smallest footprint, load only the languages you need:
 
 ```js
 const hljs = require('highlight.js/lib/core');
-hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'));
+const { xml } = require('highlight.js/lib/languages');
+hljs.registerLanguage('xml', xml);
 
 const highlightedCode = hljs.highlight('<span>Hello World!</span>', {language: 'xml'}).value
 ```
@@ -284,7 +285,7 @@ It is more efficient to import only the library and register the languages you n
 
 ```js
 import hljs from 'highlight.js/lib/core';
-import javascript from 'highlight.js/lib/languages/javascript';
+import { javascript } from 'highlight.js/lib/languages';
 hljs.registerLanguage('javascript', javascript);
 ```
 

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -6,7 +6,7 @@ const { getLanguages } = require("./lib/language.js");
 const { install, mkdir, installCleanCSS } = require("./lib/makestuff.js");
 const { filter } = require("./lib/dependencies.js");
 const { rollupWrite } = require("./lib/bundling.js");
-const { generateCJSLanguageIndex, generateESLanguageIndex } = require('./lib/indexgen.js');
+const { generateCJSLanguageIndex, generateESLanguageIndex } = require('./lib/language_indexgen.js');
 const log = (...args) => console.log(...args);
 
 // https://nodejs.org/api/packages.html#packages_writing_dual_packages_while_avoiding_or_minimizing_hazards

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -6,6 +6,7 @@ const { getLanguages } = require("./lib/language.js");
 const { install, mkdir, installCleanCSS } = require("./lib/makestuff.js");
 const { filter } = require("./lib/dependencies.js");
 const { rollupWrite } = require("./lib/bundling.js");
+const { generateCJSLanguageIndex, generateESLanguageIndex } = require('./lib/indexgen.js');
 const log = (...args) => console.log(...args);
 
 // https://nodejs.org/api/packages.html#packages_writing_dual_packages_while_avoiding_or_minimizing_hazards
@@ -195,6 +196,8 @@ async function buildNode(options) {
   await buildCJSIndex("index", languages);
   await buildCJSIndex("common", common);
   await buildLanguages(languages, options);
+  await fs.writeFile(`${process.env.BUILD_DIR}/lib/languages/index.js`, generateCJSLanguageIndex());
+  await fs.writeFile(`${process.env.BUILD_DIR}/es/languages/index.js`, generateESLanguageIndex());
 
   log("Writing highlight.js");
   await buildNodeHighlightJS(options);

--- a/tools/lib/language_indexgen.js
+++ b/tools/lib/language_indexgen.js
@@ -1,0 +1,48 @@
+const { basename } = require('path');
+const glob = require('glob');
+
+// if a language name starts with a number, we convert it to a textual representation
+// as variables in JS cannot start with numbers:
+const numbers = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+
+const allLangs = glob.sync("./src/languages/*.js");
+
+/**
+ * @param {string} str
+ */
+const camelcasify = (str) => {
+  while (str.match(/-/)) {
+    str = str.slice(0, str.indexOf('-')) + str[str.indexOf('-') + 1].toUpperCase() + str.slice(str.indexOf('-') + 2);
+  }
+  return str;
+};
+
+function generateESLanguageIndex() {
+  let indexContents = '';
+  allLangs.forEach(langDef => {
+    const langPath = `./${basename(langDef)}`;
+    let langExport = basename(langDef, '.js');
+    if (!isNaN(langExport[0])) langExport = `${numbers[parseInt(langExport[0])]}-${langExport.slice(1)}`;
+    const exportLine = `export { default as ${camelcasify(langExport)} } from '${langPath}';\n`;
+    indexContents += exportLine;
+  });
+  return indexContents;
+}
+
+function generateCJSLanguageIndex() {
+  let indexContents = 'module.exports = {\n';
+  allLangs.forEach((langDef, i) => {
+    const langPath = `./${basename(langDef)}`;
+    let langExport = basename(langDef, '.js');
+    if (!isNaN(langExport[0])) langExport = `${numbers[parseInt(langExport[0])]}-${langExport.slice(1)}`;
+    const exportLine = `  ${camelcasify(langExport)}: require('${langPath}')${i === allLangs.length - 1 ? '' : ','}\n`;
+    indexContents += exportLine;
+  });
+  indexContents += '};\n';
+  return indexContents;
+}
+
+module.exports = {
+  generateCJSLanguageIndex,
+  generateESLanguageIndex
+};


### PR DESCRIPTION
This is an exploratory PR for issue #3470

### Changes
- Adds an index generation script under `tools/lib`
- Uses that script in `tools/build_node.js`
- Outputs 2 extra files `build/lib/languages/index.js` and `build/es/languages/index.js`

To test that this worked as intended for Node I created 2 files (locally):
`test-import.mjs`
```js
import { abnf, oneC, xml } from './build/es/languages/index.js';
import hljs from './build/es/index.js';

hljs.registerLanguage('abnf', abnf);
hljs.registerLanguage('1c', oneC);
hljs.registerLanguage('xml', xml);
```
`test-import.js`
```js
const { abnf, oneC, xml } = require('./build/lib/languages');
const hljs = require('./build/lib');

hljs.registerLanguage('abnf', abnf);
hljs.registerLanguage('1c', oneC);
hljs.registerLanguage('xml', xml);

console.log(hljs.getLanguage('abnf'));
```

### Checklist
- [x] Markup tests don't apply here
- [ ] Updated the changelog at `CHANGES.md`
- [ ] TBD: name conversion for languages which are stored in a file with a `-` (dash) are camelCased, e.g `pythonRepl`
- [x] TBD: name conversion for languages which start with a number converts the first number to textual representation and camelCases the rest (eg `1c` becomes `oneC`). This is required for ES exports and has been kept for CJS exports to keep consistency