### PR TITLE
Add Motoko and Candid to supported languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,14 @@ Grammars:
 - enh(js/ts) Added support for GraphQL tagged template strings [Ali Ukani][]
 - enh(javascript) add sessionStorage to list of built-in variables [Jeroen van Vianen][]
 - enh(http) Add support for HTTP/3 [Rijenkii][]
+- added 3rd party Motoko grammar to SUPPORTED_LANGUAGES [rvanasa][]
+- added 3rd party Candid grammar to SUPPORTED_LANGUAGES [rvanasa][]
 
 [AdamRaichu]: https://github.com/AdamRaichu
 [Ali Ukani]: https://github.com/ali
 [Jeroen van Vianen]: https://github.com/morinel
 [Rijenkii]: https://github.com/rijenkii
+[rvanasa]: https://github.com/rvanasa
 
 
 ## Version 11.7.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -41,6 +41,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | C++                     | cpp, hpp, cc, hh, c++, h++, cxx, hxx |   |
 | C/AL                    | cal                    |         |
 | Cache Object Script     | cos, cls               |         |
+| Candid                  | candid, did            | [highlightjs-motoko](https://github.com/rvanasa/highlightjs-motoko) |
 | CMake                   | cmake, cmake.in        |         |
 | COBOL                   | cobol, standard-cobol   | [highlightjs-cobol](https://github.com/otterkit/highlightjs-cobol) |
 | Coq                     | coq                    |         |
@@ -139,6 +140,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Mojolicious             | mojolicious            |         |
 | Monkey                  | monkey                 |         |
 | Moonscript              | moonscript, moon       |         |
+| Motoko                  | motoko, mo             | [highlightjs-motoko](https://github.com/rvanasa/highlightjs-motoko) |
 | N1QL                    | n1ql                   |         |
 | NSIS                    | nsis                   |         |
 | Never                   | never                  | [highlightjs-never](https://github.com/never-lang/highlightjs-never) |


### PR DESCRIPTION
This PR includes links to [highlightjs-motoko](https://github.com/rvanasa/highlightjs-motoko), which provides syntax highlighting for [Motoko](https://github.com/dfinity/motoko#readme) as well as [Candid](https://github.com/dfinity/candid#readme) (an [IDL](https://en.wikipedia.org/wiki/Interface_description_language) commonly used with Motoko).
