### PR TITLE
fix(rust) recognize `include_bytes!` macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Grammars:
 
+- fix(rust) recognize `include_bytes!` macro (#3541) [Serial-ATA][]
 - enh(swift) add SE-0335 existential `any` keyword (#3515) [Bradley Mackey][]
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 - enh(xml) recognize Unicode letters instead of only ASCII letters in XML element and attribute names (#3256)[Martin Honnen][]
@@ -10,6 +11,7 @@ Grammars:
 - Added 3rd party Oak grammar to SUPPORTED_LANGUAGES [Tim Smith][]
 - enh(python) add `match` and `case` keywords [Avrumy Lunger][]
 
+[Serial-ATA]: https://github.com/Serial-ATA
 [Bradley Mackey]: https://github.com/bradleymackey
 [Marcus Ortiz]: https://github.com/mportiz08
 [Martin Honnen]: https://github.com/martin-honnen

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -127,7 +127,7 @@ export default function(hljs) {
     "file!",
     "format!",
     "format_args!",
-    "include_bin!",
+    "include_bytes!",
     "include_str!",
     "line!",
     "local_data_key!",


### PR DESCRIPTION
### Changes
Change builtin `include_bin` to `include_bytes`, as the former doesn't exist.

### Checklist
- [X] Added markup tests, or they don't apply here because it is a simple word correction.
- [X] Updated the changelog at `CHANGES.md`
