### PR TITLE
fix(typescript) add `mts` and `cts` aliases

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -217,7 +217,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | TP                      | tp                     |         |
 | Transact-SQL            | tsql                   | [highlightjs-tsql](https://github.com/highlightjs/highlightjs-tsql) |
 | Twig                    | twig, craftcms         |         |
-| TypeScript              | typescript, ts, tsx    |         |
+| TypeScript              | typescript, ts, tsx, mts, cts |         |
 | Unicorn Rails log       | unicorn-rails-log      | [highlightjs-unicorn-rails-log](https://github.com/sweetppro/highlightjs-unicorn-rails-log) |
 | VB.Net                  | vbnet, vb              |         |
 | VBA                     | vba                    | [highlightjs-vba](https://github.com/dullin/highlightjs-vba) |

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -105,7 +105,9 @@ export default function(hljs) {
     name: 'TypeScript',
     aliases: [
       'ts',
-      'tsx'
+      'tsx',
+      'mts',
+      'cts'
     ]
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Adds `mts` and `cts` aliases for the new supported module type specific extensions: https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`

Did not add tests as I don't think they apply to such a trivial change. Also I didn't update `CHANGES.md`. Not sure what the process is for that, to me it looks like it's automated somehow?

Closes #3706 
