### PR TITLE
enh(swift) support `macro` keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Core Grammars:
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]
 - fix(haxe) differentiate `abstract` declaration from keyword [Robert Borghese][]
 - fix(bash) do not delimit a string by an escaped apostrophe [hancar][]
+- enh(swift) support `macro` keyword [Bradley Mackey][]
 
 Dev tool: 
 
@@ -21,7 +22,7 @@ Dev tool:
 [Shah Shabbir Ahmmed]: https://github.com/shabbir23ah
 [Josh Goebel]: https://github.com/joshgoebel
 [Checconio]: https://github.com/Checconio
-
+[Bradley Mackey]: https://github.com/bradleymackey
 
 ## Version 11.8.0
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -79,6 +79,7 @@ export const keywords = [
   'nonisolated', // contextual
   'lazy', // contextual
   'let',
+  'macro',
   'mutating', // contextual
   'nonmutating', // contextual
   /open\(set\)/, // contextual

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -342,9 +342,10 @@ export default function(hljs) {
     illegal: /["']/
   };
   // https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID362
-  const FUNCTION = {
+  // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/declarations/#Macro-Declaration
+  const FUNCTION_OR_MACRO = {
     match: [
-      /func/,
+      /(func|macro)/,
       /\s+/,
       either(QUOTED_IDENTIFIER.match, Swift.identifier, Swift.operator)
     ],
@@ -441,7 +442,7 @@ export default function(hljs) {
     keywords: KEYWORDS,
     contains: [
       ...COMMENTS,
-      FUNCTION,
+      FUNCTION_OR_MACRO,
       INIT_SUBSCRIPT,
       {
         beginKeywords: 'struct protocol class extension enum actor',

--- a/test/markup/swift/macro.expect.txt
+++ b/test/markup/swift/macro.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-keyword">macro</span> <span class="hljs-title function_">warning</span>(<span class="hljs-keyword">_</span> <span class="hljs-params">message</span>: <span class="hljs-type">String</span>) <span class="hljs-operator">=</span> #externalMacro(module: <span class="hljs-string">&quot;MyMacros&quot;</span>, type: <span class="hljs-string">&quot;WarningMacro&quot;</span>)
+
+<span class="hljs-meta">@freestanding</span>(declaration)
+<span class="hljs-keyword">macro</span> <span class="hljs-title function_">error</span>(<span class="hljs-keyword">_</span> <span class="hljs-params">message</span>: <span class="hljs-type">String</span>) <span class="hljs-operator">=</span> #externalMacro(module: <span class="hljs-string">&quot;MyMacros&quot;</span>, type: <span class="hljs-string">&quot;ErrorMacro&quot;</span>)

--- a/test/markup/swift/macro.expect.txt
+++ b/test/markup/swift/macro.expect.txt
@@ -2,3 +2,5 @@
 
 <span class="hljs-meta">@freestanding</span>(declaration)
 <span class="hljs-keyword">macro</span> <span class="hljs-title function_">error</span>(<span class="hljs-keyword">_</span> <span class="hljs-params">message</span>: <span class="hljs-type">String</span>) <span class="hljs-operator">=</span> #externalMacro(module: <span class="hljs-string">&quot;MyMacros&quot;</span>, type: <span class="hljs-string">&quot;ErrorMacro&quot;</span>)
+
+#myMacro()

--- a/test/markup/swift/macro.txt
+++ b/test/markup/swift/macro.txt
@@ -2,3 +2,5 @@ macro warning(_ message: String) = #externalMacro(module: "MyMacros", type: "War
 
 @freestanding(declaration)
 macro error(_ message: String) = #externalMacro(module: "MyMacros", type: "ErrorMacro")
+
+#myMacro()

--- a/test/markup/swift/macro.txt
+++ b/test/markup/swift/macro.txt
@@ -1,0 +1,4 @@
+macro warning(_ message: String) = #externalMacro(module: "MyMacros", type: "WarningMacro")
+
+@freestanding(declaration)
+macro error(_ message: String) = #externalMacro(module: "MyMacros", type: "ErrorMacro")


### PR DESCRIPTION
`macro` is implemented in Swift 5.9.

An example of a macro definition can be seen in [SE-0389](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md), defining a macro behaves a lot like a function.
For now, macro definitions and uses are not highlighted, as these may be user-defined. It might be worth highlighting builtin macros as `built_in`s (e.g. `#externalMacro`), but we should wait for a public release of Swift 5.9 before doing so.

### Changes
- Support `macro` keyword from Swift 5.9.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
