### PR TITLE
Add PRQL language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Grammars:
 - Use substring() instead of deprecated substr() [Tobias Buschor][]
 - Added 3rd party Oak grammar to SUPPORTED_LANGUAGES [Tim Smith][]
 - enh(python) add `match` and `case` keywords [Avrumy Lunger][]
+- Added PRQL language [Maximilian Roos]
 
 [Serial-ATA]: https://github.com/Serial-ATA
 [Bradley Mackey]: https://github.com/bradleymackey
@@ -19,6 +20,7 @@ Grammars:
 [Tobias Buschor]: https://github.com/nuxodin/
 [Tim Smith]: https://github.com/timlabs
 [Avrumy Lunger]: https://github.com/vrumger
+[Maximilian Roos]: https://github.com/max-sixty
 
 ## Version 11.5.0
 

--- a/src/languages/prql.js
+++ b/src/languages/prql.js
@@ -1,0 +1,49 @@
+export default function (hljs) {
+    const TRANSFORMS = ['from', 'select|2', 'derive|3', 'filter', 'take', 'sort', 'join', 'aggregate|3', 'func', 'group', 'window|4', 'prql|10'];
+    const ILLEGAL = [/:=/, /\[:/, /`/];
+
+    return {
+        name: 'PRQL',
+        case_insensitive: true,
+        keywords: {
+            keyword: TRANSFORMS.join(' '),
+            literal: 'false true null and or not',
+        },
+        illegal: ILLEGAL,
+        contains: [
+            hljs.COMMENT('#', '$'),
+            { // named arg
+                scope: 'params',
+                begin: /\w+\s*:/,
+                end: '',
+                illegal: ILLEGAL,
+                relevance: 1
+            },
+            { // assign
+                // TODO: handle operators like `== `
+                scope: { 1: 'variable' },
+                match: [/\w+\s*/, /=[^=]/],
+                illegal: ILLEGAL,
+                relevance: 0
+            },
+            { // date
+                scope: 'literal',
+                begin: /@\d{2}/,
+                end: ' ',
+                illegal: ILLEGAL,
+                relevance: 2
+            },
+            { // interpolation string
+                scope: 'attribute',
+                begin: '(s|f)"', end: '"',
+                relevance: 3
+            },
+            { // normal string
+                scope: 'string',
+                begin: '"', end: '"',
+                relevance: 0
+            },
+
+        ]
+    }
+}

--- a/test/detect/prql/default.txt
+++ b/test/detect/prql/default.txt
@@ -1,0 +1,21 @@
+from employees                                # Each line transforms the previous result.
+filter start_date > @2021-01-01               # Clear date syntax.
+derive [                                      # `derive` adds columns / variables.
+  gross_salary = salary + payroll_tax,
+  gross_cost = gross_salary + benefits_cost   # Variables can use other variables.
+]
+filter gross_cost > 0
+group [title, country] (                      # `group` runs a pipeline over each group.
+  aggregate [                                 # `aggregate` reduces each group to a row.
+    average salary,
+    sum     salary,
+    average gross_salary,
+    sum     gross_salary,
+    average gross_cost,
+    sum_gross_cost = sum gross_cost,          # `=` sets a column name.
+    ct = count,
+  ]
+)
+sort [sum_gross_cost, -country]               # `-country` means descending order.
+filter ct > 200
+take 20

--- a/test/markup/prql/default.expect.txt
+++ b/test/markup/prql/default.expect.txt
@@ -1,0 +1,21 @@
+<span class="hljs-keyword">from</span> employees                                <span class="hljs-comment"># Each line transforms the previous result.</span>
+<span class="hljs-keyword">filter</span> start_date &gt; <span class="hljs-literal">@2021-01-01 </span>              <span class="hljs-comment"># Clear date syntax.</span>
+<span class="hljs-keyword">derive</span> [                                      <span class="hljs-comment"># `derive` adds columns / variables.</span>
+  <span class="hljs-variable">gross_salary </span>= salary + payroll_tax,
+  <span class="hljs-variable">gross_cost </span>= gross_salary + benefits_cost   <span class="hljs-comment"># Variables can use other variables.</span>
+]
+<span class="hljs-keyword">filter</span> gross_cost &gt; 0
+<span class="hljs-keyword">group</span> [title, country] (                      <span class="hljs-comment"># `group` runs a pipeline over each group.</span>
+  <span class="hljs-keyword">aggregate</span> [                                 <span class="hljs-comment"># `aggregate` reduces each group to a row.</span>
+    average salary,
+    sum     salary,
+    average gross_salary,
+    sum     gross_salary,
+    average gross_cost,
+    <span class="hljs-variable">sum_gross_cost </span>= sum gross_cost,          <span class="hljs-comment"># `=` sets a column name.</span>
+    <span class="hljs-variable">ct </span>= count,
+  ]
+)
+<span class="hljs-keyword">sort</span> [sum_gross_cost, -country]               <span class="hljs-comment"># `-country` means descending order.</span>
+<span class="hljs-keyword">filter</span> ct &gt; 200
+<span class="hljs-keyword">take</span> 20

--- a/test/markup/prql/default.txt
+++ b/test/markup/prql/default.txt
@@ -1,0 +1,21 @@
+from employees                                # Each line transforms the previous result.
+filter start_date > @2021-01-01               # Clear date syntax.
+derive [                                      # `derive` adds columns / variables.
+  gross_salary = salary + payroll_tax,
+  gross_cost = gross_salary + benefits_cost   # Variables can use other variables.
+]
+filter gross_cost > 0
+group [title, country] (                      # `group` runs a pipeline over each group.
+  aggregate [                                 # `aggregate` reduces each group to a row.
+    average salary,
+    sum     salary,
+    average gross_salary,
+    sum     gross_salary,
+    average gross_cost,
+    sum_gross_cost = sum gross_cost,          # `=` sets a column name.
+    ct = count,
+  ]
+)
+sort [sum_gross_cost, -country]               # `-country` means descending order.
+filter ct > 200
+take 20


### PR DESCRIPTION
### Changes
Adds PRQL lang, consistent with https://github.com/prql/prql/pull/570.

I couldn't manage to implement grammar for the function calls, which are like OCaml's; I took those notes out of the this PR, but if anyone has ideas, that'd be very welcome.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
