### PR TITLE
enh(http) Allow arbitrary protocol versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,10 @@ New Grammars:
 Grammars:
 
 - enh(javascript) add sessionStorage to list of built-in variables [Jeroen van Vianen][]
+- enh(http) Add support for HTTP/3 [Rijenkii][]
 
 [Jeroen van Vianen]: https://github.com/morinel
+[Rijenkii]: https://github.com/rijenkii
 
 ## Version 11.7.0
 

--- a/src/languages/http.js
+++ b/src/languages/http.js
@@ -8,7 +8,7 @@ Website: https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview
 
 export default function(hljs) {
   const regex = hljs.regex;
-  const VERSION = 'HTTP/(2|1\\.[01])';
+  const VERSION = 'HTTP/([32]|1\\.[01])';
   const HEADER_NAME = /[A-Za-z][A-Za-z0-9-]*/;
   const HEADER = {
     className: 'attribute',

--- a/test/markup/http/http3.expect.txt
+++ b/test/markup/http/http3.expect.txt
@@ -1,0 +1,13 @@
+<span class="hljs-meta">HTTP/3</span> <span class="hljs-number">200</span>
+<span class="hljs-attribute">content-encoding</span><span class="hljs-punctuation">: </span>gzip
+<span class="hljs-attribute">accept-ranges</span><span class="hljs-punctuation">: </span>bytes
+<span class="hljs-attribute">age</span><span class="hljs-punctuation">: </span>361798
+<span class="hljs-attribute">cache-control</span><span class="hljs-punctuation">: </span>max-age=604800
+<span class="hljs-attribute">content-type</span><span class="hljs-punctuation">: </span>text/html; charset=UTF-8
+<span class="hljs-attribute">date</span><span class="hljs-punctuation">: </span>Sat, 21 Jan 2023 12:31:21 GMT
+<span class="hljs-attribute">etag</span><span class="hljs-punctuation">: </span>&quot;3147526947+ident&quot;
+<span class="hljs-attribute">expires</span><span class="hljs-punctuation">: </span>Sat, 28 Jan 2023 12:31:21 GMT
+<span class="hljs-attribute">last-modified</span><span class="hljs-punctuation">: </span>Thu, 17 Oct 2019 07:18:26 GMT
+<span class="hljs-attribute">server</span><span class="hljs-punctuation">: </span>ECS (dcb/7ECB)
+<span class="hljs-attribute">x-cache</span><span class="hljs-punctuation">: </span>HIT
+<span class="hljs-attribute">content-length</span><span class="hljs-punctuation">: </span>648

--- a/test/markup/http/http3.txt
+++ b/test/markup/http/http3.txt
@@ -1,0 +1,13 @@
+HTTP/3 200
+content-encoding: gzip
+accept-ranges: bytes
+age: 361798
+cache-control: max-age=604800
+content-type: text/html; charset=UTF-8
+date: Sat, 21 Jan 2023 12:31:21 GMT
+etag: "3147526947+ident"
+expires: Sat, 28 Jan 2023 12:31:21 GMT
+last-modified: Thu, 17 Oct 2019 07:18:26 GMT
+server: ECS (dcb/7ECB)
+x-cache: HIT
+content-length: 648


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
According to [RFC 2616 § 3.1](https://www.rfc-editor.org/rfc/rfc2616#section-3.1), `HTTP-Version` is defined as
```abnf
HTTP-Version = "HTTP" "/" 1*DIGIT "." 1*DIGIT
```
So, at least one digit in major and minor version.
And, according to [RFC 9114 § 4.3.1-4.3.2](https://www.rfc-editor.org/rfc/rfc9114.html#name-request-pseudo-header-field), HTTP/3 requests and responses implicitly have a protocol version of "3.0".

However, `curl` for instance in addition to `HTTP/1.0` and `HTTP/1.1` outputs versions `HTTP/2` and `HTTP/3`, without the minor version.

This pull request makes all current and future versions of HTTP protocol compatible, with and without the minor version.

This also allows to write `HTTP/0`, e.g. if I really do not care about the protocol version in my code block.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`

### PS

Why is there a 11.9.0 in the `CHANGES.md`? Latest released version is 11.7.0.