### PR TITLE
explicitly set sideEffect for css and scss files, fixes #3504

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "type": "commonjs",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": ["*.css", "*.scss"],
   "scripts": {
     "mocha": "mocha",
     "lint": "eslint src/*.js src/lib/*.js demo/*.js tools/**/*.js --ignore-pattern vendor",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
make it possible to import css or scss using ES6 `import 'file.css'`

<!-- Please link to a related issue below. -->
 fixes #3504

### Changes
`"sideEffects": false,` to `"sideEffects": ["*.css", "*.scss"],`  
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
