### PR TITLE
fix(nix) Support escaped dollar sign in strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,12 @@ New Grammars:
 Grammars:
 - fix(js) do not flag `import()` as a function, rather a keyword [nathnolt][]
 - fix(bash) recognize the `((` keyword [Nick Chambers][]
+- fix(nix) support escaped dollar signs in strings [h7x4][]
 
 [Josh Temple]: https://github.com/joshtemple
 [nathnolt]: https://github.com/nathnolt
 [Nick Chambers]: https://github.com/uplime
+[h7x4]: https://github.com/h7x4
 
 ## Version 11.6.0
 

--- a/src/languages/nix.js
+++ b/src/languages/nix.js
@@ -45,6 +45,10 @@ export default function(hljs) {
     end: /\}/,
     keywords: KEYWORDS
   };
+  const ESCAPED_DOLLAR = {
+    className: 'char.escape',
+    begin: /''\$\{/,
+  };
   const ATTRS = {
     begin: /[a-zA-Z0-9-_]+(\s*=)/,
     returnBegin: true,
@@ -59,7 +63,7 @@ export default function(hljs) {
   };
   const STRING = {
     className: 'string',
-    contains: [ ANTIQUOTE ],
+    contains: [ ESCAPED_DOLLAR, ANTIQUOTE ],
     variants: [
       {
         begin: "''",

--- a/src/languages/nix.js
+++ b/src/languages/nix.js
@@ -47,7 +47,7 @@ export default function(hljs) {
   };
   const ESCAPED_DOLLAR = {
     className: 'char.escape',
-    begin: /''\$\{/,
+    begin: /''\$/,
   };
   const ATTRS = {
     begin: /[a-zA-Z0-9-_]+(\s*=)/,

--- a/test/markup/nix/default.expect.txt
+++ b/test/markup/nix/default.expect.txt
@@ -16,6 +16,7 @@
 
   <span class="hljs-attr">postInstall</span> = <span class="hljs-string">&#x27;&#x27;
     <span class="hljs-subst">${ <span class="hljs-keyword">if</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">then</span> <span class="hljs-string">&quot;--<span class="hljs-subst">${test}</span>&quot;</span> <span class="hljs-keyword">else</span> <span class="hljs-literal">false</span> }</span>
+    <span class="hljs-char escape_">&#x27;&#x27;${</span> escaped }
   &#x27;&#x27;</span>;
 
   <span class="hljs-attr">meta</span> = <span class="hljs-keyword">with</span> stdenv.lib; {

--- a/test/markup/nix/default.expect.txt
+++ b/test/markup/nix/default.expect.txt
@@ -16,7 +16,7 @@
 
   <span class="hljs-attr">postInstall</span> = <span class="hljs-string">&#x27;&#x27;
     <span class="hljs-subst">${ <span class="hljs-keyword">if</span> <span class="hljs-literal">true</span> <span class="hljs-keyword">then</span> <span class="hljs-string">&quot;--<span class="hljs-subst">${test}</span>&quot;</span> <span class="hljs-keyword">else</span> <span class="hljs-literal">false</span> }</span>
-    <span class="hljs-char escape_">&#x27;&#x27;${</span> escaped }
+    <span class="hljs-char escape_">&#x27;&#x27;$</span>{ escaped }
   &#x27;&#x27;</span>;
 
   <span class="hljs-attr">meta</span> = <span class="hljs-keyword">with</span> stdenv.lib; {

--- a/test/markup/nix/default.txt
+++ b/test/markup/nix/default.txt
@@ -16,6 +16,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     ${ if true then "--${test}" else false }
+    ''${ escaped }
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added a rule that escapes `''$` in strings.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Resolves #3635

### Checklist

- [X] Added markup tests
- [X] Updated the changelog at `CHANGES.md`
