### PR TITLE
Assign authorship to Josh Goebel

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
   ],
   "homepage": "https://highlightjs.org/",
   "version": "11.5.0",
-  "author": {
-    "name": "Ivan Sagalaev",
-    "email": "maniac@softwaremaniacs.org"
-  },
+  "author": "Josh Goebel <hello@joshgoebel.com>",
   "contributors": [
     "Josh Goebel <hello@joshgoebel.com>",
     "Egor Rogov <e.rogov@postgrespro.ru>",


### PR DESCRIPTION
I'm getting contacted occasionally by people who look up the
package's author from npm's registry. Package.json doesn't have a
dedicated 'maintainer' field, so 'author' should work, I think.

(Don't think this change deserves to be in CHANGES.)