### PR TITLE
Scala - add using directives support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,9 @@ Core Grammars:
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
 - enh(swift) regex literal support [Bradley Mackey][]
 - enh(swift) `@unchecked` and `@Sendable` support [Bradley Mackey][]
+- enh(scala) add using directives support `//> using foo bar` [Jamie Thompson][]
 
-Dev tool: 
+Dev tool:
 
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -151,6 +151,34 @@ export default function(hljs) {
     beginScope: { 2: "keyword", }
   };
 
+  // glob all non-whitespace characters as a "string"
+  // sourced from https://github.com/scala/docs.scala-lang/pull/2845
+  const DIRECTIVE_VALUE = {
+    className: 'string',
+    begin: /\S+/,
+  }
+
+  // directives
+  // sourced from https://github.com/scala/docs.scala-lang/pull/2845
+  const USING_DIRECTIVE = {
+    begin: [
+      '//>',
+      /\s+/,
+      /using/,
+      /\s+/,
+      /\S+/
+    ],
+    beginScope: {
+      1: "comment",
+      3: "keyword",
+      5: "type"
+    },
+    end: /$/,
+    contains: [
+      DIRECTIVE_VALUE,
+    ]
+  }
+
   return {
     name: 'Scala',
     keywords: {
@@ -158,6 +186,7 @@ export default function(hljs) {
       keyword: 'type yield lazy override def with val var sealed abstract private trait object if then forSome for while do throw finally protected extends import final return else break new catch super class case package default try this match continue throws implicit export enum given transparent'
     },
     contains: [
+      USING_DIRECTIVE,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       STRING,

--- a/test/markup/scala/using-directives.expect.txt
+++ b/test/markup/scala/using-directives.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-comment">//&gt;</span> <span class="hljs-keyword">using</span> <span class="hljs-type">scala</span> <span class="hljs-string">3.3.0</span>
+<span class="hljs-comment">//&gt;</span> <span class="hljs-keyword">using</span> <span class="hljs-type">options</span> <span class="hljs-string">-source:future</span> <span class="hljs-string">-Xfatal-warnings</span>
+<span class="hljs-comment">//&gt;</span> <span class="hljs-keyword">using</span> <span class="hljs-type">test.resourceDir</span> <span class="hljs-string">./resources</span>
+<span class="hljs-comment">// using foo bar &lt;-- this should not be highlighted</span>

--- a/test/markup/scala/using-directives.txt
+++ b/test/markup/scala/using-directives.txt
@@ -1,0 +1,4 @@
+//> using scala 3.3.0
+//> using options -source:future -Xfatal-warnings
+//> using test.resourceDir ./resources
+// using foo bar <-- this should not be highlighted


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add support for highlighting using directives

e.g. 

```scala
//> using scala 3.3.0
//> using options -source:future -Xfatal-warnings
//> using test.resourceDir ./resources
```

for reference, see the new directives syntax at https://scala-cli.virtuslab.org/docs/reference/directives

originally based on https://github.com/scala/docs.scala-lang/pull/2845

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Add a new comment kind for using directives, highlighting keys as a `type`, values as a `string`, and `using` as a keyword

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
