### PR TITLE
XQuery: common .xqm suffix added

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -237,7 +237,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | X++                     | axapta, x++            |         |
 | x86 Assembly            | x86asm                 |         |
 | XL                      | xl, tao                |         |
-| XQuery                  | xquery, xpath, xq      |         |
+| XQuery                  | xquery, xpath, xq, xqm |         |
 | YAML                    | yml, yaml              |         |
 | ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |
 | Zephir                  | zephir, zep            |         |

--- a/src/languages/xquery.js
+++ b/src/languages/xquery.js
@@ -348,7 +348,8 @@ export default function(_hljs) {
     name: 'XQuery',
     aliases: [
       'xpath',
-      'xq'
+      'xq',
+      'xqm'
     ],
     case_insensitive: false,
     illegal: /(proc)|(abstract)|(extends)|(until)|(#)/,


### PR DESCRIPTION
Add .xqm suffix for XQuery files

### Changes
`xqm` is a common suffix for XQuery library modules, it is used by BaseX and eXist-db, and possibly other XQuery processors.
