### PR TITLE
enh(swift) ownership modifiers support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
 - enh(swift) regex literal support [Bradley Mackey][]
 - enh(swift) `@unchecked` and `@Sendable` support [Bradley Mackey][]
+- enh(swift) ownership modifiers support [Bradley Mackey][]
 
 Dev tool: 
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -44,6 +44,7 @@ export const keywords = [
   'case',
   'catch',
   'class',
+  'consume', // contextual
   'continue',
   'convenience', // contextual
   'default',

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -40,13 +40,16 @@ export const keywords = [
   /as\?/, // operator
   /as!/, // operator
   'as', // operator
+  'borrowing', // contextual
   'break',
   'case',
   'catch',
   'class',
   'consume', // contextual
+  'consuming', // contextual
   'continue',
   'convenience', // contextual
+  'copy', // contextual
   'default',
   'defer',
   'deinit',

--- a/test/markup/swift/ownership.expect.txt
+++ b/test/markup/swift/ownership.expect.txt
@@ -1,5 +1,23 @@
 <span class="hljs-keyword">consume</span> x
 <span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">consume</span> y
 doStuffUniquely(with: <span class="hljs-keyword">consume</span> x)
+<span class="hljs-keyword">copy</span> x
+<span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">copy</span> x
+doStuff(with: <span class="hljs-keyword">copy</span> x)
 
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: ~<span class="hljs-title class_">Copyable</span> {}
+
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">B</span>: <span class="hljs-title class_">P</span> {
+  <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-params">x</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>, <span class="hljs-params">y</span>: <span class="hljs-keyword">consuming</span> <span class="hljs-type">Foo</span>)
+}
+<span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-keyword">_</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>)
+<span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-keyword">_</span>: <span class="hljs-keyword">consuming</span> <span class="hljs-type">Foo</span>)
+<span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-keyword">_</span>: <span class="hljs-keyword">inout</span> <span class="hljs-type">Foo</span>)
+<span class="hljs-keyword">let</span> f: (<span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>) -&gt; <span class="hljs-type">Void</span> <span class="hljs-operator">=</span> { a <span class="hljs-keyword">in</span> a.foo() }
+<span class="hljs-keyword">let</span> f: (<span class="hljs-keyword">consuming</span> <span class="hljs-type">Foo</span>) -&gt; <span class="hljs-type">Void</span> <span class="hljs-operator">=</span> { a <span class="hljs-keyword">in</span> a.foo() }
+<span class="hljs-keyword">let</span> f: (<span class="hljs-keyword">inout</span> <span class="hljs-type">Foo</span>) -&gt; <span class="hljs-type">Void</span> <span class="hljs-operator">=</span> { a <span class="hljs-keyword">in</span> a.foo() }
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">Foo</span> {
+  <span class="hljs-keyword">consuming</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>()
+  <span class="hljs-keyword">borrowing</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>()
+  <span class="hljs-keyword">mutating</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>()
+}

--- a/test/markup/swift/ownership.expect.txt
+++ b/test/markup/swift/ownership.expect.txt
@@ -1,3 +1,5 @@
 <span class="hljs-keyword">consume</span> x
 <span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">consume</span> y
 doStuffUniquely(with: <span class="hljs-keyword">consume</span> x)
+
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: ~<span class="hljs-title class_">Copyable</span> {}

--- a/test/markup/swift/ownership.expect.txt
+++ b/test/markup/swift/ownership.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-keyword">consume</span> x
+<span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">consume</span> y
+doStuffUniquely(with: <span class="hljs-keyword">consume</span> x)

--- a/test/markup/swift/ownership.txt
+++ b/test/markup/swift/ownership.txt
@@ -1,5 +1,23 @@
 consume x
 _ = consume y
 doStuffUniquely(with: consume x)
+copy x
+_ = copy x
+doStuff(with: copy x)
 
 struct MoveOnly: ~Copyable {}
+
+struct B: P {
+  func foo(x: borrowing Foo, y: consuming Foo)
+}
+func foo(_: borrowing Foo)
+func foo(_: consuming Foo)
+func foo(_: inout Foo)
+let f: (borrowing Foo) -> Void = { a in a.foo() }
+let f: (consuming Foo) -> Void = { a in a.foo() }
+let f: (inout Foo) -> Void = { a in a.foo() }
+struct Foo {
+  consuming func foo()
+  borrowing func foo()
+  mutating func foo()
+}

--- a/test/markup/swift/ownership.txt
+++ b/test/markup/swift/ownership.txt
@@ -1,0 +1,3 @@
+consume x
+_ = consume y
+doStuffUniquely(with: consume x)

--- a/test/markup/swift/ownership.txt
+++ b/test/markup/swift/ownership.txt
@@ -1,3 +1,5 @@
 consume x
 _ = consume y
 doStuffUniquely(with: consume x)
+
+struct MoveOnly: ~Copyable {}


### PR DESCRIPTION
Implements various ownership constructs from [Swift Evolution](https://github.com/apple/swift-evolution). These are implemented in Swift 5.9.

- SE-0366 (`consume`)
- SE-0377 (`borrowing`, `consuming`, `copy`)
- SE-0390 (verify `~Copyable` highlighting)

### Changes
- Support `consume`, `copy`, `borrowing`, `consuming` contextual keywords in Swift, the basis of the ownership-based memory model.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
