### PR TITLE
(Fix) Haskell added 'where' inside data block. Resolves #3753

### DIFF
--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -129,7 +129,7 @@ export default function(hljs) {
         className: 'class',
         begin: '\\b(data|(new)?type)\\b',
         end: '$',
-        keywords: 'data family type newtype deriving',
+        keywords: 'data family type newtype deriving where',
         contains: [
           PRAGMA,
           CONSTRUCTOR,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
The where keyword in the Haskell GADT syntax wasn't highlighted correctly, adding 'where' keyword inside the data block correct the issue.
<!--- Describe your changes -->
Added 'where' keyword inside data block inside *haskell.js*
### Checklist
- [x] Added markup tests
- [ ] Updated the changelog at `CHANGES.md`
