### PR TITLE
Add names to dsconfig, php, python-repl (#3769)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Improvements:
 
 - added a function to default export to generate a fresh highlighter instance to be used by extensions [WisamMechano][]
 - added BETA `__emitTokens` key to grammars to allow then to direct their own parsing, only using Highlight.js for the HTML rendering [Josh Goebel][]
+- added explicit `name` to all languages, verifiable by a test [Alexey Inkin][]
 
 New Grammars:
 
@@ -49,6 +50,7 @@ Parser:
 [Keyacom]: https://github.com/Keyacom
 [Boris Verkhovskiy]: https://github.com/verhovsky
 [Cyrus Kao]: https://github.com/CyrusKao
+[Alexey Inkin]: https://github.com/alexeyinkin
 
 ## Version 11.7.0
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -853,8 +853,6 @@ const HLJS = function(hljs) {
       // entire highlighter
       lang = PLAINTEXT_LANGUAGE;
     }
-    // give it a temporary name if it doesn't have one in the meta-data
-    if (!lang.name) lang.name = languageName;
     languages[languageName] = lang;
     lang.rawDefinition = languageDefinition.bind(null, hljs);
 

--- a/src/languages/dsconfig.js
+++ b/src/languages/dsconfig.js
@@ -31,6 +31,7 @@ export default function(hljs) {
   };
 
   return {
+    name: 'dsconfig',
     keywords: 'dsconfig',
     contains: [
       {

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -477,6 +477,7 @@ export default function(hljs) {
   };
 
   return {
+    name: 'PHP',
     case_insensitive: false,
     keywords: KEYWORDS,
     contains: [

--- a/src/languages/python-repl.js
+++ b/src/languages/python-repl.js
@@ -7,6 +7,7 @@ Category: common
 
 export default function(hljs) {
   return {
+    name: 'Python REPL',
     aliases: [ 'pycon' ],
     contains: [
       {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -162,7 +162,7 @@ declare module 'highlight.js' {
     export interface Mode extends ModeCallbacks, ModeDetails {}
 
     export interface LanguageDetail {
-        name?: string
+        name: string
         unicodeRegex?: boolean
         rawDefinition?: () => Language
         aliases?: string[]


### PR DESCRIPTION
- Addresses #3769 

### Changes
Adds names to the three languages missing it.
Removes the implicit name setting for a language if it misses one.
Updates the `LanguageDetails` type to reflect that there is always a name.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
