### PR TITLE
Support Haskell characters. Fixes #3355

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,14 @@ Grammars:
 - enh(http) Add support for HTTP/3 [Rijenkii][]
 - added 3rd party Motoko grammar to SUPPORTED_LANGUAGES [rvanasa][]
 - added 3rd party Candid grammar to SUPPORTED_LANGUAGES [rvanasa][]
+- fix(haskell) Added support for characters [CrystalSplitter][]
 
 [AdamRaichu]: https://github.com/AdamRaichu
 [Ali Ukani]: https://github.com/ali
 [Jeroen van Vianen]: https://github.com/morinel
 [Rijenkii]: https://github.com/rijenkii
 [rvanasa]: https://github.com/rvanasa
+[CrystalSplitter]: https://github.com/CrystalSplitter
 
 
 ## Version 11.7.0

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -177,7 +177,18 @@ export default function(hljs) {
 
       // Literals and names.
 
-      // TODO: characters.
+      // Single characters.
+      {
+        scope: 'string',
+        begin: /'(?=\\?.')/,
+        end: /'/,
+        contains: [
+          {
+            scope: 'char.escape',
+            match: /\\./,
+          },
+        ]
+      },
       hljs.QUOTE_STRING_MODE,
       NUMBER,
       CONSTRUCTOR,

--- a/test/markup/haskell/char.expect.txt
+++ b/test/markup/haskell/char.expect.txt
@@ -1,0 +1,19 @@
+<span class="hljs-comment">-- simple string</span>
+<span class="hljs-title">t1</span> = <span class="hljs-string">&quot;starscout&quot;</span>
+
+<span class="hljs-comment">-- simple char</span>
+<span class="hljs-title">t2</span> = <span class="hljs-string">&#x27;m&#x27;</span>
+
+<span class="hljs-comment">-- char and string</span>
+<span class="hljs-title">t3</span> = <span class="hljs-string">&#x27;m&#x27;</span> : <span class="hljs-string">&quot;oonbow&quot;</span>
+
+<span class="hljs-comment">-- escaping</span>
+<span class="hljs-title">t4</span> = <span class="hljs-string">&#x27;<span class="hljs-char escape_">\&quot;</span>&#x27;</span> : <span class="hljs-string">&#x27;x&#x27;</span> : <span class="hljs-string">&quot;y&quot;</span>
+<span class="hljs-title">t5</span> = <span class="hljs-string">&#x27;<span class="hljs-char escape_">\&#x27;</span>&#x27;</span> : <span class="hljs-string">&#x27;x&#x27;</span> : <span class="hljs-string">&quot;y&quot;</span>
+
+<span class="hljs-comment">-- should not parse as chars or strings</span>
+<span class="hljs-title">t6</span> = &#x27;&#x27;
+<span class="hljs-title">t7</span> = &#x27;a
+<span class="hljs-title">t8</span> = &#x27;&#x27;a
+<span class="hljs-title">t9</span> = a&#x27;
+<span class="hljs-title">t10</span> = a&#x27;&#x27;

--- a/test/markup/haskell/char.txt
+++ b/test/markup/haskell/char.txt
@@ -1,0 +1,19 @@
+-- simple string
+t1 = "starscout"
+
+-- simple char
+t2 = 'm'
+
+-- char and string
+t3 = 'm' : "oonbow"
+
+-- escaping
+t4 = '\"' : 'x' : "y"
+t5 = '\'' : 'x' : "y"
+
+-- should not parse as chars or strings
+t6 = ''
+t7 = 'a
+t8 = ''a
+t9 = a'
+t10 = a''


### PR DESCRIPTION
This commit fixes #3355. This one is somewhat tricky to handle because of the positive lookahead.

This commit also introduces some test cases to ensure that the feature continues to function.

### Changes
Add support for Haskell characters.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
