### PR TITLE
Fix: The END mode should be object rather than array

### DIFF
--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -119,20 +119,18 @@ export default function(hljs) {
     beginScope: { 2: "keyword", }
   };
 
-  const END = [
-    {
-      begin: [
-        /^\s*/, // Is first token on the line
-        /end/,
-        /\s+/,
-        /(extension\b)?/, // `extension` is the only marker that follows an `end` that cannot be captured by another rule.
-      ],
-      beginScope: {
-        2: "keyword",
-        4: "keyword",
-      }
+  const END = {
+    begin: [
+      /^\s*/, // Is first token on the line
+      /end/,
+      /\s+/,
+      /(extension\b)?/, // `extension` is the only marker that follows an `end` that cannot be captured by another rule.
+    ],
+    beginScope: {
+      2: "keyword",
+      4: "keyword",
     }
-  ];
+  };
 
   // TODO: use negative look-behind in future
   //       /(?<!\.)\binline(?=\s)/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The END mode should be object rather than array.
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
