### PR TITLE
Add sessionStorage as built-in variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 11.8.0
+
+Grammars:
+
+- enh(javascript) add sessionStorage to list of built-in variables [Jeroen van Vianen][]
+
+[Jeroen van Vianen]: https://github.com/morinel
+
 ## Version 11.7.0
 
 New Grammars:

--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -145,6 +145,7 @@ export const BUILT_IN_VARIABLES = [
   "window",
   "document",
   "localStorage",
+  "sessionStorage",
   "module",
   "global" // Node.js
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add sessionStorage as a built-in variable to javascript, just like localStorage

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3667 

### Changes
Added sessionStorage as built-in variable

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
