### PR TITLE
Add the Embedded Puppet templating language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Parser:
 
 - (enh) prevent rehighlighting of an element [joshgoebel][]
 - added 3rd party Iptables grammar to SUPPORTED_LANGUAGES [Checconio][]
+- Add support for Embedded Puppet (epp) [Ben Ford][], [Antoine Musso][] [Wikimedia Foundation][]
 
 Core Grammars:
 - enh(haxe) added `final`, `is`, `macro` keywords and `$` identifiers [Robert Borghese][]
@@ -15,7 +16,7 @@ Core Grammars:
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
 - enh(swift) regex literal support [Bradley Mackey][]
 
-Dev tool: 
+Dev tool:
 
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]
@@ -25,7 +26,9 @@ Dev tool:
 [Josh Goebel]: https://github.com/joshgoebel
 [Checconio]: https://github.com/Checconio
 [Bradley Mackey]: https://github.com/bradleymackey
-
+[Ben Ford]: https://github.com/binford2k
+[Antoine Musso]: https://github.com/hashar
+[Wikimedia Foundation]: https://wikimediafoundation.org
 
 ## Version 11.8.0
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -75,6 +75,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | EBNF                    | ebnf                   |         |
 | Elixir                  | elixir                 |         |
 | Elm                     | elm                    |         |
+| Embedded Puppet         | epp                    |         |
 | Erlang                  | erlang, erl            |         |
 | Excel                   | excel, xls, xlsx       |         |
 | Extempore               | extempore, xtlang, xtm | [highlightjs-xtlang](https://github.com/highlightjs/highlightjs-xtlang) |

--- a/src/languages/epp.js
+++ b/src/languages/epp.js
@@ -1,0 +1,32 @@
+/*
+Language: EPP (Embedded Puppet templating language)
+Requires: xml.js, puppet.js
+Author: Ben Ford <ben.ford@puppet.com>
+Contributors: Antoine Musso <hashar@free.fr>
+Description: "Bridge" language defining fragments of Puppet in plain text within <% .. %>
+Website: https://www.puppet.com/docs/puppet/8/lang_template_epp.html
+Category: template
+*/
+
+/** @type LanguageFn */
+export default function(hljs) {
+  return {
+    name: 'EPP',
+
+    // The actual content can be any type
+    subLanguage: [],
+
+    // Test sample is recognized as `mel`, disable auto-detection since it is
+    // "hard": https://github.com/highlightjs/highlight.js/issues/1213
+    disableAutodetect: true,
+    contains: [
+      hljs.COMMENT('<%#', '%>'),
+      {
+        begin: '<%[%=-]?', end: '[%-]?%>',
+        subLanguage: 'puppet',
+        excludeBegin: true,
+        excludeEnd: true
+      }
+    ]
+  };
+}

--- a/src/languages/erb.js
+++ b/src/languages/erb.js
@@ -12,7 +12,7 @@ Category: template
 export default function(hljs) {
   return {
     name: 'ERB',
-    subLanguage: 'xml',
+    subLanguage: 'xml',  // TODO: it can be any language
     contains: [
       hljs.COMMENT('<%#', '%>'),
       {

--- a/test/detect/epp/default.txt
+++ b/test/detect/epp/default.txt
@@ -1,0 +1,10 @@
+<%# this is a comment %>
+
+<% if $ec2_metadata { -%>
+       This is an EC2 node:
+-------------------------------------------------------
+       AMI ID: <%= $ec2_metadata["ami-id"] %>
+     Hostname: <%= $ec2_metadata["public-hostname"] %>
+  Instance ID: <%= $ec2_metadata["instance-id"] %>
+Instance Type: <%= $ec2_metadata["instance-type"] %>
+<% } -%>

--- a/test/markup/epp/anysublanguage.expect.txt
+++ b/test/markup/epp/anysublanguage.expect.txt
@@ -1,0 +1,12 @@
+<span class="language-xml"><span class="hljs-meta">&lt;?xml version=<span class="hljs-string">&quot;1.0&quot;</span> ?&gt;</span>
+<span class="hljs-comment">&lt;!-- XML is reliably detected --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">ec2</span>&gt;</span>
+&lt;%</span><span class="language-puppet"> if <span class="hljs-variable">$ec2_metadata</span> { </span><span class="language-xml">-%&gt;
+  <span class="hljs-tag">&lt;<span class="hljs-name">metadata</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">ami-id</span>&gt;</span>&lt;%=</span><span class="language-puppet"> <span class="hljs-variable">$ec2_metadata</span>[<span class="hljs-string">&quot;ami-id&quot;</span>] </span><span class="language-mercury"><span class="hljs-comment">%&gt;&lt;/ami-id&gt;</span>
+    &lt;<span class="hljs-keyword">instance</span>-id&gt;&lt;<span class="hljs-comment">%=</span></span><span class="language-puppet"> <span class="hljs-variable">$ec2_metadata</span>[<span class="hljs-string">&quot;instance-id&quot;</span>] </span><span class="language-xml">%&gt;<span class="hljs-tag">&lt;/<span class="hljs-name">instance-id</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">public-hostname</span>&gt;</span>&lt;%=</span><span class="language-puppet"> <span class="hljs-variable">$ec2_metadata</span>[<span class="hljs-string">&quot;public-hostname&quot;</span>] </span><span class="language-xml">%&gt;<span class="hljs-tag">&lt;/<span class="hljs-name">public-hostname</span>&gt;</span>
+  <span class="hljs-tag">&lt;/<span class="hljs-name">metadata</span>&gt;</span>
+&lt;%</span><span class="language-puppet"> } </span><span class="language-xml">-%&gt;
+<span class="hljs-tag">&lt;/<span class="hljs-name">ec2</span>&gt;</span>
+</span>

--- a/test/markup/epp/anysublanguage.txt
+++ b/test/markup/epp/anysublanguage.txt
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<!-- XML is reliably detected -->
+<ec2>
+<% if $ec2_metadata { -%>
+  <metadata>
+    <ami-id><%= $ec2_metadata["ami-id"] %></ami-id>
+    <instance-id><%= $ec2_metadata["instance-id"] %></instance-id>
+    <public-hostname><%= $ec2_metadata["public-hostname"] %></public-hostname>
+  </metadata>
+<% } -%>
+</ec2>

--- a/test/markup/epp/comment.expect.txt
+++ b/test/markup/epp/comment.expect.txt
@@ -1,0 +1,4 @@
+<span class="language-pgsql"><span class="hljs-keyword">Before</span> <span class="hljs-keyword">comment</span>
+</span><span class="hljs-comment">&lt;%# this is a comment %&gt;</span><span class="language-pgsql">
+<span class="hljs-keyword">After</span> <span class="hljs-keyword">comment</span>
+</span>

--- a/test/markup/epp/comment.txt
+++ b/test/markup/epp/comment.txt
@@ -1,0 +1,3 @@
+Before comment
+<%# this is a comment %>
+After comment

--- a/test/markup/epp/containspuppet.expect.txt
+++ b/test/markup/epp/containspuppet.expect.txt
@@ -1,0 +1,9 @@
+<span class="language-erlang-repl">&lt;<span class="hljs-comment">%</span></span><span class="language-puppet">
+<span class="hljs-comment"># A dummy Puppet class</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title">highlighter</span> {
+    <span class="hljs-keyword">file</span> { <span class="hljs-string">&#x27;/etc/foo.conf&#x27;</span>:
+        <span class="hljs-attr">ensure</span> =&gt; <span class="hljs-literal">present</span>,
+    }
+}
+</span><span class="language-diff"><span class="hljs-deletion">-%&gt;</span>
+</span>

--- a/test/markup/epp/containspuppet.txt
+++ b/test/markup/epp/containspuppet.txt
@@ -1,0 +1,8 @@
+<%
+# A dummy Puppet class
+class highlighter {
+    file { '/etc/foo.conf':
+        ensure => present,
+    }
+}
+-%>


### PR DESCRIPTION
_This was originally proposed in 2016 by @binford2k as #1345_

Puppet configuration management supports two kinds of templating system to generate files resources based on Puppet variables:

- Embedded Ruby (erb) which is already supported by highlightjs
- Embedded Puppet (epp) which this pull request add support for

epp is similar with some differences:
* variables are decorated with `$`
* curly braces are used instead of `do` / `end` blocks
* arguments of blocks are in slightly different position
* interpolated strings use `${...}` instead of the `#`
* etc

It is similar to erb but the backing language is Puppet rather than plain ruby.

[detect]

The detect test is erroneously recognized as `mel` and some attempts to tweak the input test gave me `awk` or `csharp`. Based on #1213, claim auto-detection to be too broad and disable it for `epp`.

[markup]

Epp can represent any other language configure it with `subLanguage: []` and provide a markup test based on XML (which is properly detected by the auto-detector).

Additional tests cover epp comment and containment of Puppet.

More or less related: the `erb` language has `subLanguage: xml` when it should be `[]`, I have left a TODO note for later.

Co-authored-by: Wikimedia Foundation Inc.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
