### PR TITLE
enh(bash) `$pattern`: allow numbers after the first character

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ New Grammars:
 
 Grammars:
 
+- enh(bash) improved pattern regex [Martin Mattel][]
 - fix(markdown) Handle `***Hello world***` without breaking [Josh Goebel][]
 - enh(php) add support for PHP Attributes [Wojciech Kania][]
 - fix(java) prevent false positive variable init on `else` [Josh Goebel][]
@@ -22,7 +23,7 @@ Grammars:
 - enh(elixir) recognize references to modules [Mark Ericksen][]
 - enh(css): add support for more properties [Nicolaos Skimas][]
 
-
+[Martin Mattel]: https://github.com/mmattel
 [John Foster]: https://github.com/jf990
 [Wojciech Kania]: https://github.com/wkania
 [Melissa Geels]: https://github.com/codecat

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ New Grammars:
 
 Grammars:
 
-- enh(bash) improved pattern regex [Martin Mattel][]
+- enh(bash) improved keyword `$pattern` (numbers allowed in command names) [Martin Mattel][]
 - fix(markdown) Handle `***Hello world***` without breaking [Josh Goebel][]
 - enh(php) add support for PHP Attributes [Wojciech Kania][]
 - fix(java) prevent false positive variable init on `else` [Josh Goebel][]

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -355,7 +355,7 @@ export default function(hljs) {
     name: 'Bash',
     aliases: [ 'sh' ],
     keywords: {
-      $pattern: /\b[a-z._-]+\b/,
+      $pattern: /\b[a-z][a-z0-9._-]+\b/,
       keyword: KEYWORDS,
       literal: LITERALS,
       built_in: [


### PR DESCRIPTION
Fixes: https://github.com/highlightjs/highlight.js/issues/3489 ((bash) keywords with numbers are not recognized)

With the new regex, also numbers INSIDE the bash pattern is allowed.
Before, eg. `a2enmod` would not have been recognized. Now it gets properly recognized.

For the details of the test results see: https://github.com/highlightjs/highlight.js/issues/3489#issuecomment-1050938466

@joshgoebel

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
