### PR TITLE
Match "::" as comment

### DIFF
--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -8,7 +8,7 @@ Website: https://en.wikipedia.org/wiki/Batch_file
 /** @type LanguageFn */
 export default function(hljs) {
   const COMMENT = hljs.COMMENT(
-    /^\s*@?rem\b/, /$/,
+    /^\s*(@?rem\b|::)/, /$/,
     { relevance: 10 }
   );
   const LABEL = {


### PR DESCRIPTION
Batch files may have have "::" instead of "rem" to mark a line as a comment