### PR TITLE
enh(cmake) support bracket comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 New Grammars:
 
-- Added 3rd party LookML grammar to SUPPORTED_LANGUAGES [Josh Temple][]
 - added 3rd party LookML grammar to SUPPORTED_LANGUAGES [Josh Temple][]
 - added 3rd party FunC grammar to SUPPORTED_LANGUAGES [Nikita Sobolev][]
 
@@ -14,12 +13,14 @@ Grammars:
 - fix(js) do not flag `import()` as a function, rather a keyword [nathnolt][]
 - fix(bash) recognize the `((` keyword [Nick Chambers][]
 - fix(nix) support escaped dollar signs in strings [h7x4][]
+- enh(cmake) support bracket comments [Hirse][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Josh Temple]: https://github.com/joshtemple
 [nathnolt]: https://github.com/nathnolt
 [Nick Chambers]: https://github.com/uplime
 [h7x4]: https://github.com/h7x4
+[Hirse]: https://github.com/Hirse
 
 
 ## Version 11.6.0

--- a/src/languages/cmake.js
+++ b/src/languages/cmake.js
@@ -52,6 +52,7 @@ export default function(hljs) {
         begin: /\$\{/,
         end: /\}/
       },
+      hljs.COMMENT(/#\[\[/, /]]/),
       hljs.HASH_COMMENT_MODE,
       hljs.QUOTE_STRING_MODE,
       hljs.NUMBER_MODE

--- a/test/markup/cmake/default.expect.txt
+++ b/test/markup/cmake/default.expect.txt
@@ -17,3 +17,7 @@
 
 <span class="hljs-keyword">add_executable</span>(myproject main.cpp mainwindow.cpp)
 <span class="hljs-keyword">qt5_use_modules</span>(myproject Widgets)
+
+<span class="hljs-comment">#[[This is a bracket comment.
+It runs until the close bracket.]]</span>
+<span class="hljs-keyword">message</span>(<span class="hljs-string">&quot;First Argument\n&quot;</span> <span class="hljs-comment">#[[Bracket Comment]]</span> <span class="hljs-string">&quot;Second Argument&quot;</span>)

--- a/test/markup/cmake/default.txt
+++ b/test/markup/cmake/default.txt
@@ -17,3 +17,7 @@ find_package(Qt5Widgets REQUIRED)
 
 add_executable(myproject main.cpp mainwindow.cpp)
 qt5_use_modules(myproject Widgets)
+
+#[[This is a bracket comment.
+It runs until the close bracket.]]
+message("First Argument\n" #[[Bracket Comment]] "Second Argument")


### PR DESCRIPTION
Resolves #3591

### Changes
Add support for [bracket comments](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#id25).
![image](https://user-images.githubusercontent.com/2564094/197365532-62ab6427-3e76-4dbc-8eff-d4264246182e.png)

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
