### PR TITLE
(docs) Add tsx alias

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -213,7 +213,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | TP                      | tp                     |         |
 | Transact-SQL            | tsql                   | [highlightjs-tsql](https://github.com/highlightjs/highlightjs-tsql) |
 | Twig                    | twig, craftcms         |         |
-| TypeScript              | typescript, ts         |         |
+| TypeScript              | typescript, ts, tsx    |         |
 | Unicorn Rails log       | unicorn-rails-log      | [highlightjs-unicorn-rails-log](https://github.com/sweetppro/highlightjs-unicorn-rails-log) |
 | VB.Net                  | vbnet, vb              |         |
 | VBA                     | vba                    | [highlightjs-vba](https://github.com/dullin/highlightjs-vba) |


### PR DESCRIPTION
`tsx` alias for TypeScript was not added to SUPPORTED_LANGUAGES.md in #3015, this fix it.

### Changes
Add `tsx` alias for TypeScript to SUPPORTED_LANGUAGES.md.

### Checklist
This is just a small update SUPPORTED_LANGUAGES.md.

- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
