### PR TITLE
Make our language metadata parsing stricter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ Grammars:
 - enh(java) add yield keyword to java [MBoegers][]
 - enh(java) add permits keyword to java [MBoegers][]
 
+Developer Tools:
+
+- (fix) make metadata parsing less fragile and prone to error [Vladimir Jimenez]
+
 [Josh Goebel]: https://github.com/joshgoebel
 [Josh Temple]: https://github.com/joshtemple
 [nathnolt]: https://github.com/nathnolt
@@ -26,6 +30,7 @@ Grammars:
 [Hirse]: https://github.com/Hirse
 [The Flix Organisation]: https://github.com/flix
 [MBoegers]: https://github.com/MBoegers
+[Vladimir Jimenez]: https://github.com/allejo
 
 ## Version 11.6.0
 

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -5,9 +5,9 @@ const path = require("path");
 const build_config = require("../build_config.js");
 
 const packageJSON = require("../../package.json");
-const REQUIRES_REGEX = /\/\*.*?Requires: (.*?)\r?\n/s;
-const CATEGORY_REGEX = /\/\*.*?Category: (.*?)\r?\n/s;
-const LANGUAGE_REGEX = /\/\*.*?Language: (.*?)\r?\n/s;
+const REQUIRES_REGEX = /^Requires: (.+?)$/m;
+const CATEGORY_REGEX = /^Category: (.+?)$/m;
+const LANGUAGE_REGEX = /^Language: (.+?)$/m;
 const { rollupCode } = require("./bundling.js");
 const { getThirdPartyPackages } = require("./external_language.js");
 


### PR DESCRIPTION
Reported by @razetime on Discord, when a language's metadata contains an empty "Requires", it will cause this cryptic error to surface:

```
$ node tools/build.js -t node
Starting build.
Finished build.
Writing styles.
/home/razetime/Documents/Code/gen/highlight.js/tools/build_node.js:184
  const common = languages.filter(l => l.categories.includes("common"));
                                         ^

TypeError: Cannot read properties of undefined (reading 'categories')
    at /home/razetime/Documents/Code/gen/highlight.js/tools/build_node.js:184:42
    at Array.filter (<anonymous>)
    at Object.buildNode [as build] (/home/razetime/Documents/Code/gen/highlight.js/tools/build_node.js:184:28)
    at async doTarget (/home/razetime/Documents/Code/gen/highlight.js/tools/build.js:90:3)
```

The cause of this problem is that our regex for parsing the metadata end up with incorrect data at times. For example, when given `Requires: ` it will end up parsing the body as `""` which later ends up evaluating to "undefined" when being mapped as a language.

### Changes

I changed the regex to be a bit more specific when looking at metadata fields and expecting there to be a value there and not just default to an empty string.

### Checklist

- [ ] ~~Added markup tests~~ No functional or grammar changes
- [x] Updated the changelog at `CHANGES.md`