### PR TITLE
Add 3rd-party support for Macaulay2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Themes:
 New Grammars:
 
 - Added GraphQL to SUPPORTED_LANGUAGES [jf990][]
+- Added Macaulay2 to SUPPORTED_LANGUAGES [Doug Torrance][]
 
 Grammars:
 
@@ -32,6 +33,7 @@ Grammars:
 [Josh Goebel]: https://github.com/joshgoebel
 [Mark Ericksen]: https://github.com/brainlid
 [Nicolaos Skimas]: https://github.com/dev-nicolaos
+[Doug Torrance]: https://github.com/d-torrance
 
 
 ## Version 11.4.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -117,6 +117,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | LiveCode Server         | livecodeserver         |         |
 | LiveScript              | livescript, ls         |         |
 | Lua                     | lua                    |         |
+| Macaulay2               | macaulay2              | [highlightjs-macaulay2](https://github.com/d-torrance/highlightjs-macaulay2) |
 | Makefile                | makefile, mk, mak, make |        |
 | Markdown                | markdown, md, mkdown, mkd |      |
 | Mathematica             | mathematica, mma, wl   |         |


### PR DESCRIPTION
Macaulay2 is a software system devoted to supporting research in algebraic geometry and commutative algebra: https://faculty.math.illinois.edu/Macaulay2/

### Changes
Added Macaulay2 row to `SUPPORTED_LANGUAGES.md`.

### Checklist
- [x] Added markup tests (see https://github.com/d-torrance/highlightjs-macaulay2)
- [x] Updated the changelog at `CHANGES.md`
