### PR TITLE
Update colors (dev dep) to new maintained version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "11.4.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
+        "@colors/colors": "^1.5.0",
         "@rollup/plugin-commonjs": "^21.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -17,7 +18,6 @@
         "@typescript-eslint/parser": "^5.12.0",
         "clean-css": "^5.0.1",
         "cli-table": "^0.3.1",
-        "colors": "^1.1.2",
         "commander": "8.2",
         "css": "^3.0.0",
         "css-color-names": "^1.0.1",
@@ -45,6 +45,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -942,15 +951,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/combined-stream": {
@@ -4107,6 +4107,12 @@
     }
   },
   "dependencies": {
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
@@ -4771,12 +4777,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
+    "@colors/colors": "^1.5.0",
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
@@ -63,7 +64,6 @@
     "@typescript-eslint/parser": "^5.12.0",
     "clean-css": "^5.0.1",
     "cli-table": "^0.3.1",
-    "colors": "^1.1.2",
     "commander": "8.2",
     "css": "^3.0.0",
     "css-color-names": "^1.0.1",

--- a/tools/checkTheme.js
+++ b/tools/checkTheme.js
@@ -5,7 +5,7 @@ const css = require("css");
 const wcagContrast = require("wcag-contrast");
 const Table = require('cli-table');
 const csscolors = require('css-color-names');
-require("colors");
+require("@colors/colors");
 
 const CODE = {
   name: "program code",


### PR DESCRIPTION
### Changes

I'll save ya some brain cells here. But if you insist on reading about it, there's a [verge article about it](https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected)

tl;dr: A `colors` maintainer went rogue, corrupted the library, here's the new version that is maintained.

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
