### PR TITLE
Support `distributed` keyword for Swift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Grammars:
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
+[Marcus Ortiz]: https://github.com/mportiz08
 
 ## Version 11.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Grammars:
 
 - enh(swift) add SE-0335 existential `any` keyword (#3515) [Bradley Mackey][]
+- enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -50,6 +50,7 @@ export const keywords = [
   'defer',
   'deinit',
   'didSet', // contextual
+  'distributed',
   'do',
   'dynamic', // contextual
   'else',

--- a/test/markup/swift/distributed-actor-runtime.expect.txt
+++ b/test/markup/swift/distributed-actor-runtime.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-keyword">distributed</span> <span class="hljs-keyword">actor</span> <span class="hljs-title class_">Foobar</span> {
+  <span class="hljs-keyword">distributed</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">baz</span>() {
+  }
+
+  <span class="hljs-keyword">func</span> <span class="hljs-title function_">qux</span>() {
+  }
+}

--- a/test/markup/swift/distributed-actor-runtime.txt
+++ b/test/markup/swift/distributed-actor-runtime.txt
@@ -1,0 +1,7 @@
+distributed actor Foobar {
+  distributed func baz() {
+  }
+
+  func qux() {
+  }
+}


### PR DESCRIPTION
This new syntax is in support of the ["Distributed Actor Isolation"][1] feature that has been accepted for Swift 5.7.

[1]: https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md

### Changes

New Swift language keyword: `distributed`

### Checklist
- [X] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
