### PR TITLE
Fix(Java) Fix `==` being interpreted as a variable declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Grammars:
 
 - fix(rust) recognize `include_bytes!` macro (#3541) [Serial-ATA][]
+- fix(java) do not intepret `==` as a variable declaration [Mousetail][]
 - enh(swift) add SE-0335 existential `any` keyword (#3515) [Bradley Mackey][]
 - enh(swift) add support for `distributed` keyword [Marcus Ortiz][]
 - enh(xml) recognize Unicode letters instead of only ASCII letters in XML element and attribute names (#3256)[Martin Honnen][]
@@ -19,6 +20,7 @@ Grammars:
 [Tobias Buschor]: https://github.com/nuxodin/
 [Tim Smith]: https://github.com/timlabs
 [Avrumy Lunger]: https://github.com/vrumger
+[Mousetail]: https://github.com/mousetail
 
 ## Version 11.5.0
 

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -187,7 +187,7 @@ export default function(hljs) {
           /\s+/,
           JAVA_IDENT_RE,
           /\s+/,
-          /=/
+          /=(?!=)/
         ],
         className: {
           1: "type",


### PR DESCRIPTION
I came across a interesting bit of python code that highlight.js thinks is Java:

```
if value == "bob":
    field = "value"
elif value == "charlie"
    field = "value"
return field
```
This seems to be caused by Java thinking it's a type defintion, where `elif` is a type, value is the name of the variable,
and the first `=` afterwards is the assignment. However, in this case it's a `==` which would be invalid Java.

This attempts to fix the issue by disallowing double equals in type definitions in Java.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
