### PR TITLE
add subLanguage support to markdown

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -21,17 +21,19 @@ export default function(hljs) {
   const CODE = {
     className: 'code',
     variants: [
-      // TODO: fix to allow these to work with sublanguage also
-      { begin: '(`{3,})[^`](.|\\n)*?\\1`*[ ]*' },
-      { begin: '(~{3,})[^~](.|\\n)*?\\1~*[ ]*' },
-      // needed to allow markdown as a sublanguage to work
       {
-        begin: '```',
-        end: '```+[ ]*$'
+        begin: '```[a-z0-9]*',
+        end: '```+[ ]*$',
+        excludeBegin: true,
+        excludeEnd: true,
+        subLanguage: []
       },
       {
-        begin: '~~~',
-        end: '~~~+[ ]*$'
+        begin: '~~~[a-z0-9]*',
+        end: '~~~+[ ]*$',
+        excludeBegin: true,
+        excludeEnd: true,
+        subLanguage: []
       },
       { begin: '`.+?`' },
       {

--- a/test/detect/markdown/withCodeBlock.txt
+++ b/test/detect/markdown/withCodeBlock.txt
@@ -1,0 +1,9 @@
+# Hello World
+
+```js
+console.log("just because there's a code block doesn't mean it's a js file");
+
+for (let i=0; i < 10; i++) {
+	console.log(i);
+}
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In addition to the subLanguage attribute, there are also a significant number of markdown tokens without a relevance value. Should that also be changed?

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

This adds subLanguage configurations to \`\`\` and \~\~\~ in the markdown language config, allowing markdown files with a significant portion of content in code blocks to be recognized as markdown.

<!--- Describe your changes -->

### Checklist
- [x] Added markup tests, or they don't apply here because... tests for markup are already covered
- [ ] Updated the changelog at `CHANGES.md`
