### PR TITLE
fix(markdown) strong/emphasis requires whitespace after

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -138,11 +138,11 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /_{2}/,
+        begin: /_{2}(?!\s)/,
         end: /_{2}/
       },
       {
-        begin: /\*{2}(?![ ])/,
+        begin: /\*{2}(?!\s)/,
         end: /\*{2}/
       }
     ]
@@ -152,11 +152,11 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /\*(?![* ])/,
+        begin: /\*(?![*\s])/,
         end: /\*/
       },
       {
-        begin: /_(?!_)/,
+        begin: /_(?![_\s])/,
         end: /_/,
         relevance: 0
       }

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -142,7 +142,7 @@ export default function(hljs) {
         end: /_{2}/
       },
       {
-        begin: /\*{2}/,
+        begin: /\*{2}(?![ ])/,
         end: /\*{2}/
       }
     ]
@@ -152,7 +152,7 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /\*(?!\*)/,
+        begin: /\*(?![* ])/,
         end: /\*/
       },
       {

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -19,3 +19,15 @@
 
 <span class="hljs-strong">**<span class="hljs-emphasis">*This is bold and italic*</span>**</span>
 <span class="hljs-strong">__<span class="hljs-emphasis">_This is bold and italic_</span>__</span>
+
+** i shouldn&#x27;t be italic**
+
+<span class="hljs-bullet">*</span> and I shouldn&#x27;t be italic either*
+
+__ not really bold__
+
+_ not italic_
+
+<span class="hljs-quote">&gt; * One (this point is italic)</span>
+<span class="hljs-quote">&gt; * Two</span>
+<span class="hljs-quote">&gt; * Three</span>

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -19,3 +19,15 @@ __Bold *then italic*__
 
 ***This is bold and italic***
 ___This is bold and italic___
+
+** i shouldn't be italic**
+
+* and I shouldn't be italic either*
+
+__ not really bold__
+
+_ not italic_
+
+> * One (this point is italic)
+> * Two
+> * Three


### PR DESCRIPTION
Resolves #3519.  Prevents false positive of emphasis when bullets are nested inside block quotes.  This doesn't detect the bullets, it only fixes the false positive.

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
