### PR TITLE
substr is deprecated, use substring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@ Grammars:
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 - enh(xml) recognize Unicode letters instead of only ASCII letters in XML element and attribute names (#3256)[Martin Honnen][]
 - Added 3rd party Toit grammar to SUPPORTED_LANGUAGES [Serzhan Nasredin][]
+- Use substring() instead of deprecated substr() [Tobias Buschor][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 [Marcus Ortiz]: https://github.com/mportiz08
 [Martin Honnen]: https://github.com/martin-honnen
 [Serzhan Nasredin]: https://github.com/snxx-lppxx
+[Tobias Buschor]: https://github.com/nuxodin/
 
 ## Version 11.5.0
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -232,7 +232,7 @@ const HLJS = function(hljs) {
         lastIndex = top.keywordPatternRe.lastIndex;
         match = top.keywordPatternRe.exec(modeBuffer);
       }
-      buf += modeBuffer.substr(lastIndex);
+      buf += modeBuffer.substring(lastIndex);
       emitter.addText(buf);
     }
 
@@ -407,7 +407,7 @@ const HLJS = function(hljs) {
      */
     function doEndMatch(match) {
       const lexeme = match[0];
-      const matchPlusRemainder = codeToHighlight.substr(match.index);
+      const matchPlusRemainder = codeToHighlight.substring(match.index);
 
       const endMode = endOfMode(top, match, matchPlusRemainder);
       if (!endMode) { return NO_MATCH; }
@@ -580,7 +580,7 @@ const HLJS = function(hljs) {
         const processedCount = processLexeme(beforeMatch, match);
         index = match.index + processedCount;
       }
-      processLexeme(codeToHighlight.substr(index));
+      processLexeme(codeToHighlight.substring(index));
       emitter.closeAllNodes();
       emitter.finalize();
       result = emitter.toHTML();

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -68,7 +68,7 @@ export default function(hljs) {
       // `<From extends string>`
       // technically this could be HTML, but it smells like a type
       let m;
-      const afterMatch = match.input.substr(afterMatchIndex);
+      const afterMatch = match.input.substring(afterMatchIndex);
       // NOTE: This is ugh, but added specifically for https://github.com/highlightjs/highlight.js/issues/3276
       if ((m = afterMatch.match(/^\s+extends\s+/))) {
         if (m.index === 0) {


### PR DESCRIPTION
Hi
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

### Changes

Replace substr width substring, using with one argument only should be compatible.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring

<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
