### PR TITLE
enh(protobuf) adds `proto` alias for Protobuf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ New Grammars:
 
 Grammars:
 
+- enh(protobuf) add `proto` alias for Protobuf [dimitropoulos][]
 - enh(sqf)  latest changes in Arma 3 v2.11 [Leopard20][]
 - enh(js/ts) Added support for GraphQL tagged template strings [Ali Ukani][]
 - enh(javascript) add sessionStorage to list of built-in variables [Jeroen van Vianen][]

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -169,7 +169,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Processing              | processing             |         |
 | Prolog                  | prolog                 |         |
 | Properties              | properties             |         |
-| Protocol Buffers        | protobuf               |         |
+| Protocol Buffers        | proto, protobuf        |         |
 | Puppet                  | puppet, pp             |         |
 | Python                  | python, py, gyp        |         |
 | Python profiler results | profile                |         |

--- a/src/languages/protobuf.js
+++ b/src/languages/protobuf.js
@@ -47,7 +47,7 @@ export default function(hljs) {
 
   return {
     name: 'Protocol Buffers',
-    aliases: ['proto', 'protobuf'],
+    aliases: ['proto'],
     keywords: {
       keyword: KEYWORDS,
       type: TYPES,

--- a/src/languages/protobuf.js
+++ b/src/languages/protobuf.js
@@ -47,6 +47,7 @@ export default function(hljs) {
 
   return {
     name: 'Protocol Buffers',
+    aliases: ['proto', 'protobuf'],
     keywords: {
       keyword: KEYWORDS,
       type: TYPES,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`proto` is the extension for protobuf files, and is used in [other](https://github.com/shikijs/shiki/blob/44b9b0c458744267d824a8283eac4d6393f65013/packages/shiki/src/languages.ts#L104) syntax highlighters as the language id.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Adds `proto` alias for Protobuf

### Checklist
- [x] Added markup tests, or they don't apply here because... this is just an update to an alias
- [x] Updated the changelog at `CHANGES.md`
