### PR TITLE
 fix(bash): do not delimit a string by \'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Core Grammars:
 - enh(haxe) support numeric separators and suffixes [Robert Borghese][]
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]
 - fix(haxe) differentiate `abstract` declaration from keyword [Robert Borghese][]
+- fix(bash) do not delimit a string by an escaped apostrophe [hancar][]
 
 Dev tool: 
 

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -60,9 +60,7 @@ export default function(hljs) {
   };
   SUBST.contains.push(QUOTE_STRING);
   const ESCAPED_QUOTE = {
-    className: '',
-    begin: /\\"/
-
+    match: /\\"/
   };
   const APOS_STRING = {
     className: 'string',

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -70,9 +70,7 @@ export default function(hljs) {
     end: /'/
   };
   const ESCAPED_APOS = {
-    className: '',
-    begin: /\\'/
-
+    match: /\\'/
   };
   const ARITHMETIC = {
     begin: /\$?\(\(/,

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -69,6 +69,11 @@ export default function(hljs) {
     begin: /'/,
     end: /'/
   };
+  const ESCAPED_APOS = {
+    className: '',
+    begin: /\\'/
+
+  };
   const ARITHMETIC = {
     begin: /\$?\(\(/,
     end: /\)\)/,
@@ -381,6 +386,7 @@ export default function(hljs) {
       QUOTE_STRING,
       ESCAPED_QUOTE,
       APOS_STRING,
+      ESCAPED_APOS,
       VAR
     ]
   };

--- a/test/markup/bash/escaped-apos.expect.txt
+++ b/test/markup/bash/escaped-apos.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-comment"># Escaped apostrophe is not a string</span>
+<span class="hljs-built_in">echo</span> \&#x27;not-a-highlighted-string\&#x27;

--- a/test/markup/bash/escaped-apos.txt
+++ b/test/markup/bash/escaped-apos.txt
@@ -1,0 +1,2 @@
+# Escaped apostrophe is not a string
+echo \'not-a-highlighted-string\'


### PR DESCRIPTION
Resolves https://github.com/highlightjs/highlight.js/issues/3791

### Changes
Escaped apostrophe in bash is not a start or an end of a string any more.

### Checklist
- [✔] Added markup tests, or they don't apply here because...
- [✔] Updated the changelog at `CHANGES.md`