### PR TITLE
Add Java 14 switch expression keyword yield

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Grammars:
 - fix(bash) recognize the `((` keyword [Nick Chambers][]
 - fix(nix) support escaped dollar signs in strings [h7x4][]
 - enh(cmake) support bracket comments [Hirse][]
+- enh(java) add yield keyword to java [MBoegers][]
 
 [Josh Goebel]: https://github.com/joshgoebel
 [Josh Temple]: https://github.com/joshtemple
@@ -21,7 +22,7 @@ Grammars:
 [Nick Chambers]: https://github.com/uplime
 [h7x4]: https://github.com/h7x4
 [Hirse]: https://github.com/Hirse
-
+[MBoegers]: https://github.com/MBoegers
 
 ## Version 11.6.0
 

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -72,7 +72,8 @@ export default function(hljs) {
     'requires',
     'exports',
     'do',
-    'sealed'
+    'sealed',
+    'yield'
   ];
 
   const BUILT_INS = [

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -73,7 +73,7 @@ export default function(hljs) {
     'exports',
     'do',
     'sealed',
-    'yield'
+    'yield',
     'permits'
   ];
 

--- a/test/markup/java/switch.expect.txt
+++ b/test/markup/java/switch.expect.txt
@@ -1,0 +1,13 @@
+<span class="hljs-keyword">switch</span>(a) {
+ <span class="hljs-keyword">case</span> <span class="hljs-literal">null</span> -&gt; <span class="hljs-keyword">yield</span> <span class="hljs-string">&quot;n&quot;</span>;
+ <span class="hljs-keyword">case</span> String s -&gt; <span class="hljs-keyword">yield</span> <span class="hljs-string">&quot;s&quot;</span>;
+ <span class="hljs-keyword">case</span> Object o -&gt; <span class="hljs-keyword">yield</span> <span class="hljs-string">&quot;o&quot;</span>;
+ <span class="hljs-keyword">default</span>: <span class="hljs-keyword">yield</span> <span class="hljs-string">&quot;d&quot;</span>,
+}
+
+<span class="hljs-keyword">switch</span>(a) {
+ <span class="hljs-keyword">case</span> <span class="hljs-literal">null</span>: <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;n&quot;</span>;
+ <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;s&quot;</span>: <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;s&quot;</span>;
+ <span class="hljs-keyword">case</span> <span class="hljs-string">&quot;o&quot;</span>: <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;o&quot;</span>;
+ <span class="hljs-keyword">default</span>: <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;d&quot;</span>;
+}

--- a/test/markup/java/switch.txt
+++ b/test/markup/java/switch.txt
@@ -1,0 +1,13 @@
+switch(a) {
+ case null -> yield "n";
+ case String s -> yield "s";
+ case Object o -> yield "o";
+ default: yield "d",
+}
+
+switch(a) {
+ case null: return "n";
+ case "s": return "s";
+ case "o": return "o";
+ default: return "d";
+}


### PR DESCRIPTION
Java 14 introduced with [JEP 361: Switch Expressions](https://openjdk.org/jeps/361) a new keyword yield.

Resolves #3647

### Changes
yield is now a keyword, a new test for switches are added

### Checklist
- [x] Added markup tests, see test/markup/java/switch.expect.txt
- [x] Updated the changelog at `CHANGES.md`
