### PR TITLE
fix(types): move `types` condition to the front

### DIFF
--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -103,8 +103,8 @@ function dual(file) {
 
 const generatePackageExports = () => ({
   ".": {
-    ...dual("./lib/index.js"),
     "types": "./types/index.d.ts",
+    ...dual("./lib/index.js"),
   },
   "./package.json": "./package.json",
   "./lib/common": dual("./lib/common.js"),


### PR DESCRIPTION
I moved `types` condition to the front (fixing a small issue introduced in https://github.com/highlightjs/highlight.js/pull/3736 ). `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=highlight.js%4011.8.0)