### PR TITLE
Update SUPPORTTED_LANGUAGES.md for MIPS

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -133,6 +133,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Maxima                  | maxima                 |         |
 | Maya Embedded Language  | mel                    |         |
 | Mercury                 | mercury                |         |
+| MIPS Assembler          | mips, mipsasm          |         |
 | mIRC Scripting Language | mirc, mrc              | [highlightjs-mirc](https://github.com/highlightjs/highlightjs-mirc) |
 | Mizar                   | mizar                  |         |
 | MKB                     | mkb                    | [highlightjs-mkb](https://github.com/Dereavy/highlightjs-mkb) |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

MIPS was already supported in highlightjs (see [`src/languages/mipsasm.js`](https://github.com/highlightjs/highlight.js/blob/main/src/languages/mipsasm.js)).

But I'm not sure why it's not in `SUPPORTED_LANGUANGES.md`. 

So I added it.

### Checklist
- [ ] Updated the changelog at `CHANGES.md`

I'm not sure should this one-line update be added to `CHANGES.md`.

