### PR TITLE
enh(swift) `@unchecked` and `@Sendable` support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Core Grammars:
 - enh(swift) support `macro` keyword [Bradley Mackey][]
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
 - enh(swift) regex literal support [Bradley Mackey][]
+- enh(swift) `@unchecked` and `@Sendable` support [Bradley Mackey][]
 
 Dev tool: 
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -278,9 +278,7 @@ export const identifier = concat(identifierHead, identifierCharacter, '*');
 export const typeIdentifier = concat(/[A-Z]/, identifierCharacter, '*');
 
 // Built-in attributes, which are highlighted as keywords.
-// Handled separately:
-//  - @available
-//  - @unchecked
+// @available is handled separately.
 export const keywordAttributes = [
   'autoclosure',
   concat(/convention\(/, either('swift', 'block', 'c'), /\)/),

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -310,6 +310,7 @@ export const keywordAttributes = [
   'Sendable',
   'testable',
   'UIApplicationMain',
+  'unchecked',
   'unknown',
   'usableFromInline'
 ];

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -278,7 +278,9 @@ export const identifier = concat(identifierHead, identifierCharacter, '*');
 export const typeIdentifier = concat(/[A-Z]/, identifierCharacter, '*');
 
 // Built-in attributes, which are highlighted as keywords.
-// @available is handled separately.
+// Handled separately:
+//  - @available
+//  - @unchecked
 export const keywordAttributes = [
   'autoclosure',
   concat(/convention\(/, either('swift', 'block', 'c'), /\)/),

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -305,6 +305,7 @@ export const keywordAttributes = [
   'propertyWrapper',
   'requires_stored_property_inits',
   'resultBuilder',
+  'Sendable',
   'testable',
   'UIApplicationMain',
   'unknown',

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -243,7 +243,7 @@ export default function(hljs) {
   // https://docs.swift.org/swift-book/ReferenceManual/Attributes.html
   const AVAILABLE_ATTRIBUTE = {
     match: /(@|#(un)?)available/,
-    scope: "keyword",
+    scope: 'keyword',
     starts: { contains: [
       {
         begin: /\(/,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -257,6 +257,10 @@ export default function(hljs) {
       }
     ] }
   };
+  const UNCHECKED_ATTRIBUTE = {
+    scope: 'keyword',
+    match: /@unchecked(?=\s+Sendable)/
+  };
   const KEYWORD_ATTRIBUTE = {
     className: 'keyword',
     match: concat(/@/, either(...Swift.keywordAttributes))
@@ -267,6 +271,7 @@ export default function(hljs) {
   };
   const ATTRIBUTES = [
     AVAILABLE_ATTRIBUTE,
+    UNCHECKED_ATTRIBUTE,
     KEYWORD_ATTRIBUTE,
     USER_DEFINED_ATTRIBUTE
   ];

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -243,7 +243,7 @@ export default function(hljs) {
   // https://docs.swift.org/swift-book/ReferenceManual/Attributes.html
   const AVAILABLE_ATTRIBUTE = {
     match: /(@|#(un)?)available/,
-    className: "keyword",
+    scope: "keyword",
     starts: { contains: [
       {
         begin: /\(/,
@@ -262,11 +262,11 @@ export default function(hljs) {
     match: /@unchecked(?=\s+Sendable)/
   };
   const KEYWORD_ATTRIBUTE = {
-    className: 'keyword',
+    scope: 'keyword',
     match: concat(/@/, either(...Swift.keywordAttributes))
   };
   const USER_DEFINED_ATTRIBUTE = {
-    className: 'meta',
+    scope: 'meta',
     match: concat(/@/, Swift.identifier)
   };
   const ATTRIBUTES = [

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -257,10 +257,6 @@ export default function(hljs) {
       }
     ] }
   };
-  const UNCHECKED_ATTRIBUTE = {
-    scope: 'keyword',
-    match: /@unchecked(?=\s+Sendable)/
-  };
   const KEYWORD_ATTRIBUTE = {
     scope: 'keyword',
     match: concat(/@/, either(...Swift.keywordAttributes))
@@ -271,7 +267,6 @@ export default function(hljs) {
   };
   const ATTRIBUTES = [
     AVAILABLE_ATTRIBUTE,
-    UNCHECKED_ATTRIBUTE,
     KEYWORD_ATTRIBUTE,
     USER_DEFINED_ATTRIBUTE
   ];

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -7,4 +7,6 @@
 <span class="hljs-keyword">@resultBuilder</span>
 <span class="hljs-keyword">@Sendable</span>
 
+<span class="hljs-meta">@unchecked</span>
+<span class="hljs-keyword">@unchecked</span> <span class="hljs-type">Sendable</span>
 @ notAnAttribute

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -5,5 +5,6 @@
 <span class="hljs-keyword">@propertyWrapper</span>
 <span class="hljs-meta">@SomeWrapper</span>(value: <span class="hljs-number">1.0</span>, other: <span class="hljs-string">&quot;string&quot;</span>, bool: <span class="hljs-literal">false</span>)
 <span class="hljs-keyword">@resultBuilder</span>
+<span class="hljs-keyword">@Sendable</span>
 
 @ notAnAttribute

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -6,7 +6,6 @@
 <span class="hljs-meta">@SomeWrapper</span>(value: <span class="hljs-number">1.0</span>, other: <span class="hljs-string">&quot;string&quot;</span>, bool: <span class="hljs-literal">false</span>)
 <span class="hljs-keyword">@resultBuilder</span>
 <span class="hljs-keyword">@Sendable</span>
+<span class="hljs-keyword">@unchecked</span>
 
-<span class="hljs-meta">@unchecked</span>
-<span class="hljs-keyword">@unchecked</span> <span class="hljs-type">Sendable</span>
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -6,7 +6,6 @@
 @SomeWrapper(value: 1.0, other: "string", bool: false)
 @resultBuilder
 @Sendable
-
 @unchecked
-@unchecked Sendable
+
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -5,5 +5,6 @@
 @propertyWrapper
 @SomeWrapper(value: 1.0, other: "string", bool: false)
 @resultBuilder
+@Sendable
 
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -7,4 +7,6 @@
 @resultBuilder
 @Sendable
 
+@unchecked
+@unchecked Sendable
 @ notAnAttribute


### PR DESCRIPTION
Implement `@unchecked` and `@Sendable` keywords for Swift.

Described in [SE-0302](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md), these should be recognised as keywords, thus are keyword attributes.

### Changes
- Recognize  `@unchecked` and `@Sendable` keywords.
- Use updated `scope` property for matching attribute keywords in Swift.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
