### PR TITLE
fix typo in language name of JavaScript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Grammars:
 Parser:
 
 - add removePlugin api [faga295][]
+- fix typo in language name of JavaScript [Cyrus Kao][]
 
 [arnoudbuzing]: https://github.com/arnoudbuzing
 [aliaegik]: https://github.com/aliaegik
@@ -47,7 +48,7 @@ Parser:
 [Sam Rawlins]: https://github.com/srawlins
 [Keyacom]: https://github.com/Keyacom
 [Boris Verkhovskiy]: https://github.com/verhovsky
-
+[Cyrus Kao]: https://github.com/CyrusKao
 
 ## Version 11.7.0
 

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -450,7 +450,7 @@ export default function(hljs) {
   };
 
   return {
-    name: 'Javascript',
+    name: 'JavaScript',
     aliases: ['js', 'jsx', 'mjs', 'cjs'],
     keywords: KEYWORDS,
     // this will be extended by TypeScript


### PR DESCRIPTION
Resolves #3757

### Changes

Change the language name of JavaScript from `Javascript` to `JavaScript`.

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
