### PR TITLE
[python] remove `->` from illegal patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Grammars:
 - fix(haskell) Added support for characters [CrystalSplitter][]
 - enh(dart) Add `base`, `interface`, `sealed`, and `when` keywords [Sam Rawlins][]
 - enh(php) detect newer more flexible NOWdoc syntax (#3679) [Timur Kamaev][]
+- enh(python) improve autodetection of code with type hinting any function's return type (making the `->` operator legal) [Keyacom][]
 
 Parser:
 
@@ -39,6 +40,7 @@ Parser:
 [rvanasa]: https://github.com/rvanasa
 [CrystalSplitter]: https://github.com/CrystalSplitter
 [Sam Rawlins]: https://github.com/srawlins
+[Keyacom]: https://github.com/Keyacom
 
 
 ## Version 11.7.0

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -367,7 +367,7 @@ export default function(hljs) {
     ],
     unicodeRegex: true,
     keywords: KEYWORDS,
-    illegal: /(<\/|->|\?)|=>/,
+    illegal: /(<\/|\?)|=>/,
     contains: [
       PROMPT,
       NUMBER,


### PR DESCRIPTION
Resolves #3659

### Changes
It puzzled me that `->` was marked as illegal ever since Python 3.0. This PR removes this illegality. Now Python code with functions that have a return type hint do not block autodetection.

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [X] Updated the changelog at `CHANGES.md`
