### PR TITLE
Fixed a documentation typo 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ Grammars:
 - enh(java) add permits keyword to java [MBoegers][]
 - fix(javascript/typescript) correct identifier matching when using numbers [Lachlan Heywood][]
 
+Improvements:
+
+- Documentation typo fix by [Eddymens][]
+
 [matyklug18]: https://github.com/matyklug18
 [Josh Goebel]: https://github.com/joshgoebel
 [Josh Temple]: https://github.com/joshtemple
@@ -29,6 +33,7 @@ Grammars:
 [The Flix Organisation]: https://github.com/flix
 [MBoegers]: https://github.com/MBoegers
 [Lachlan Heywood]: https://github.com/lachieh
+[Eddymens]: https://github.com/eddymens
 
 ## Version 11.6.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,7 @@ highlight
 Core highlighting function.  Accepts the code to highlight (string) and a list of options (object).
 The ``language`` parameter must be present and specify the language name or alias
 of the grammar to be used for highlighting.
-The ``ignoreIllegals`` is an optional parameter than when true forces highlighting
+The ``ignoreIllegals`` is an optional parameter that when ``true`` forces highlighting
 to finish even in case of detecting illegal syntax for the
 language instead of throwing an exception.
 


### PR DESCRIPTION
### Changes
Fixed typo in the sentence describing the `ignoreIllegals` parameter used in the `highlight()` method.

### Checklist
- [x] They don't apply here because it's a doc fix
- [x] Updated the changelog at `CHANGES.md`
