### PR TITLE
fix(haskell) Do not treat dashes inside infix operators as comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@ Core Grammars:
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]
 - fix(haxe) differentiate `abstract` declaration from keyword [Robert Borghese][]
 - fix(bash) do not delimit a string by an escaped apostrophe [hancar][]
+- fix(haskell) do not treat double dashes inside infix operators as comments [Zlondrej][]
 
-Dev tool: 
+Dev tool:
 
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]
@@ -72,6 +73,7 @@ Core Grammars:
 [Keyacom]: https://github.com/Keyacom
 [Boris Verkhovskiy]: https://github.com/verhovsky
 [Cyrus Kao]: https://github.com/CyrusKao
+[Zlondrej]: https://github.com/zlondrej
 
 ## Version 11.7.0
 

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -7,8 +7,26 @@ Category: functional
 */
 
 export default function(hljs) {
+
+  /* See:
+     - https://www.haskell.org/onlinereport/lexemes.html
+     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/binary_literals.html
+     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/numeric_underscores.html
+     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/hex_float_literals.html
+  */
+  const decimalDigits = '([0-9]_*)+';
+  const hexDigits = '([0-9a-fA-F]_*)+';
+  const binaryDigits = '([01]_*)+';
+  const octalDigits = '([0-7]_*)+';
+  const ascSymbol = '[!#$%&*+.\\/<=>?@\\\\^~-]';
+  const uniSymbol = '(\\p{S}|\\p{P})' // Symbol or Punctuation
+  const special = '[(),;\\[\\]`|{}]';
+  const symbol = `(${ascSymbol}|(?!(${special}|[_:"']))${uniSymbol})`;
+
   const COMMENT = { variants: [
-    hljs.COMMENT('--', '$'),
+    // Double dash forms a valid comment only if it's not part of legal lexeme.
+    // See: Haskell 98 report: https://www.haskell.org/onlinereport/lexemes.html
+    hljs.COMMENT(`(?<!${symbol})--+(?!${symbol})`, '$'),
     hljs.COMMENT(
       /\{-/,
       /-\}/,
@@ -56,19 +74,6 @@ export default function(hljs) {
     contains: LIST.contains
   };
 
-  /* See:
-
-     - https://www.haskell.org/onlinereport/lexemes.html
-     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/binary_literals.html
-     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/numeric_underscores.html
-     - https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/hex_float_literals.html
-
-  */
-  const decimalDigits = '([0-9]_*)+';
-  const hexDigits = '([0-9a-fA-F]_*)+';
-  const binaryDigits = '([01]_*)+';
-  const octalDigits = '([0-7]_*)+';
-
   const NUMBER = {
     className: 'number',
     relevance: 0,
@@ -92,6 +97,7 @@ export default function(hljs) {
       + 'qualified type data newtype deriving class instance as default '
       + 'infix infixl infixr foreign export ccall stdcall cplusplus '
       + 'jvm dotnet safe unsafe family forall mdo proc rec',
+    unicodeRegex: true,
     contains: [
       // Top-level constructions.
       {

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -26,7 +26,13 @@ export default function(hljs) {
   const COMMENT = { variants: [
     // Double dash forms a valid comment only if it's not part of legal lexeme.
     // See: Haskell 98 report: https://www.haskell.org/onlinereport/lexemes.html
-    hljs.COMMENT(`(?<!${symbol})--+(?!${symbol})`, '$'),
+    //
+    // The commented code does the job, but we can't use negative lookbehind,
+    // due to poor support by Safari browser.
+    // > hljs.COMMENT(`(?<!${symbol})--+(?!${symbol})`, '$'),
+    // So instead, we'll add a no-markup rule before the COMMENT rule in the rules list
+    // to match the problematic infix operators that contain double dash.
+    hljs.COMMENT('--+', '$'),
     hljs.COMMENT(
       /\{-/,
       /-\}/,
@@ -199,6 +205,8 @@ export default function(hljs) {
       NUMBER,
       CONSTRUCTOR,
       hljs.inherit(hljs.TITLE_MODE, { begin: '^[_a-z][\\w\']*' }),
+      // No markup, prevents infix operators from being recognized as comments.
+      { begin: `(?!-)${symbol}--+|--+(?!-)${symbol}`},
       COMMENT,
       { // No markup, relevance booster
         begin: '->|<-' }

--- a/test/markup/haskell/inline-comments.expect.txt
+++ b/test/markup/haskell/inline-comments.expect.txt
@@ -1,0 +1,97 @@
+ <span class="hljs-comment">-- These are not comments, as the symbols, together with double dashes, form a legal lexemes.</span>
+
+ <span class="hljs-comment">-- Using ascii symbols</span>
+ --!
+ !--!
+ !--
+ #---
+ ---#
+ #---#
+ $----
+ ----$
+ $----$
+ %--
+ --%
+ %--%
+ &amp;---
+ ---&amp;
+ &amp;--&amp;
+ --*
+ *--
+ *--*
+ --+
+ +--
+ +--+
+ --.
+ .--
+ .--.
+ --/
+ /--
+ /--/
+ --&lt;
+ &lt;--
+ &lt;--&lt;
+ --=
+ =--
+ =--=
+ --&gt;
+ &gt;--
+ &gt;--&gt;
+ --?
+ ?--?
+ ?--
+ --@
+ @--@
+ @--
+ \--
+ --\
+ \--\
+ ^--
+ --^
+ ^--^
+ ~--
+ --~
+ ~--~
+ <span class="hljs-comment">-- Using unicode symbols</span>
+ ⅀--
+ --¬
+ ⅄--±
+ <span class="hljs-comment">-- Using unicode punctuation</span>
+ §--
+ --؉
+ ܅--๏
+
+ <span class="hljs-comment">-- However these are comments as they consist of `special` symbols or `_`, `:`, `&quot;`, `&#x27;`</span>
+ <span class="hljs-comment">-- or otherwise don&#x27;t form a legal lexeme together with the dashes.</span>
+ <span class="hljs-comment">--undefined</span>
+ <span class="hljs-comment">--(</span>
+ <span class="hljs-comment">---)</span>
+ <span class="hljs-comment">----_</span>
+ <span class="hljs-comment">--:</span>
+ <span class="hljs-comment">--&quot;</span>
+ <span class="hljs-comment">--&#x27;</span>
+ <span class="hljs-comment">--,</span>
+ <span class="hljs-comment">--;</span>
+ <span class="hljs-comment">--[</span>
+ <span class="hljs-comment">--]</span>
+ <span class="hljs-comment">--`</span>
+ <span class="hljs-comment">--|</span>
+ <span class="hljs-comment">--{</span>
+ <span class="hljs-comment">--}</span>
+ undefined<span class="hljs-comment">--</span>
+ (<span class="hljs-comment">--</span>
+ )<span class="hljs-comment">---</span>
+ _<span class="hljs-comment">----</span>
+ :<span class="hljs-comment">--</span>
+ <span class="hljs-string">&quot;&quot;</span><span class="hljs-comment">--</span>
+ &#x27;&#x27;<span class="hljs-comment">--</span>
+ ,<span class="hljs-comment">--</span>
+ ;<span class="hljs-comment">--</span>
+ [<span class="hljs-comment">--</span>
+ ]<span class="hljs-comment">--</span>
+ `<span class="hljs-comment">--</span>
+ |<span class="hljs-comment">--</span>
+ <span class="hljs-comment">{-- Well, this one is a block comment, so we have to terminate it -}</span>
+ }<span class="hljs-comment">--</span>
+ <span class="hljs-comment">---</span>
+ <span class="hljs-comment">----</span>

--- a/test/markup/haskell/inline-comments.txt
+++ b/test/markup/haskell/inline-comments.txt
@@ -1,0 +1,97 @@
+ -- These are not comments, as the symbols, together with double dashes, form a legal lexemes.
+
+ -- Using ascii symbols
+ --!
+ !--!
+ !--
+ #---
+ ---#
+ #---#
+ $----
+ ----$
+ $----$
+ %--
+ --%
+ %--%
+ &---
+ ---&
+ &--&
+ --*
+ *--
+ *--*
+ --+
+ +--
+ +--+
+ --.
+ .--
+ .--.
+ --/
+ /--
+ /--/
+ --<
+ <--
+ <--<
+ --=
+ =--
+ =--=
+ -->
+ >--
+ >-->
+ --?
+ ?--?
+ ?--
+ --@
+ @--@
+ @--
+ \--
+ --\
+ \--\
+ ^--
+ --^
+ ^--^
+ ~--
+ --~
+ ~--~
+ -- Using unicode symbols
+ ⅀--
+ --¬
+ ⅄--±
+ -- Using unicode punctuation
+ §--
+ --؉
+ ܅--๏
+
+ -- However these are comments as they consist of `special` symbols or `_`, `:`, `"`, `'`
+ -- or otherwise don't form a legal lexeme together with the dashes.
+ --undefined
+ --(
+ ---)
+ ----_
+ --:
+ --"
+ --'
+ --,
+ --;
+ --[
+ --]
+ --`
+ --|
+ --{
+ --}
+ undefined--
+ (--
+ )---
+ _----
+ :--
+ ""--
+ ''--
+ ,--
+ ;--
+ [--
+ ]--
+ `--
+ |--
+ {-- Well, this one is a block comment, so we have to terminate it -}
+ }--
+ ---
+ ----


### PR DESCRIPTION
This fixes cases where operators like `$--`, `-->` or similar are treated as comment.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
Only detects line comments according to lexical structure described in Haskell 98 report: https://www.haskell.org/onlinereport/lexemes.html

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
