### PR TITLE
Fix repo URL

### DIFF
--- a/extra/3RD_PARTY_QUICK_START.md
+++ b/extra/3RD_PARTY_QUICK_START.md
@@ -7,7 +7,7 @@ So you'd like to create and share your own language definition for Highlight.js.
 - [ ] Have a look at some real-life examples first
   - https://github.com/highlightjs/highlightjs-cypher
   - https://github.com/highlightjs/highlightjs-robots-txt
-- [ ] Clone the main [highlight-js](https://github.com/highlightjs/highlightjs) repository from GitHub
+- [ ] Clone the main [highlight-js](https://github.com/highlightjs/highlight.js) repository from GitHub
 - [ ] Read our [Language Contributor Checklist](https://highlightjs.readthedocs.io/en/latest/language-contribution.html)
 - [ ] Review the [Language Definition Guide](https://highlightjs.readthedocs.io/en/latest/language-guide.html)
 - [ ] Start with our [repository template](https://github.com/highlightjs/highlightjs-language-template) to more easily follow the suggested layout. (this isn't ready yet!)


### PR DESCRIPTION
Fix the `highlight.js` repo URL in the 3rd-party quickstart guide.