### PR TITLE
3rd-party support for Oak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@ Grammars:
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 - enh(xml) recognize Unicode letters instead of only ASCII letters in XML element and attribute names (#3256)[Martin Honnen][]
 - Added 3rd party Toit grammar to SUPPORTED_LANGUAGES [Serzhan Nasredin][]
+- Added 3rd party Oak grammar to SUPPORTED_LANGUAGES [Tim Smith][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 [Marcus Ortiz]: https://github.com/mportiz08
 [Martin Honnen]: https://github.com/martin-honnen
 [Serzhan Nasredin]: https://github.com/snxx-lppxx
+[Tim Smith]: https://github.com/timlabs
 
 ## Version 11.5.0
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -137,6 +137,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Nginx                   | nginx, nginxconf       |         |
 | Nim                     | nim, nimrod            |         |
 | Nix                     | nix                    |         |
+| Oak                     | oak                    | [highlightjs-oak](https://github.com/timlabs/highlightjs-oak) |
 | Object Constraint Language | ocl                 | [highlightjs-ocl](https://github.com/nhomble/highlightjs-ocl)        |
 | OCaml                   | ocaml, ml              |         |
 | Objective C             | objectivec, mm, objc, obj-c, obj-c++, objective-c++ |    |


### PR DESCRIPTION
Oak is a proof checker focused on simplicity, readability, and ease of use: https://oakproof.org/

### Changes
Added Oak to supported languages (3rd party).

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
