### PR TITLE
PHP Comments inside function invoke & declaration

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -484,7 +484,7 @@ export default function(hljs) {
     contains: [
       ATTRIBUTES,
       hljs.HASH_COMMENT_MODE,
-      hljs.COMMENT('//', '$'),
+      hljs.C_LINE_COMMENT_MODE,
       hljs.COMMENT(
         '/\\*',
         '\\*/',

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -411,6 +411,8 @@ export default function(hljs) {
       VARIABLE,
       LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
       hljs.C_BLOCK_COMMENT_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
       STRING,
       NUMBER,
       CONSTRUCTOR_CALL,
@@ -528,6 +530,7 @@ export default function(hljs) {
         },
       },
       CONSTRUCTOR_CALL,
+      // FUNCTION DECLARATION
       {
         scope: 'function',
         relevance: 0,
@@ -554,6 +557,8 @@ export default function(hljs) {
               VARIABLE,
               LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
               hljs.C_BLOCK_COMMENT_MODE,
+              hljs.C_LINE_COMMENT_MODE,
+              hljs.HASH_COMMENT_MODE,
               STRING,
               NUMBER
             ]

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -433,6 +433,41 @@ export default function(hljs) {
   };
   PARAMS_MODE.contains.push(FUNCTION_INVOKE);
 
+  const FUNCTION_DECLARATION = {
+    scope: 'function',
+    relevance: 0,
+    beginKeywords: 'fn function',
+    end: /[;{]/,
+    excludeEnd: true,
+    illegal: '[$%\\[]',
+    contains: [
+      { beginKeywords: 'use', },
+      hljs.UNDERSCORE_TITLE_MODE,
+      {
+        begin: '=>', // No markup, just a relevance booster
+        endsParent: true
+      },
+      {
+        scope: 'params',
+        begin: '\\(',
+        end: '\\)',
+        excludeBegin: true,
+        excludeEnd: true,
+        keywords: KEYWORDS,
+        contains: [
+          'self',
+          VARIABLE,
+          LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
+          hljs.C_BLOCK_COMMENT_MODE,
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.HASH_COMMENT_MODE,
+          STRING,
+          NUMBER
+        ]
+      },
+    ]
+  };
+
   const ATTRIBUTE_CONTAINS = [
     NAMED_ARGUMENT,
     LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
@@ -530,41 +565,7 @@ export default function(hljs) {
         },
       },
       CONSTRUCTOR_CALL,
-      // FUNCTION DECLARATION
-      {
-        scope: 'function',
-        relevance: 0,
-        beginKeywords: 'fn function',
-        end: /[;{]/,
-        excludeEnd: true,
-        illegal: '[$%\\[]',
-        contains: [
-          { beginKeywords: 'use', },
-          hljs.UNDERSCORE_TITLE_MODE,
-          {
-            begin: '=>', // No markup, just a relevance booster
-            endsParent: true
-          },
-          {
-            scope: 'params',
-            begin: '\\(',
-            end: '\\)',
-            excludeBegin: true,
-            excludeEnd: true,
-            keywords: KEYWORDS,
-            contains: [
-              'self',
-              VARIABLE,
-              LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
-              hljs.C_BLOCK_COMMENT_MODE,
-              hljs.C_LINE_COMMENT_MODE,
-              hljs.HASH_COMMENT_MODE,
-              STRING,
-              NUMBER
-            ]
-          },
-        ]
-      },
+      FUNCTION_DECLARATION,
       {
         scope: 'class',
         variants: [

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -49,3 +49,29 @@
     <span class="hljs-attr">label</span>: <span class="hljs-string">&#x27;foo&#x27;</span>,
     <span class="hljs-attr">time</span>:<span class="hljs-title function_ invoke__">time</span>() + <span class="hljs-keyword">array</span>(<span class="hljs-number">5</span>)[<span class="hljs-number">0</span>] + <span class="hljs-title class_">Foo</span>::<span class="hljs-variable constant_">HOUR</span>,
 );
+
+<span class="hljs-comment">/**
+ * Comments inside function declaration
+ */</span>
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">foo</span>(<span class="hljs-params">
+    <span class="hljs-comment">// line comment</span>
+    <span class="hljs-variable">$foo</span>,
+    <span class="hljs-comment">/* block comment */</span>
+    <span class="hljs-variable">$bar</span> = <span class="hljs-string">&#x27;str//foo&#x27;</span>,
+    <span class="hljs-comment"># hash comment</span>
+    <span class="hljs-variable">$yoo</span> = <span class="hljs-number">123</span>
+</span>)</span>{
+    <span class="hljs-keyword">return</span> <span class="hljs-string">&#x27;&#x27;</span>;
+}
+
+<span class="hljs-comment">/**
+ * Comments inside function invoke
+ */</span>
+<span class="hljs-title function_ invoke__">foo</span>(
+    <span class="hljs-string">&#x27;string&#x27;</span>,
+    [
+        <span class="hljs-comment"># hash comment</span>
+        <span class="hljs-comment">// line comment</span>
+        <span class="hljs-comment">/* block comment */</span>
+    ]
+);

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -49,3 +49,29 @@ setAlarm(
     label: 'foo',
     time:time() + array(5)[0] + Foo::HOUR,
 );
+
+/**
+ * Comments inside function declaration
+ */
+function foo(
+    // line comment
+    $foo,
+    /* block comment */
+    $bar = 'str//foo',
+    # hash comment
+    $yoo = 123
+){
+    return '';
+}
+
+/**
+ * Comments inside function invoke
+ */
+foo(
+    'string',
+    [
+        # hash comment
+        // line comment
+        /* block comment */
+    ]
+);


### PR DESCRIPTION
PHP language not supported php comments inside function invoke and function declaration.

### Changes
Added:
`hljs.C_LINE_COMMENT_MODE`
`hljs.HASH_COMMENT_MODE`

Was:
![image](https://user-images.githubusercontent.com/15121552/208270574-f4be01ec-dd9a-4ca0-8b5f-cf9fb18712a4.png)

Become:
![image](https://user-images.githubusercontent.com/15121552/208270558-4bd22558-b58f-419b-a540-e2ca88053b4a.png)



### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
