### PR TITLE
enh(swift) regex literal support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - fix(bash) do not delimit a string by an escaped apostrophe [hancar][]
 - enh(swift) support `macro` keyword [Bradley Mackey][]
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
+- enh(swift) regex literal support [Bradley Mackey][]
 
 Dev tool: 
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -208,12 +208,6 @@ export default function(hljs) {
     ],
   };
 
-  const EXTENDED_REGEXP_COMMENT = {
-    scope: 'comment',
-    begin: /#/,
-    end: /$/,
-  };
-
   // Adapted from hljs.REGEXP_MODE
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => ({
@@ -221,7 +215,11 @@ export default function(hljs) {
     end: concat(/\//, rawDelimiter),
     contains: [
       ...REGEXP_CONTENTS,
-      EXTENDED_REGEXP_COMMENT
+      {
+        scope: 'comment',
+        begin: /#/,
+        end: /$/,
+      }
     ]
   });
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -31,6 +31,10 @@ export default function(hljs) {
     BLOCK_COMMENT
   ];
 
+  const REGEXP_MODES = [
+    hljs.REGEXP_MODE
+  ];
+
   // https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID413
   // https://docs.swift.org/swift-book/ReferenceManual/zzSummaryOfTheGrammar.html
   const DOT_KEYWORD = {
@@ -286,6 +290,7 @@ export default function(hljs) {
       'self',
       TUPLE_ELEMENT_NAME,
       ...COMMENTS,
+      ...REGEXP_MODES,
       ...KEYWORD_MODES,
       ...BUILT_INS,
       ...OPERATORS,
@@ -466,6 +471,7 @@ export default function(hljs) {
         contains: [ ...COMMENTS ],
         relevance: 0
       },
+      ...REGEXP_MODES,
       ...KEYWORD_MODES,
       ...BUILT_INS,
       ...OPERATORS,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -194,6 +194,7 @@ export default function(hljs) {
       {
         begin: concat(
           rawDelimiter,
+          // bare regexps cannot start with whitespace
           rawDelimiter === "" ? /\/[^\s]/ : /\//
         ),
         end: concat(/\//, rawDelimiter),

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -192,7 +192,10 @@ export default function(hljs) {
     begin: outerRule,
     contains: [
       {
-        begin: concat(rawDelimiter, /\//),
+        begin: concat(
+          rawDelimiter,
+          rawDelimiter === "" ? /\/[^\s]/ : /\//
+        ),
         end: concat(/\//, rawDelimiter),
         // newlines are only allowed for extended regexps
         illegal: rawDelimiter === "" ? /\n/ : "",
@@ -215,7 +218,7 @@ export default function(hljs) {
       REGEXP_LITERAL("###", /(?=###\/[\s\S]*\/###)/),
       REGEXP_LITERAL("##", /(?=##\/[\s\S]*\/##)/),
       REGEXP_LITERAL("#", /(?=#\/[\s\S]*\/#)/),
-      REGEXP_LITERAL("", /(?=\/[^/\n]*\/)/),
+      REGEXP_LITERAL("", /(?=\/[^\s][^/\n]*\/)/),
     ],
   };
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -193,19 +193,9 @@ export default function(hljs) {
   // Adapted from hljs.REGEXP_MODE
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const BARE_REGEXP_LITERAL = {
-    // this outer rule makes sure we actually have a WHOLE regex and not simply
-    // an expression such as:
-    //
-    //     3 / something
-    //
-    begin: /(?=\/[^\s][^/\n]*\/)/,
-    contains: [
-      {
-        begin: /\/[^\s]/,
-        end: /\//,
-        contains: REGEXP_CONTENTS
-      }
-    ]
+    begin: /\/[^\s](?=[^/\n]*\/)/,
+    end: /\//,
+    contains: REGEXP_CONTENTS
   };
 
   // Adapted from hljs.REGEXP_MODE

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -190,16 +190,12 @@ export default function(hljs) {
     }
   ];
 
-  // Adapted from hljs.REGEXP_MODE
-  // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const BARE_REGEXP_LITERAL = {
     begin: /\/[^\s](?=[^/\n]*\/)/,
     end: /\//,
     contains: REGEXP_CONTENTS
   };
 
-  // Adapted from hljs.REGEXP_MODE
-  // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => ({
     begin: concat(rawDelimiter, /\//),
     end: concat(/\//, rawDelimiter),
@@ -213,6 +209,7 @@ export default function(hljs) {
     ]
   });
 
+  // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const REGEXP = {
     scope: "regexp",
     variants: [

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -212,23 +212,18 @@ export default function(hljs) {
 
   // Adapted from hljs.REGEXP_MODE
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
-  const EXTENDED_REGEXP_LITERAL = (rawDelimiter, outerRule) => ({
-    begin: outerRule,
-    contains: [
-      {
-        begin: concat(rawDelimiter, /\//),
-        end: concat(/\//, rawDelimiter),
-        contains: REGEXP_CONTENTS,
-      },
-    ],
+  const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => ({
+    begin: concat(rawDelimiter, /\//),
+    end: concat(/\//, rawDelimiter),
+    contains: REGEXP_CONTENTS,
   });
 
   const REGEXP = {
     scope: "regexp",
     variants: [
-      EXTENDED_REGEXP_LITERAL('###', /(?=###\/[\s\S]*\/###)/),
-      EXTENDED_REGEXP_LITERAL('##', /(?=##\/[\s\S]*\/##)/),
-      EXTENDED_REGEXP_LITERAL('#', /(?=#\/[\s\S]*\/#)/),
+      EXTENDED_REGEXP_LITERAL('###'),
+      EXTENDED_REGEXP_LITERAL('##'),
+      EXTENDED_REGEXP_LITERAL('#'),
       BARE_REGEXP_LITERAL,
     ],
   };

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -186,8 +186,8 @@ export default function(hljs) {
       begin: /\[/,
       end: /\]/,
       relevance: 0,
-      contains: [ hljs.BACKSLASH_ESCAPE ],
-    },
+      contains: [ hljs.BACKSLASH_ESCAPE ]
+    }
   ];
 
   // Adapted from hljs.REGEXP_MODE
@@ -203,9 +203,9 @@ export default function(hljs) {
       {
         begin: /\/[^\s]/,
         end: /\//,
-        contains: REGEXP_CONTENTS,
-      },
-    ],
+        contains: REGEXP_CONTENTS
+      }
+    ]
   };
 
   // Adapted from hljs.REGEXP_MODE
@@ -218,7 +218,7 @@ export default function(hljs) {
       {
         scope: 'comment',
         begin: /#/,
-        end: /$/,
+        end: /$/
       }
     ]
   });
@@ -229,8 +229,8 @@ export default function(hljs) {
       EXTENDED_REGEXP_LITERAL('###'),
       EXTENDED_REGEXP_LITERAL('##'),
       EXTENDED_REGEXP_LITERAL('#'),
-      BARE_REGEXP_LITERAL,
-    ],
+      BARE_REGEXP_LITERAL
+    ]
   };
 
   // https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID412

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -208,12 +208,21 @@ export default function(hljs) {
     ],
   };
 
+  const EXTENDED_REGEXP_COMMENT = {
+    scope: 'comment',
+    begin: /#/,
+    end: /$/,
+  };
+
   // Adapted from hljs.REGEXP_MODE
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => ({
     begin: concat(rawDelimiter, /\//),
     end: concat(/\//, rawDelimiter),
-    contains: REGEXP_CONTENTS,
+    contains: [
+      ...REGEXP_CONTENTS,
+      EXTENDED_REGEXP_COMMENT
+    ]
   });
 
   const REGEXP = {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -204,7 +204,6 @@ export default function(hljs) {
       {
         begin: /\/[^\s]/,
         end: /\//,
-        illegal: /\n/,
         contains: REGEXP_CONTENTS,
       },
     ],

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -198,7 +198,6 @@ export default function(hljs) {
     //
     //     3 / something
     //
-    // (which will then blow up when regex's `illegal` sees the newline)
     begin: /(?=\/[^\s][^/\n]*\/)/,
     contains: [
       {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -194,6 +194,7 @@ export default function(hljs) {
       {
         begin: concat(rawDelimiter, /\//),
         end: concat(/\//, rawDelimiter),
+        // newlines are only allowed for extended regexps
         illegal: rawDelimiter === "" ? /\n/ : "",
         contains: [
           hljs.BACKSLASH_ESCAPE,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -213,12 +213,6 @@ export default function(hljs) {
   // Adapted from hljs.REGEXP_MODE
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const EXTENDED_REGEXP_LITERAL = (rawDelimiter, outerRule) => ({
-    // this outer rule makes sure we actually have a WHOLE regex and not simply
-    // an expression such as:
-    //
-    //     3 / something
-    //
-    // (which will then blow up when regex's `illegal` sees the newline)
     begin: outerRule,
     contains: [
       {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -196,18 +196,22 @@ export default function(hljs) {
     contains: REGEXP_CONTENTS
   };
 
-  const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => ({
-    begin: concat(rawDelimiter, /\//),
-    end: concat(/\//, rawDelimiter),
-    contains: [
-      ...REGEXP_CONTENTS,
-      {
-        scope: 'comment',
-        begin: /#/,
-        end: /$/
-      }
-    ]
-  });
+  const EXTENDED_REGEXP_LITERAL = (rawDelimiter) => {
+    const begin = concat(rawDelimiter, /\//);
+    const end = concat(/\//, rawDelimiter);
+    return {
+      begin,
+      end,
+      contains: [
+        ...REGEXP_CONTENTS,
+        {
+          scope: "comment",
+          begin: `#(?!.*${end})`,
+          end: /$/,
+        },
+      ],
+    };
+  };
 
   // https://docs.swift.org/swift-book/documentation/the-swift-programming-language/lexicalstructure/#Regular-Expression-Literals
   const REGEXP = {

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -161,7 +161,6 @@ export const REGEXP_MODE = {
     scope: 'regexp',
     begin: /\//,
     end: /\/[gimuy]*/,
-    illegal: /\n/,
     contains: [
       BACKSLASH_ESCAPE,
       {

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -150,27 +150,18 @@ export const BINARY_NUMBER_MODE = {
   relevance: 0
 };
 export const REGEXP_MODE = {
-  // this outer rule makes sure we actually have a WHOLE regex and not simply
-  // an expression such as:
-  //
-  //     3 / something
-  //
-  // (which will then blow up when regex's `illegal` sees the newline)
-  begin: /(?=\/[^/\n]*\/)/,
-  contains: [{
-    scope: 'regexp',
-    begin: /\//,
-    end: /\/[gimuy]*/,
-    contains: [
-      BACKSLASH_ESCAPE,
-      {
-        begin: /\[/,
-        end: /\]/,
-        relevance: 0,
-        contains: [BACKSLASH_ESCAPE]
-      }
-    ]
-  }]
+  scope: "regexp",
+  begin: /\/(?=[^/\n]*\/)/,
+  end: /\/[gimuy]*/,
+  contains: [
+    BACKSLASH_ESCAPE,
+    {
+      begin: /\[/,
+      end: /\]/,
+      relevance: 0,
+      contains: [BACKSLASH_ESCAPE]
+    }
+  ]
 };
 export const TITLE_MODE = {
   scope: 'title',

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -9,8 +9,22 @@
 method(value: <span class="hljs-regexp">/hello/</span>)
 method(<span class="hljs-regexp">/hello/</span>, world)
 method(<span class="hljs-regexp">/hello/</span>, <span class="hljs-regexp">/world/</span>)
+foo(<span class="hljs-regexp">/a, b/</span>) <span class="hljs-comment">// Will become regex literal &#x27;/a, b/&#x27;</span>
+qux(<span class="hljs-regexp">/, !/</span>)  <span class="hljs-comment">// Will become regex literal &#x27;/, !/&#x27;</span>
+qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will become regex literal &#x27;/,/&#x27;</span>
+<span class="hljs-keyword">let</span> g <span class="hljs-operator">=</span> hasSubscript[<span class="hljs-regexp">/]/</span><span class="hljs-number">2</span> <span class="hljs-comment">// Will become regex literal &#x27;/]/&#x27;</span>
+<span class="hljs-keyword">let</span> h <span class="hljs-operator">=</span> <span class="hljs-regexp">/0; let f = 1/</span> <span class="hljs-comment">// Will become the regex literal &#x27;/0; let y = 1/&#x27;</span>
+<span class="hljs-keyword">let</span> i <span class="hljs-operator">=</span> <span class="hljs-regexp">/^x/</span>           <span class="hljs-comment">// Will become the regex literal &#x27;/^x/&#x27;</span>
 
+<span class="hljs-comment">// extended literals</span>
 <span class="hljs-regexp">#/hello/#</span>
+<span class="hljs-regexp">#/he/llo/#</span>
+<span class="hljs-regexp">##/hello/##</span>
+<span class="hljs-regexp">##/he/llo/##</span>
+<span class="hljs-regexp">###/hello/###</span>
+<span class="hljs-regexp">###/he/llo/###</span>
+#<span class="hljs-regexp">###/hello/###</span>#
+#<span class="hljs-regexp">###/he/llo/###</span>#
 <span class="hljs-regexp">#/hello world/#</span>
 <span class="hljs-regexp">#/\w+\s+(\d+)\s+\w+/#</span>
 <span class="hljs-regexp">#/(.+?): (.+)/#</span>
@@ -22,18 +36,7 @@ method(value: <span class="hljs-regexp">#/hello/#</span>)
 method(<span class="hljs-regexp">#/hello/#</span>, world)
 method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/world/#</span>)
 
-<span class="hljs-regexp">#/he/llo/#</span>
-<span class="hljs-regexp">##/hello/##</span>
-<span class="hljs-regexp">###/hello/###</span>
-#<span class="hljs-regexp">###/hello/###</span>#
-
-foo(<span class="hljs-regexp">/a, b/</span>) <span class="hljs-comment">// Will become regex literal &#x27;/a, b/&#x27;</span>
-qux(<span class="hljs-regexp">/, !/</span>)  <span class="hljs-comment">// Will become regex literal &#x27;/, !/&#x27;</span>
-qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will become regex literal &#x27;/,/&#x27;</span>
-<span class="hljs-keyword">let</span> g <span class="hljs-operator">=</span> hasSubscript[<span class="hljs-regexp">/]/</span><span class="hljs-number">2</span> <span class="hljs-comment">// Will become regex literal &#x27;/]/&#x27;</span>
-<span class="hljs-keyword">let</span> h <span class="hljs-operator">=</span> <span class="hljs-regexp">/0; let f = 1/</span> <span class="hljs-comment">// Will become the regex literal &#x27;/0; let y = 1/&#x27;</span>
-<span class="hljs-keyword">let</span> i <span class="hljs-operator">=</span> <span class="hljs-regexp">/^x/</span>           <span class="hljs-comment">// Will become the regex literal &#x27;/^x/&#x27;</span>
-
+<span class="hljs-comment">// multiline extended literals</span>
 <span class="hljs-keyword">let</span> regex <span class="hljs-operator">=</span> <span class="hljs-regexp">#/
   # Match a line of the format e.g &quot;DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00&quot;
   (?&lt;kind&gt;    \w+)                \s\s+
@@ -53,7 +56,9 @@ qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will 
   nice
 /#</span>
 
-<span class="hljs-comment">// operator collisions</span>
+<span class="hljs-comment">// whitespace</span>
 <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>
+<span class="hljs-number">2</span> <span class="hljs-operator">/</span>     <span class="hljs-number">2</span>    <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-regexp">/2/</span> <span class="hljs-number">2</span>       <span class="hljs-comment">// is a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-regexp">#/ 2 /#</span> <span class="hljs-number">2</span>   <span class="hljs-comment">// is a regex</span>
+<span class="hljs-regexp">/\ escaped leading whitespace/</span> <span class="hljs-comment">// is a regex</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -52,3 +52,8 @@ qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will 
   newline explicit\n
   nice
 /#</span>
+
+<span class="hljs-comment">// operator collisions</span>
+<span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>
+<span class="hljs-number">2</span> <span class="hljs-regexp">/2/</span> <span class="hljs-number">2</span>       <span class="hljs-comment">// is a regex</span>
+<span class="hljs-number">2</span> <span class="hljs-regexp">#/ 2 /#</span> <span class="hljs-number">2</span>   <span class="hljs-comment">// is a regex</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -40,6 +40,7 @@ qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will 
 method(value: <span class="hljs-regexp">#/hello/#</span>)
 method(<span class="hljs-regexp">#/hello/#</span>, world)
 method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/world/#</span>)
+<span class="hljs-regexp">#/regex with #not a comment/#</span>
 
 <span class="hljs-comment">// multiline extended literals</span>
 <span class="hljs-keyword">let</span> regex <span class="hljs-operator">=</span> <span class="hljs-regexp">#/

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -9,3 +9,35 @@
 method(value: <span class="hljs-regexp">/hello/</span>)
 method(<span class="hljs-regexp">/hello/</span>, world)
 method(<span class="hljs-regexp">/hello/</span>, <span class="hljs-regexp">/world/</span>)
+
+<span class="hljs-regexp">#/hello/#</span>
+<span class="hljs-regexp">#/hello world/#</span>
+<span class="hljs-regexp">#/\w+\s+(\d+)\s+\w+/#</span>
+<span class="hljs-regexp">#/(.+?): (.+)/#</span>
+<span class="hljs-keyword">let</span> p <span class="hljs-operator">=</span> <span class="hljs-regexp">#/hello/#</span>
+<span class="hljs-keyword">let</span> n <span class="hljs-operator">=</span> <span class="hljs-regexp">#/hello/#</span> <span class="hljs-operator">+</span> <span class="hljs-regexp">/world/</span> <span class="hljs-operator">-</span> <span class="hljs-regexp">#/nice/#</span>
+<span class="hljs-keyword">let</span> q <span class="hljs-operator">=</span> <span class="hljs-regexp">#/hello/#</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>
+(<span class="hljs-regexp">#/hello/#</span>)
+method(value: <span class="hljs-regexp">#/hello/#</span>)
+method(<span class="hljs-regexp">#/hello/#</span>, world)
+method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/world/#</span>)
+
+<span class="hljs-regexp">#/he/llo/#</span>
+<span class="hljs-regexp">##/hello/##</span>
+<span class="hljs-regexp">###/hello/###</span>
+#<span class="hljs-regexp">###/hello/###</span>#
+
+foo(<span class="hljs-regexp">/a, b/</span>) <span class="hljs-comment">// Will become regex literal &#x27;/a, b/&#x27;</span>
+qux(<span class="hljs-regexp">/, !/</span>)  <span class="hljs-comment">// Will become regex literal &#x27;/, !/&#x27;</span>
+qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will become regex literal &#x27;/,/&#x27;</span>
+<span class="hljs-keyword">let</span> g <span class="hljs-operator">=</span> hasSubscript[<span class="hljs-regexp">/]/</span><span class="hljs-number">2</span> <span class="hljs-comment">// Will become regex literal &#x27;/]/&#x27;</span>
+<span class="hljs-keyword">let</span> h <span class="hljs-operator">=</span> <span class="hljs-regexp">/0; let f = 1/</span> <span class="hljs-comment">// Will become the regex literal &#x27;/0; let y = 1/&#x27;</span>
+<span class="hljs-keyword">let</span> i <span class="hljs-operator">=</span> <span class="hljs-regexp">/^x/</span>           <span class="hljs-comment">// Will become the regex literal &#x27;/^x/&#x27;</span>
+
+<span class="hljs-keyword">let</span> regex <span class="hljs-operator">=</span> <span class="hljs-regexp">#/
+  # Match a line of the format e.g &quot;DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00&quot;
+  (?&lt;kind&gt;    \w+)                \s\s+
+  (?&lt;date&gt;    \S+)                \s\s+
+  (?&lt;account&gt; (?: (?!\s\s) . )+)  \s\s+ # Note that account names may contain spaces.
+  (?&lt;amount&gt;  .*)
+/#</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -41,3 +41,14 @@ qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will 
   (?&lt;account&gt; (?: (?!\s\s) . )+)  \s\s+ # Note that account names may contain spaces.
   (?&lt;amount&gt;  .*)
 /#</span>
+<span class="hljs-regexp">#/
+  this is another extended regex literal
+  /this is still in the regex/
+  123
+  12 / 2
+  (/hello/)
+  # regex comment
+  backslash escape literal newline\
+  newline explicit\n
+  nice
+/#</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -87,3 +87,8 @@ x<span class="hljs-operator">+</span><span class="hljs-regexp">#/y/#</span> <spa
     <span class="hljs-regexp">/test/</span> <span class="hljs-operator">+</span> <span class="hljs-regexp">#/test/#</span>
   }
 }
+
+<span class="hljs-comment">// unterminated</span>
+<span class="hljs-operator">/</span>something
+another line
+<span class="hljs-operator">/</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -56,6 +56,12 @@ method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/w
   newline explicit\n
   nice
 /#</span>
+<span class="hljs-regexp">##/
+  multiline
+/##</span>
+<span class="hljs-regexp">###/
+  multiline
+/###</span>
 
 <span class="hljs-comment">// whitespace</span>
 <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -66,3 +66,12 @@ method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/w
 x<span class="hljs-operator">+/</span>y<span class="hljs-operator">/</span> <span class="hljs-comment">// infix operator, not a regex</span>
 x <span class="hljs-operator">+</span> <span class="hljs-regexp">/y/</span> <span class="hljs-comment">// is a regex</span>
 x<span class="hljs-operator">+</span><span class="hljs-regexp">#/y/#</span> <span class="hljs-comment">// is a regex</span>
+
+<span class="hljs-comment">// structural</span>
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">Planet</span> {
+  <span class="hljs-keyword">var</span> d <span class="hljs-operator">=</span> <span class="hljs-regexp">/test/</span>
+  <span class="hljs-keyword">var</span> e <span class="hljs-operator">=</span> <span class="hljs-regexp">#/test/#</span>
+  <span class="hljs-keyword">var</span> n: <span class="hljs-keyword">Any</span> {
+    <span class="hljs-regexp">/test/</span> <span class="hljs-operator">+</span> <span class="hljs-regexp">#/test/#</span>
+  }
+}

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-regexp">/hello/</span>
+<span class="hljs-regexp">/hello world/</span>
+<span class="hljs-regexp">/\w+\s+(\d+)\s+\w+/</span>
+<span class="hljs-regexp">/(.+?): (.+)/</span>
+<span class="hljs-keyword">let</span> p <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span>
+<span class="hljs-keyword">let</span> n <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span> <span class="hljs-operator">+</span> <span class="hljs-regexp">/world/</span> <span class="hljs-operator">-</span> <span class="hljs-regexp">/nice/</span>
+<span class="hljs-keyword">let</span> q <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>
+(<span class="hljs-regexp">/hello/</span>)
+method(value: <span class="hljs-regexp">/hello/</span>)
+method(<span class="hljs-regexp">/hello/</span>, world)
+method(<span class="hljs-regexp">/hello/</span>, <span class="hljs-regexp">/world/</span>)

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -63,3 +63,6 @@ method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/w
 <span class="hljs-number">2</span> <span class="hljs-regexp">/2/</span> <span class="hljs-number">2</span>       <span class="hljs-comment">// is a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-regexp">#/ 2 /#</span> <span class="hljs-number">2</span>   <span class="hljs-comment">// is a regex</span>
 <span class="hljs-regexp">/\ escaped leading whitespace/</span> <span class="hljs-comment">// is a regex</span>
+x<span class="hljs-operator">+/</span>y<span class="hljs-operator">/</span> <span class="hljs-comment">// infix operator, not a regex</span>
+x <span class="hljs-operator">+</span> <span class="hljs-regexp">/y/</span> <span class="hljs-comment">// is a regex</span>
+x<span class="hljs-operator">+</span><span class="hljs-regexp">#/y/#</span> <span class="hljs-comment">// is a regex</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -43,27 +43,35 @@ method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/w
 
 <span class="hljs-comment">// multiline extended literals</span>
 <span class="hljs-keyword">let</span> regex <span class="hljs-operator">=</span> <span class="hljs-regexp">#/
-  # Match a line of the format e.g &quot;DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00&quot;
+  <span class="hljs-comment"># Match a line of the format e.g &quot;DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00&quot;</span>
   (?&lt;kind&gt;    \w+)                \s\s+
   (?&lt;date&gt;    \S+)                \s\s+
-  (?&lt;account&gt; (?: (?!\s\s) . )+)  \s\s+ # Note that account names may contain spaces.
+  (?&lt;account&gt; (?: (?!\s\s) . )+)  \s\s+ <span class="hljs-comment"># Note that account names may contain spaces.</span>
   (?&lt;amount&gt;  .*)
 /#</span>
 <span class="hljs-regexp">#/
+  <span class="hljs-comment">#regex comment</span>
+  <span class="hljs-comment"># regex comment</span>
+  <span class="hljs-comment">## regex comment</span>
   this is another extended regex literal
   /this is still in the regex/
   123
   12 / 2
   (/hello/)
-  # regex comment
   backslash escape literal newline\
   newline explicit\n
   nice
 /#</span>
 <span class="hljs-regexp">##/
+  <span class="hljs-comment">#regex comment</span>
+  <span class="hljs-comment"># regex comment</span>
+  <span class="hljs-comment">#/ regex comment</span>
   multiline
 /##</span>
 <span class="hljs-regexp">###/
+  <span class="hljs-comment">#regex comment</span>
+  <span class="hljs-comment"># regex comment</span>
+  <span class="hljs-comment">#/ regex comment</span>
   multiline
 /###</span>
 

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -1,3 +1,5 @@
+<span class="hljs-regexp">/escape\/slash/</span>
+<span class="hljs-regexp">/escape \/ slash \/ /</span>
 <span class="hljs-regexp">/hello/</span>
 <span class="hljs-regexp">/hello world/</span>
 <span class="hljs-regexp">/\w+\s+(\d+)\s+\w+/</span>
@@ -18,6 +20,8 @@ qux(<span class="hljs-regexp">/,/</span>)    <span class="hljs-comment">// Will 
 <span class="hljs-keyword">let</span> i <span class="hljs-operator">=</span> <span class="hljs-regexp">/^x/</span>           <span class="hljs-comment">// Will become the regex literal &#x27;/^x/&#x27;</span>
 
 <span class="hljs-comment">// extended literals</span>
+<span class="hljs-regexp">#/raw\/slashes/#</span>
+<span class="hljs-regexp">#/raw \/ slashes \/ /#</span>
 <span class="hljs-regexp">#/hello/#</span>
 <span class="hljs-regexp">#/he/llo/#</span>
 <span class="hljs-regexp">##/hello/##</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -2,6 +2,7 @@
 <span class="hljs-regexp">/hello world/</span>
 <span class="hljs-regexp">/\w+\s+(\d+)\s+\w+/</span>
 <span class="hljs-regexp">/(.+?): (.+)/</span>
+<span class="hljs-regexp">/(?&lt;identifier&gt;[[:alpha:]]\w*) = (?&lt;hex&gt;[0-9A-F]+)/</span>
 <span class="hljs-keyword">let</span> p <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span>
 <span class="hljs-keyword">let</span> n <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span> <span class="hljs-operator">+</span> <span class="hljs-regexp">/world/</span> <span class="hljs-operator">-</span> <span class="hljs-regexp">/nice/</span>
 <span class="hljs-keyword">let</span> q <span class="hljs-operator">=</span> <span class="hljs-regexp">/hello/</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>

--- a/test/markup/swift/regex.expect.txt
+++ b/test/markup/swift/regex.expect.txt
@@ -71,6 +71,8 @@ method(<span class="hljs-regexp">#/hello/#</span>, <span class="hljs-regexp">#/w
 <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-operator">/</span>     <span class="hljs-number">2</span>    <span class="hljs-operator">/</span> <span class="hljs-number">2</span>     <span class="hljs-comment">// not a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-regexp">/2/</span> <span class="hljs-number">2</span>       <span class="hljs-comment">// is a regex</span>
+<span class="hljs-number">2</span> <span class="hljs-regexp">/2 /</span> <span class="hljs-number">2</span>      <span class="hljs-comment">// is a regex</span>
+<span class="hljs-number">2</span> <span class="hljs-operator">/</span> <span class="hljs-number">2</span><span class="hljs-operator">/</span> <span class="hljs-number">2</span>      <span class="hljs-comment">// not a regex</span>
 <span class="hljs-number">2</span> <span class="hljs-regexp">#/ 2 /#</span> <span class="hljs-number">2</span>   <span class="hljs-comment">// is a regex</span>
 <span class="hljs-regexp">/\ escaped leading whitespace/</span> <span class="hljs-comment">// is a regex</span>
 x<span class="hljs-operator">+/</span>y<span class="hljs-operator">/</span> <span class="hljs-comment">// infix operator, not a regex</span>

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -50,20 +50,28 @@ let regex = #/
   (?<amount>  .*)
 /#
 #/
+  #regex comment
+  # regex comment
+  ## regex comment
   this is another extended regex literal
   /this is still in the regex/
   123
   12 / 2
   (/hello/)
-  # regex comment
   backslash escape literal newline\
   newline explicit\n
   nice
 /#
 ##/
+  #regex comment
+  # regex comment
+  #/ regex comment
   multiline
 /##
 ###/
+  #regex comment
+  # regex comment
+  #/ regex comment
   multiline
 /###
 

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -1,3 +1,5 @@
+/escape\/slash/
+/escape \/ slash \/ /
 /hello/
 /hello world/
 /\w+\s+(\d+)\s+\w+/
@@ -18,6 +20,8 @@ let h = /0; let f = 1/ // Will become the regex literal '/0; let y = 1/'
 let i = /^x/           // Will become the regex literal '/^x/'
 
 // extended literals
+#/raw\/slashes/#
+#/raw \/ slashes \/ /#
 #/hello/#
 #/he/llo/#
 ##/hello/##

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -9,3 +9,35 @@ let q = /hello/ / 2
 method(value: /hello/)
 method(/hello/, world)
 method(/hello/, /world/)
+
+#/hello/#
+#/hello world/#
+#/\w+\s+(\d+)\s+\w+/#
+#/(.+?): (.+)/#
+let p = #/hello/#
+let n = #/hello/# + /world/ - #/nice/#
+let q = #/hello/# / 2
+(#/hello/#)
+method(value: #/hello/#)
+method(#/hello/#, world)
+method(#/hello/#, #/world/#)
+
+#/he/llo/#
+##/hello/##
+###/hello/###
+####/hello/####
+
+foo(/a, b/) // Will become regex literal '/a, b/'
+qux(/, !/)  // Will become regex literal '/, !/'
+qux(/,/)    // Will become regex literal '/,/'
+let g = hasSubscript[/]/2 // Will become regex literal '/]/'
+let h = /0; let f = 1/ // Will become the regex literal '/0; let y = 1/'
+let i = /^x/           // Will become the regex literal '/^x/'
+
+let regex = #/
+  # Match a line of the format e.g "DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00"
+  (?<kind>    \w+)                \s\s+
+  (?<date>    \S+)                \s\s+
+  (?<account> (?: (?!\s\s) . )+)  \s\s+ # Note that account names may contain spaces.
+  (?<amount>  .*)
+/#

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -52,3 +52,8 @@ let regex = #/
   newline explicit\n
   nice
 /#
+
+// operator collisions
+2 / 2 / 2     // not a regex
+2 /2/ 2       // is a regex
+2 #/ 2 /# 2   // is a regex

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -56,6 +56,12 @@ let regex = #/
   newline explicit\n
   nice
 /#
+##/
+  multiline
+/##
+###/
+  multiline
+/###
 
 // whitespace
 2 / 2 / 2     // not a regex

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -1,0 +1,11 @@
+/hello/
+/hello world/
+/\w+\s+(\d+)\s+\w+/
+/(.+?): (.+)/
+let p = /hello/
+let n = /hello/ + /world/ - /nice/
+let q = /hello/ / 2
+(/hello/)
+method(value: /hello/)
+method(/hello/, world)
+method(/hello/, /world/)

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -87,3 +87,8 @@ struct Planet {
     /test/ + #/test/#
   }
 }
+
+// unterminated
+/something
+another line
+/

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -40,6 +40,7 @@ let q = #/hello/# / 2
 method(value: #/hello/#)
 method(#/hello/#, world)
 method(#/hello/#, #/world/#)
+#/regex with #not a comment/#
 
 // multiline extended literals
 let regex = #/

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -2,6 +2,7 @@
 /hello world/
 /\w+\s+(\d+)\s+\w+/
 /(.+?): (.+)/
+/(?<identifier>[[:alpha:]]\w*) = (?<hex>[0-9A-F]+)/
 let p = /hello/
 let n = /hello/ + /world/ - /nice/
 let q = /hello/ / 2

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -71,6 +71,8 @@ let regex = #/
 2 / 2 / 2     // not a regex
 2 /     2    / 2     // not a regex
 2 /2/ 2       // is a regex
+2 /2 / 2      // is a regex
+2 / 2/ 2      // not a regex
 2 #/ 2 /# 2   // is a regex
 /\ escaped leading whitespace/ // is a regex
 x+/y/ // infix operator, not a regex

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -63,3 +63,6 @@ let regex = #/
 2 /2/ 2       // is a regex
 2 #/ 2 /# 2   // is a regex
 /\ escaped leading whitespace/ // is a regex
+x+/y/ // infix operator, not a regex
+x + /y/ // is a regex
+x+#/y/# // is a regex

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -66,3 +66,12 @@ let regex = #/
 x+/y/ // infix operator, not a regex
 x + /y/ // is a regex
 x+#/y/# // is a regex
+
+// structural
+struct Planet {
+  var d = /test/
+  var e = #/test/#
+  var n: Any {
+    /test/ + #/test/#
+  }
+}

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -41,3 +41,14 @@ let regex = #/
   (?<account> (?: (?!\s\s) . )+)  \s\s+ # Note that account names may contain spaces.
   (?<amount>  .*)
 /#
+#/
+  this is another extended regex literal
+  /this is still in the regex/
+  123
+  12 / 2
+  (/hello/)
+  # regex comment
+  backslash escape literal newline\
+  newline explicit\n
+  nice
+/#

--- a/test/markup/swift/regex.txt
+++ b/test/markup/swift/regex.txt
@@ -9,8 +9,22 @@ let q = /hello/ / 2
 method(value: /hello/)
 method(/hello/, world)
 method(/hello/, /world/)
+foo(/a, b/) // Will become regex literal '/a, b/'
+qux(/, !/)  // Will become regex literal '/, !/'
+qux(/,/)    // Will become regex literal '/,/'
+let g = hasSubscript[/]/2 // Will become regex literal '/]/'
+let h = /0; let f = 1/ // Will become the regex literal '/0; let y = 1/'
+let i = /^x/           // Will become the regex literal '/^x/'
 
+// extended literals
 #/hello/#
+#/he/llo/#
+##/hello/##
+##/he/llo/##
+###/hello/###
+###/he/llo/###
+####/hello/####
+####/he/llo/####
 #/hello world/#
 #/\w+\s+(\d+)\s+\w+/#
 #/(.+?): (.+)/#
@@ -22,18 +36,7 @@ method(value: #/hello/#)
 method(#/hello/#, world)
 method(#/hello/#, #/world/#)
 
-#/he/llo/#
-##/hello/##
-###/hello/###
-####/hello/####
-
-foo(/a, b/) // Will become regex literal '/a, b/'
-qux(/, !/)  // Will become regex literal '/, !/'
-qux(/,/)    // Will become regex literal '/,/'
-let g = hasSubscript[/]/2 // Will become regex literal '/]/'
-let h = /0; let f = 1/ // Will become the regex literal '/0; let y = 1/'
-let i = /^x/           // Will become the regex literal '/^x/'
-
+// multiline extended literals
 let regex = #/
   # Match a line of the format e.g "DEBIT  03/03/2022  Totally Legit Shell Corp  $2,000,000.00"
   (?<kind>    \w+)                \s\s+
@@ -53,7 +56,9 @@ let regex = #/
   nice
 /#
 
-// operator collisions
+// whitespace
 2 / 2 / 2     // not a regex
+2 /     2    / 2     // not a regex
 2 /2/ 2       // is a regex
 2 #/ 2 /# 2   // is a regex
+/\ escaped leading whitespace/ // is a regex

--- a/test/markup/swift/tuples.expect.txt
+++ b/test/markup/swift/tuples.expect.txt
@@ -14,3 +14,4 @@
 )
 (<span class="hljs-keyword">let</span> x, <span class="hljs-keyword">var</span> y)
 ([key: value, key: value])
+(<span class="hljs-regexp">/my regex/</span>)

--- a/test/markup/swift/tuples.txt
+++ b/test/markup/swift/tuples.txt
@@ -14,3 +14,4 @@
 )
 (let x, var y)
 ([key: value, key: value])
+(/my regex/)


### PR DESCRIPTION
Swift 5.7 introduced regex literals, specified in [SE-0354](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md).

This includes support for bare-slash (`/example/`) and extended regex literals (`#/example/#`, `##/example/##`, etc).
- Bare slash literals are not enabled by default in Swift 5, but will be in Swift 6.
- Bare slash literals cannot start with whitespace, but extended literals can.
- Only extended regex literals support newlines.
- Multiline extended literals support comments starting with `#`, continuing until end of line.
- Follows convention of raw strings, supporting up to 3 levels of delimiting for extended literals, ensuring `#` delimiters match.

### Changes
- Add regex literal support

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
