### PR TITLE
Introducing Unicode letter support for XML element names/tags and attribute names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@ Grammars:
 
 - enh(swift) add SE-0335 existential `any` keyword (#3515) [Bradley Mackey][]
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
+- enh(xml) recognize Unicode letters instead of only ASCII letters in XML element and attribute names (#3256)[Martin Honnen][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 [Marcus Ortiz]: https://github.com/mportiz08
+[Martin Honnen]: https://github.com/martin-honnen
 
 ## Version 11.5.0
 

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -8,9 +8,15 @@ Audit: 2020
 /** @type LanguageFn */
 export default function(hljs) {
   const regex = hljs.regex;
-  // Element names can contain letters, digits, hyphens, underscores, and periods
-  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]*:/), /[A-Z0-9_.-]*/);
-  const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
+  // XML names can have the following additional letters: https://www.w3.org/TR/xml/#NT-NameChar
+  // OTHER_NAME_CHARS = /[:\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]/;
+  // Element names start with NAME_START_CHAR followed by optional other Unicode letters, ASCII digits, hyphens, underscores, and periods
+  // const TAG_NAME_RE = regex.concat(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/, regex.optional(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*:/), /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*/);;
+  // const XML_IDENT_RE = /[A-Z_a-z:\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]+/;
+  // const TAG_NAME_RE = regex.concat(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/, regex.optional(/[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*:/), /[A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*/);
+  // however, to cater for performance and more Unicode support rely simply on the Unicode letter class
+  const TAG_NAME_RE = regex.concat(/[\p{L}_]/u, regex.optional(/[\p{L}0-9_.-]*:/u), /[\p{L}0-9_.-]*/u);
+  const XML_IDENT_RE = /[\p{L}0-9._:-]+/u;
   const XML_ENTITIES = {
     className: 'symbol',
     begin: /&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -87,6 +87,7 @@ export default function(hljs) {
       'svg'
     ],
     case_insensitive: true,
+    unicodeRegex: true,
     contains: [
       {
         className: 'meta',

--- a/test/markup/xml/non-ascii-attribute-names.expect.txt
+++ b/test/markup/xml/non-ascii-attribute-names.expect.txt
@@ -1,0 +1,3 @@
+﻿<span class="hljs-tag">&lt;<span class="hljs-name">productos</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">producto</span> <span class="hljs-attr">categoría</span>=<span class="hljs-string">&quot;mueble&quot;</span> <span class="hljs-attr">descripción</span>=<span class="hljs-string">&quot;Asiento cómodo para dos o más personas, que tiene respaldo y brazos.&quot;</span>&gt;</span>sofá<span class="hljs-tag">&lt;/<span class="hljs-name">producto</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">productos</span>&gt;</span>

--- a/test/markup/xml/non-ascii-attribute-names.txt
+++ b/test/markup/xml/non-ascii-attribute-names.txt
@@ -1,0 +1,3 @@
+﻿<productos>
+  <producto categoría="mueble" descripción="Asiento cómodo para dos o más personas, que tiene respaldo y brazos.">sofá</producto>
+</productos>

--- a/test/markup/xml/non-ascii-element-names.expect.txt
+++ b/test/markup/xml/non-ascii-element-names.expect.txt
@@ -1,0 +1,12 @@
+﻿<span class="hljs-tag">&lt;<span class="hljs-name">productos</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">producto</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">name</span>&gt;</span>sofá<span class="hljs-tag">&lt;/<span class="hljs-name">name</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">categoría</span>&gt;</span>mueble<span class="hljs-tag">&lt;/<span class="hljs-name">categoría</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">descripción</span>&gt;</span>Asiento cómodo para dos o más personas, que tiene respaldo y brazos.<span class="hljs-tag">&lt;/<span class="hljs-name">descripción</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">producto</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">producto</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">name</span>&gt;</span>sillón<span class="hljs-tag">&lt;/<span class="hljs-name">name</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">categoría</span>&gt;</span>mueble<span class="hljs-tag">&lt;/<span class="hljs-name">categoría</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">descripción</span>&gt;</span>Silla de brazos, mayor y más cómoda que la ordinaria.<span class="hljs-tag">&lt;/<span class="hljs-name">descripción</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">producto</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">productos</span>&gt;</span>

--- a/test/markup/xml/non-ascii-element-names.txt
+++ b/test/markup/xml/non-ascii-element-names.txt
@@ -1,0 +1,12 @@
+﻿<productos>
+  <producto>
+    <name>sofá</name>
+    <categoría>mueble</categoría>
+    <descripción>Asiento cómodo para dos o más personas, que tiene respaldo y brazos.</descripción>
+  </producto>
+  <producto>
+    <name>sillón</name>
+    <categoría>mueble</categoría>
+    <descripción>Silla de brazos, mayor y más cómoda que la ordinaria.</descripción>
+  </producto>
+</productos>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3256 

### Changes
Fixed the xml regular expressions to use the Unicode "letter" class/category `L` and Unicode based regular expressions with e.g. `/.../u` so that, instead of only ASCII characters, any Unicode letter in XML element/tag names and XML attribute names is recognized and the markup is properly highlighted.

### Checklist
- [x] Added two markup tests
- [x] Updated the changelog at `CHANGES.md`
