### PR TITLE
fix language detection regex - Issue 3762

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Parser:
 
 - add removePlugin api [faga295][]
 - fix typo in language name of JavaScript [Cyrus Kao][]
+- fix "+" characters not being matched because of language detection regex [Aldo Santiago]
 
 [arnoudbuzing]: https://github.com/arnoudbuzing
 [aliaegik]: https://github.com/aliaegik
@@ -49,6 +50,7 @@ Parser:
 [Keyacom]: https://github.com/Keyacom
 [Boris Verkhovskiy]: https://github.com/verhovsky
 [Cyrus Kao]: https://github.com/CyrusKao
+[Aldo Santiago]: https://github.com/santi4o
 
 ## Version 11.7.0
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -70,7 +70,7 @@ const HLJS = function(hljs) {
     ignoreUnescapedHTML: false,
     throwUnescapedHTML: false,
     noHighlightRe: /^(no-?highlight)$/i,
-    languageDetectRe: /\blang(?:uage)?-([\w-]+)\b/i,
+    languageDetectRe: /\blang(?:uage)?-(\w[\w+-]*)/i,
     classPrefix: 'hljs-',
     cssSelector: 'pre code',
     languages: null,


### PR DESCRIPTION
Updated language detection regex to match "+" characters

Resolves #3762 

### Changes
Hello! I updated the regex to `/\blang(?:uage)?-(\w[\w+-]*)/i` where `(\w[\w+-]*)` will match a word character followed by zero or more occurrences of word characters, hyphens, or plus symbols. I also removed the last boundary matcher (`\b`) because it would not match languages ending with `+` or `-` like `c++`

### Checklist
- [ ] Markup tests (I think they don't apply here)
- [x] Updated the changelog at `CHANGES.md`
