### PR TITLE
Add Java 17 permits keyword to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Grammars:
 - fix(bash) recognize the `((` keyword [Nick Chambers][]
 - fix(nix) support escaped dollar signs in strings [h7x4][]
 - enh(cmake) support bracket comments [Hirse][]
+- enh(java) add permits keyword to java [MBoegers][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Josh Temple]: https://github.com/joshtemple
@@ -21,6 +22,7 @@ Grammars:
 [Nick Chambers]: https://github.com/uplime
 [h7x4]: https://github.com/h7x4
 [Hirse]: https://github.com/Hirse
+[MBoegers]: https://github.com/MBoegers
 
 
 ## Version 11.6.0

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -72,7 +72,8 @@ export default function(hljs) {
     'requires',
     'exports',
     'do',
-    'sealed'
+    'sealed',
+    'permits'
   ];
 
   const BUILT_INS = [

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -9,7 +9,7 @@
     }
 }
 
-<span class="hljs-keyword">sealed</span> <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Command</span> permits LoginCommand {
+<span class="hljs-keyword">sealed</span> <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Command</span> <span class="hljs-keyword">permits</span> LoginCommand {
     <span class="hljs-keyword">void</span> <span class="hljs-title function_">run</span><span class="hljs-params">()</span>;
 }
 


### PR DESCRIPTION
Java 17 introduced sealed classes/interfaces with [EP 409: Sealed Classes](https://openjdk.org/jeps/409). The new keywords sealed and non-sealed were present but permits was missing.

Resolves #3646

### Changes
Permits is now a general keyword and the present tests are fixed acordingly.

### Checklist
- [ ] Added markup tests, see test/markup/java/titles.expect.txt
- [ ] Updated the changelog at `CHANGES.md`
