### PR TITLE
added 3rd party Iptables grammar to SUPPORTED_LANGUAGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,10 @@
 Parser:
 
 - (enh) prevent rehighlighting of an element [joshgoebel][]
+- added 3rd party Iptables grammar to SUPPORTED_LANGUAGES [Checconio][]
 
 [Josh Goebel]: https://github.com/joshgoebel
+[Checconio]: https://github.com/Checconio
 
 
 ## Version 11.8.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -108,6 +108,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Ini, TOML               | ini, toml              |         |
 | Inform7                 | inform7, i7            |         |
 | IRPF90                  | irpf90                 |         |
+| Iptables                | iptables               | [highlightjs-iptables](https://github.com/highlightjs/highlightjs-iptables) |
 | JSON                    | json                   |         |
 | Java                    | java, jsp              |         |
 | JavaScript              | javascript, js, jsx    |         |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added new syntax for Iptables files

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Src and CDN: https://github.com/highlightjs/highlightjs-iptables

### Changes
New syntaxt

### Checklist
- [X] Added markup tests, or they don't apply here because...
- [X] Updated the changelog at `CHANGES.md`
