### PR TITLE
Add COBOL to supported languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Grammars:
 - Use substring() instead of deprecated substr() [Tobias Buschor][]
 - Added 3rd party Oak grammar to SUPPORTED_LANGUAGES [Tim Smith][]
 - enh(python) add `match` and `case` keywords [Avrumy Lunger][]
+- Added 3rd party COBOL grammar to SUPPORTED_LANGUAGES [Gabriel Gonçalves][]
 
 [shikhar13012001]: https://github.com/shikhar13012001
 [Bluecoreg]: https://github.com/Bluecoreg
@@ -41,6 +42,7 @@ Grammars:
 [Tim Smith]: https://github.com/timlabs
 [Avrumy Lunger]: https://github.com/vrumger
 [Mousetail]: https://github.com/mousetail
+[Gabriel Gonçalves]: https://github.com/KTSnowy
 
 ## Version 11.5.0
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -41,6 +41,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | C/AL                    | cal                    |         |
 | Cache Object Script     | cos, cls               |         |
 | CMake                   | cmake, cmake.in        |         |
+| COBOL                   | cobol, standard-cobol   | [highlightjs-cobol](https://github.com/otterkit/highlightjs-cobol) |
 | Coq                     | coq                    |         |
 | CSP                     | csp                    |         |
 | CSS                     | css                    |         |


### PR DESCRIPTION
GitHub repo: https://github.com/otterkit/highlightjs-cobol
NPM: https://www.npmjs.com/package/highlightjs-cobol

CDN links like unpkg.com are also working and I made a codepen to test syntax highlighting:
https://codepen.io/ktsnowy/pen/vYRXxov

### Changes
Added COBOL language and link for the highlightjs-cobol package in the [SUPPORTED_LANGUAGES.md](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`

> Added markup tests

Not yet due to COBOL having a quite large keyword list, but I've been testing it on codepen.
