### PR TITLE
Add operators to Elixir

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -223,6 +223,10 @@ export default function(hljs) {
       })
     ]
   };
+  const OPERATOR = {
+    scope: 'operator',
+    begin: /([-\|<]>)|(([\+\-\&\|]){2})|(<>)|([<>]=?)|([!=]==?)/,
+  };
   const CLASS = hljs.inherit(FUNCTION, {
     className: 'class',
     beginKeywords: 'defimpl defmodule defprotocol defrecord',
@@ -236,6 +240,7 @@ export default function(hljs) {
     hljs.HASH_COMMENT_MODE,
     CLASS,
     FUNCTION,
+    OPERATOR,
     { begin: '::' },
     {
       className: 'symbol',


### PR DESCRIPTION
What it says on the tin: this adds support for `|>`, `->`, comparison, and array operators in Elixir. These are currently not highlit and I'm not sure if there's precedent for doing so, but the documentation indicates that this category exists so I assume it's there to be used.

I am not making any other changes in this PR, but I do notice that it uses `className` instead of `scope`; would you be interested in a separate PR that brings the Elixir language definition up to the v11 API?