### PR TITLE
Added RDF/XML as an alias for the "HTML, XML" language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,16 @@ Dev tool:
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]
 
+Core Grammars:
+
+- Added "RDF/XML" as an alias for the "HTML, XML" grammar, and listed it also in SUPPORTED_LANGUAGES [csnyulas][]
+
+
 [Shah Shabbir Ahmmed]: https://github.com/shabbir23ah
 [Josh Goebel]: https://github.com/joshgoebel
 [Checconio]: https://github.com/Checconio
+[csnyulas]: https://github.com/csnyulas
+
 
 
 ## Version 11.8.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -97,7 +97,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | GraphQL                 | graphql                |         |
 | Groovy                  | groovy                 |         |
 | GSQL                    | gsql                   | [highlightjs-gsql](https://github.com/DanBarkus/highlightjs-gsql) |
-| HTML, XML               | xml, html, xhtml, rss, atom, xjb, xsd, xsl, plist, svg | |
+| HTML, XML               | xml, html, xhtml, rss, atom, xjb, xsd, xsl, RDF/XML, plist, svg | |
 | HTTP                    | http, https            |         |
 | Haml                    | haml                   |         |
 | Handlebars              | handlebars, hbs, html.hbs, html.handlebars        | |

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -82,6 +82,7 @@ export default function(hljs) {
       'xjb',
       'xsd',
       'xsl',
+      'RDF/XML',
       'plist',
       'wsf',
       'svg'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added RDF/XML as an alias for the "HTML, XML" language. RDF/XML is an important file format (and also a serialization of Web Ontology Language models, and an official DOCTYPE). It is a W3C recommendation, and it is widely used in the Semantic Web community to represent (OWL) ontologies and RDF graphs.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Just added an additional alias "RDF/XML" for the "HTML, XML" language in the `xml.js` and `SUPPORTED_LANGUAGES.md` files, and logged these changes in the `CHANGES.md`. 

### Checklist
- [ ] Added markup tests, or they don't apply here because... (I am not sure if aliases need to be tested individually, and if yes how)
- [X] Updated the changelog at `CHANGES.md`
