### PR TITLE
Add Mint Programming Language to `SUPPORTED_LANGUAGES.md`

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -135,6 +135,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Maya Embedded Language  | mel                    |         |
 | Mercury                 | mercury                |         |
 | MIPS Assembler          | mips, mipsasm          |         |
+| Mint                    | mint                   | [highlightjs-mint](https://github.com/mint-lang/highlightjs-mint) |
 | mIRC Scripting Language | mirc, mrc              | [highlightjs-mirc](https://github.com/highlightjs/highlightjs-mirc) |
 | Mizar                   | mizar                  |         |
 | MKB                     | mkb                    | [highlightjs-mkb](https://github.com/Dereavy/highlightjs-mkb) |


### PR DESCRIPTION
Adds [Mint](https://mint-lang.com) programming language to the list of supported languages:

https://github.com/mint-lang/highlightjs-mint
