### PR TITLE
More Scala 3 soft keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,8 +28,7 @@ Grammars:
 - enh(java) add yield keyword to java [MBoegers][]
 - enh(java) add permits keyword to java [MBoegers][]
 - fix(javascript/typescript) correct identifier matching when using numbers [Lachlan Heywood][]
-- enh(scala) add Scala 3 `derives` soft keyword [Jisoo Park][]
-- enh(scala) add Scala 3 soft modifiers (`infix`, `opaque`, `open`) [Jisoo Park][]
+- enh(scala) add Scala 3 soft keywords (`derives`, `infix`, `opaque`, `open`, and `as`) [Jisoo Park][]
 
 Improvements:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Grammars:
 - enh(java) add yield keyword to java [MBoegers][]
 - enh(java) add permits keyword to java [MBoegers][]
 - fix(javascript/typescript) correct identifier matching when using numbers [Lachlan Heywood][]
+- enh(scala) add Scala 3 `derives` soft keyword [Jisoo Park][]
 
 Improvements:
 
@@ -45,7 +46,7 @@ Improvements:
 [Lachlan Heywood]: https://github.com/lachieh
 [Eddymens]: https://github.com/eddymens
 [Sopitive]: https://github.com/Sopitive
-
+[Jisoo Park]: https://github.com/guersam
 
 ## Version 11.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Grammars:
 - enh(java) add permits keyword to java [MBoegers][]
 - fix(javascript/typescript) correct identifier matching when using numbers [Lachlan Heywood][]
 - enh(scala) add Scala 3 `derives` soft keyword [Jisoo Park][]
+- enh(scala) add Scala 3 soft modifiers (`infix`, `opaque`, `open`) [Jisoo Park][]
 
 Improvements:
 

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -137,6 +137,25 @@ export default function(hljs) {
     }
   };
 
+  const IMPORT_EXPORT = {
+    beginKeywords: 'import export',
+    end: /[;\n]/,
+    excludeEnd: true,
+    contains: [
+      { beginKeywords: 'as' },
+      {
+        begin: '{',
+        end: '}',
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: [
+          TYPE,
+          { beginKeywords: 'as' },
+        ]
+      }
+    ],
+  };
+
   // TODO: use negative look-behind in future
   //       /(?<!\.)\binline(?=\s)/
   const INLINE_MODES = [
@@ -184,6 +203,7 @@ export default function(hljs) {
       hljs.C_NUMBER_MODE,
       EXTENSION,
       END,
+      IMPORT_EXPORT,
       ...INLINE_MODES,
       USING_PARAM_CLAUSE,
       ANNOTATION,

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -72,7 +72,7 @@ export default function(hljs) {
 
   const CLASS = {
     className: 'class',
-    beginKeywords: 'class object trait type',
+    beginKeywords: 'class object trait type enum',
     end: /[:={\[\n;]/,
     excludeEnd: true,
     contains: [
@@ -80,6 +80,11 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE,
       {
         beginKeywords: 'extends with',
+        relevance: 10
+      },
+      {
+        beginKeywords: 'derives',
+        contains: [ TYPE ],
         relevance: 10
       },
       {
@@ -99,7 +104,7 @@ export default function(hljs) {
         relevance: 0,
         contains: [ TYPE ]
       },
-      NAME
+      NAME,
     ]
   };
 

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -156,11 +156,23 @@ export default function(hljs) {
     beginScope: { 2: "keyword", }
   };
 
+  const SOFT_MODIFIER = {
+    begin: [
+      /\b(?<!\.)(infix|inline|opaque|open|transparent)\b/,
+      /\s+/,
+      /(?=object|def|val|var|type|given|class|trait|object|enum|case class|case object|infix|inline|opaque|open|transparent)/,
+    ],
+    beginScope: {
+      1: 'keyword',
+    },
+    contains: [ 'self' ],
+  };
+
   return {
     name: 'Scala',
     keywords: {
       literal: 'true false null',
-      keyword: 'type yield lazy override def with val var sealed abstract private trait object if then forSome for while do throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit export enum given transparent'
+      keyword: 'type yield lazy override def with val var sealed abstract private trait object if then forSome for while do throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit export enum given'
     },
     contains: [
       hljs.C_LINE_COMMENT_MODE,
@@ -174,7 +186,8 @@ export default function(hljs) {
       END,
       ...INLINE_MODES,
       USING_PARAM_CLAUSE,
-      ANNOTATION
+      ANNOTATION,
+      SOFT_MODIFIER,
     ]
   };
 }

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -84,7 +84,6 @@ export default function(hljs) {
       },
       {
         beginKeywords: 'derives',
-        contains: [ TYPE ],
       },
       {
         begin: /\[/,
@@ -139,14 +138,11 @@ export default function(hljs) {
   const IMPORT_EXPORT = {
     beginKeywords: 'import export',
     end: /[;\n]/,
-    excludeEnd: true,
     contains: [
       { beginKeywords: 'as' },
       {
         begin: '{',
         end: '}',
-        excludeBegin: true,
-        excludeEnd: true,
         contains: [
           TYPE,
           { beginKeywords: 'as' },

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -174,17 +174,18 @@ export default function(hljs) {
     beginScope: { 2: "keyword", }
   };
 
-  const SOFT_MODIFIER = {
-    begin: [
-      /(?=^|;)\s*/,
-      /\b(infix|inline|opaque|open|transparent)\b/,
+  const SOFT_MODIFIERS = [ 'infix', 'inline', 'opaque', 'open', 'transparent' ];
+  const SOFT_MODIFIER_RE = regex.either(...SOFT_MODIFIERS);
+
+  const SOFT_MODIFIER_MODE = {
+    begin: regex.concat(
+      /(^|;)\s*/,
+      SOFT_MODIFIER_RE,
       /\s+/,
-      /(?=object|def|val|var|type|given|class|trait|object|enum|case class|case object|infix|inline|opaque|open|transparent)/,
-    ],
-    beginScope: {
-      2: 'keyword',
-    },
-    contains: [ 'self' ],
+      regex.anyNumberOfTimes(regex.concat(SOFT_MODIFIER_RE, /\s+/)),
+      regex.lookahead(/(object|def|val|var|type|given|class|trait|object|enum|case class|case object)/),
+    ),
+    keywords: SOFT_MODIFIERS,
   };
 
   return {
@@ -207,7 +208,7 @@ export default function(hljs) {
       ...INLINE_MODES,
       USING_PARAM_CLAUSE,
       ANNOTATION,
-      SOFT_MODIFIER,
+      SOFT_MODIFIER_MODE,
     ]
   };
 }

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -85,7 +85,6 @@ export default function(hljs) {
       {
         beginKeywords: 'derives',
         contains: [ TYPE ],
-        relevance: 10
       },
       {
         begin: /\[/,

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -176,12 +176,13 @@ export default function(hljs) {
 
   const SOFT_MODIFIER = {
     begin: [
-      /\b(?<!\.)(infix|inline|opaque|open|transparent)\b/,
+      /(?=^|;)\s*/,
+      /\b(infix|inline|opaque|open|transparent)\b/,
       /\s+/,
       /(?=object|def|val|var|type|given|class|trait|object|enum|case class|case object|infix|inline|opaque|open|transparent)/,
     ],
     beginScope: {
-      1: 'keyword',
+      2: 'keyword',
     },
     contains: [ 'self' ],
   };

--- a/test/markup/scala/case-classes.expect.txt
+++ b/test/markup/scala/case-classes.expect.txt
@@ -1,3 +1,6 @@
 <span class="hljs-keyword">abstract</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Vertical</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">CaseJeu</span></span>
 <span class="hljs-keyword">case</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Haut</span>(<span class="hljs-params">name: <span class="hljs-type">String</span></span>) <span class="hljs-keyword">extends</span> <span class="hljs-title">Vertical</span></span>
 <span class="hljs-keyword">case</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Bas</span>(<span class="hljs-params">name: <span class="hljs-type">String</span></span>) <span class="hljs-keyword">extends</span> <span class="hljs-title">Vertical</span></span>
+
+<span class="hljs-keyword">case</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span> <span class="hljs-keyword">derives</span> <span class="hljs-title">Eq</span></span>
+<span class="hljs-keyword">val</span> derives = <span class="hljs-number">1</span>

--- a/test/markup/scala/case-classes.txt
+++ b/test/markup/scala/case-classes.txt
@@ -1,3 +1,6 @@
 abstract class Vertical extends CaseJeu
 case class Haut(name: String) extends Vertical
 case class Bas(name: String) extends Vertical
+
+case class Foo derives Eq
+val derives = 1

--- a/test/markup/scala/enum.expect.txt
+++ b/test/markup/scala/enum.expect.txt
@@ -1,6 +1,10 @@
-<span class="hljs-keyword">enum</span> <span class="hljs-type">Color</span>:
+<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-title">Color</span></span>:
   <span class="hljs-keyword">case</span> <span class="hljs-type">Red</span>, <span class="hljs-type">Green</span>, <span class="hljs-type">Blue</span>
 
-<span class="hljs-keyword">enum</span> <span class="hljs-type">State</span>:
+<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-title">State</span></span>:
   <span class="hljs-keyword">case</span> <span class="hljs-type">On</span>
   <span class="hljs-keyword">case</span> <span class="hljs-type">Off</span>
+
+<span class="hljs-class"><span class="hljs-keyword">enum</span> <span class="hljs-title">Tree</span>[<span class="hljs-type">T</span>] <span class="hljs-keyword">derives</span> <span class="hljs-title">Eq</span>, <span class="hljs-title">Show</span></span>:
+  <span class="hljs-keyword">case</span> <span class="hljs-type">Branch</span>(left: <span class="hljs-type">Tree</span>[<span class="hljs-type">T</span>], right: <span class="hljs-type">Tree</span>[<span class="hljs-type">T</span>])
+  <span class="hljs-keyword">case</span> <span class="hljs-type">Leaf</span>(elem: <span class="hljs-type">T</span>)

--- a/test/markup/scala/enum.txt
+++ b/test/markup/scala/enum.txt
@@ -4,3 +4,7 @@ enum Color:
 enum State:
   case On
   case Off
+
+enum Tree[T] derives Eq, Show:
+  case Branch(left: Tree[T], right: Tree[T])
+  case Leaf(elem: T)

--- a/test/markup/scala/export.expect.txt
+++ b/test/markup/scala/export.expect.txt
@@ -1,2 +1,0 @@
-<span class="hljs-keyword">export</span> scanUnit.scan
-<span class="hljs-keyword">export</span> printUnit.{status =&gt; _, *}

--- a/test/markup/scala/export.txt
+++ b/test/markup/scala/export.txt
@@ -1,2 +1,0 @@
-export scanUnit.scan
-export printUnit.{status => _, *}

--- a/test/markup/scala/import-export.expect.txt
+++ b/test/markup/scala/import-export.expect.txt
@@ -1,0 +1,16 @@
+<span class="hljs-keyword">import</span> scanUnit.scan
+<span class="hljs-keyword">import</span> printUnit.{status =&gt; _, *}
+
+<span class="hljs-keyword">import</span> foo <span class="hljs-keyword">as</span> bar
+<span class="hljs-keyword">import</span> foo.{bar <span class="hljs-keyword">as</span> baz, *}
+
+<span class="hljs-keyword">export</span> scanUnit.scan
+<span class="hljs-keyword">export</span> printUnit.{status =&gt; _, *}
+
+<span class="hljs-keyword">export</span> foo <span class="hljs-keyword">as</span> bar
+<span class="hljs-keyword">export</span> foo.{
+  <span class="hljs-type">Bar</span>,
+  bar <span class="hljs-keyword">as</span> baz
+}
+
+<span class="hljs-keyword">val</span> as = <span class="hljs-number">1</span>

--- a/test/markup/scala/import-export.txt
+++ b/test/markup/scala/import-export.txt
@@ -1,0 +1,16 @@
+import scanUnit.scan
+import printUnit.{status => _, *}
+
+import foo as bar
+import foo.{bar as baz, *}
+
+export scanUnit.scan
+export printUnit.{status => _, *}
+
+export foo as bar
+export foo.{
+  Bar,
+  bar as baz
+}
+
+val as = 1

--- a/test/markup/scala/soft-modifiers.expect.txt
+++ b/test/markup/scala/soft-modifiers.expect.txt
@@ -1,0 +1,16 @@
+<span class="hljs-keyword">infix</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">+</span></span>(that: <span class="hljs-type">Int</span>) = ???
+a.infix == b.infix
+
+<span class="hljs-keyword">opaque</span> <span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-title">MyInt</span> </span>= <span class="hljs-type">Int</span>
+c opaque d
+
+<span class="hljs-keyword">open</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">A</span></span>
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">open</span> </span>= <span class="hljs-number">1</span>
+
+<span class="hljs-keyword">transparent</span> <span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>() = <span class="hljs-number">42</span>
+<span class="hljs-keyword">transparent</span> <span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">S</span></span>
+
+<span class="hljs-keyword">val</span> transparent = <span class="hljs-number">43</span>
+
+<span class="hljs-keyword">transparent</span>
+<span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">T</span></span>

--- a/test/markup/scala/soft-modifiers.expect.txt
+++ b/test/markup/scala/soft-modifiers.expect.txt
@@ -14,3 +14,5 @@ c opaque d
 
 <span class="hljs-keyword">transparent</span>
 <span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">T</span></span>
+
+<span class="hljs-keyword">transparent</span> <span class="hljs-keyword">infix</span> <span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">g</span></span>(a: <span class="hljs-type">Int</span>) = <span class="hljs-number">42</span>

--- a/test/markup/scala/soft-modifiers.txt
+++ b/test/markup/scala/soft-modifiers.txt
@@ -14,3 +14,5 @@ val transparent = 43
 
 transparent
 trait T
+
+transparent infix inline def g(a: Int) = 42

--- a/test/markup/scala/soft-modifiers.txt
+++ b/test/markup/scala/soft-modifiers.txt
@@ -1,0 +1,16 @@
+infix def +(that: Int) = ???
+a.infix == b.infix
+
+opaque type MyInt = Int
+c opaque d
+
+open class A
+def open = 1
+
+transparent inline def f() = 42
+transparent trait S
+
+val transparent = 43
+
+transparent
+trait T

--- a/test/markup/scala/transparent.expect.txt
+++ b/test/markup/scala/transparent.expect.txt
@@ -1,2 +1,0 @@
-<span class="hljs-keyword">transparent</span> <span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">f</span></span>() = <span class="hljs-number">42</span>
-<span class="hljs-keyword">transparent</span> <span class="hljs-class"><span class="hljs-keyword">trait</span> <span class="hljs-title">S</span></span>

--- a/test/markup/scala/transparent.txt
+++ b/test/markup/scala/transparent.txt
@@ -1,2 +1,0 @@
-transparent inline def f() = 42
-transparent trait S


### PR DESCRIPTION
### Changes
- add Scala 3 `derives` soft keyword
- add missing Scala 3 soft modifiers (`infix`, `opaque`, `open`)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
