### PR TITLE
Build non-minified CSS files for node & CDN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,12 +20,14 @@ Dev tool:
 
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]
+- (enh) Build non-minified CSS files for node & CDN. [mvorisek][]
 
 [Robert Borghese]: https://github.com/RobertBorghese
 [Shah Shabbir Ahmmed]: https://github.com/shabbir23ah
 [Josh Goebel]: https://github.com/joshgoebel
 [Checconio]: https://github.com/Checconio
 [Bradley Mackey]: https://github.com/bradleymackey
+[mvorisek]: https://github.com/mvorisek
 
 
 ## Version 11.8.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,11 @@
 ## Version 11.9.0 (next release)
 
-Supported Node.js versions:
+CAVEATS / POTENTIALLY BREAKING CHANGES
 
-- (chore) Drops support for Node 14.x, which is no longer supported by Node.js.
-
-Packaging: 
-
-- (enh) Build non-minified CSS files for node & CDN. [mvorisek][]
+- Drops support for Node 14.x, which is no longer supported by Node.js.
+- In the `node` build `styles/*.css` files now ship un-minified 
+  with minified counterparts as: `styles/*.min.css` [mvorisek][]
+  (this makes things consistent with our `cdn` builds) 
 
 Parser:
 
@@ -14,6 +13,7 @@ Parser:
 - added 3rd party Iptables grammar to SUPPORTED_LANGUAGES [Checconio][]
 
 Core Grammars:
+
 - enh(haxe) added `final`, `is`, `macro` keywords and `$` identifiers [Robert Borghese][]
 - enh(haxe) support numeric separators and suffixes [Robert Borghese][]
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]

--- a/tools/build_browser.js
+++ b/tools/build_browser.js
@@ -169,9 +169,11 @@ function installDemoStyles() {
 
   glob.sync("**", { cwd: "./src/styles" }).forEach((file) => {
     const stat = fss.statSync(`./src/styles/${file}`);
+    if (stat.isDirectory()) return;
+
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`);
-    } else if (!stat.isDirectory) {
+      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`, false);
+    } else {
       // images, backgrounds, etc
       install(`./src/styles/${file}`, `demo/styles/${file}`);
     }

--- a/tools/build_browser.js
+++ b/tools/build_browser.js
@@ -172,7 +172,7 @@ function installDemoStyles() {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`, { minify: false });
+      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`);
     } else {
       // images, backgrounds, etc
       install(`./src/styles/${file}`, `demo/styles/${file}`);

--- a/tools/build_browser.js
+++ b/tools/build_browser.js
@@ -172,7 +172,7 @@ function installDemoStyles() {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`, false);
+      installCleanCSS(`./src/styles/${file}`, `demo/styles/${file}`, { minify: false });
     } else {
       // images, backgrounds, etc
       install(`./src/styles/${file}`, `demo/styles/${file}`);

--- a/tools/build_cdn.js
+++ b/tools/build_cdn.js
@@ -141,7 +141,8 @@ function installStyles() {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, false);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, true);
     } else {
       // images, backgrounds, etc
       install(`./src/styles/${file}`, `styles/${file}`);

--- a/tools/build_cdn.js
+++ b/tools/build_cdn.js
@@ -141,8 +141,8 @@ function installStyles() {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, false);
-      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, true);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, { minify: false });
+      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, { minify: true });
     } else {
       // images, backgrounds, etc
       install(`./src/styles/${file}`, `styles/${file}`);

--- a/tools/build_config.js
+++ b/tools/build_config.js
@@ -8,6 +8,10 @@ module.exports = {
   clean_css: {
     level: 2
   },
+  clean_css_beautify: {
+    level: 0,
+    format: 'beautify'
+  },
   rollup: {
     core: {
       input: {

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -173,8 +173,9 @@ async function buildNode(options) {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `styles/${file}`);
-      installCleanCSS(`./src/styles/${file}`, `scss/${file.replace(".css", ".scss")}`);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, false);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, true);
+      installCleanCSS(`./src/styles/${file}`, `scss/${file.replace(".css", ".scss")}`, false);
     } else {
       // images, etc.
       install(`./src/styles/${file}`, `styles/${file}`);

--- a/tools/build_node.js
+++ b/tools/build_node.js
@@ -173,9 +173,9 @@ async function buildNode(options) {
     if (stat.isDirectory()) return;
 
     if (file.endsWith(".css")) {
-      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, false);
-      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, true);
-      installCleanCSS(`./src/styles/${file}`, `scss/${file.replace(".css", ".scss")}`, false);
+      installCleanCSS(`./src/styles/${file}`, `styles/${file}`, { minify: false });
+      installCleanCSS(`./src/styles/${file}`, `styles/${file.replace(".css", ".min.css")}`, { minify: true });
+      installCleanCSS(`./src/styles/${file}`, `scss/${file.replace(".css", ".scss")}`, { minify: false });
     } else {
       // images, etc.
       install(`./src/styles/${file}`, `styles/${file}`);

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -27,8 +27,9 @@ code.hljs {
 `.trim();
 
 function installCleanCSS(file, dest, opts = {}) {
-   // default is to minify
-  const minify = opts.minify == undefined ? true : opts.minify;
+  // default is to minify
+  // eslint-disable-next-line no-undefined
+  const minify = opts.minify === undefined ? true : opts.minify;
 
   const theme = fs.readFileSync(file, { encoding: "utf8" });
   const content = DEFAULT_CSS + "\n" + theme;

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -26,10 +26,10 @@ code.hljs {
 }
 `.trim();
 
-function installCleanCSS(file, dest) {
+function installCleanCSS(file, dest, minify) {
   const theme = fs.readFileSync(file, { encoding: "utf8" });
   const content = DEFAULT_CSS + "\n" + theme;
-  const out = new CleanCSS(config.clean_css).minify(content).styles;
+  const out = new CleanCSS(minify ? config.clean_css : config.clean_css_beautify).minify(content).styles;
   fs.writeFileSync(`${process.env.BUILD_DIR}/${dest}`, out);
 }
 

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -26,7 +26,9 @@ code.hljs {
 }
 `.trim();
 
-function installCleanCSS(file, dest, minify) {
+function installCleanCSS(file, dest, opts = {}) {
+  const minify = opts.minify ?? true; // default is to minify
+
   const theme = fs.readFileSync(file, { encoding: "utf8" });
   const content = DEFAULT_CSS + "\n" + theme;
   const out = new CleanCSS(minify ? config.clean_css : config.clean_css_beautify).minify(content).styles;

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -27,7 +27,8 @@ code.hljs {
 `.trim();
 
 function installCleanCSS(file, dest, opts = {}) {
-  const minify = opts.minify ?? true; // default is to minify
+   // default is to minify
+  const minify = opts.minify == undefined ? true : opts.minify;
 
   const theme = fs.readFileSync(file, { encoding: "utf8" });
   const content = DEFAULT_CSS + "\n" + theme;


### PR DESCRIPTION
fix #3797

### Changes

Beatified `.css` files are newly created in node/cdn build. `.min.css` files are build as before.

### Checklist
- [X] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
