### PR TITLE
enh(nsis) Add !assert compiler flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(swift) support parameter pack keywords [Bradley Mackey][]
 - enh(swift) regex literal support [Bradley Mackey][]
 - enh(swift) `@unchecked` and `@Sendable` support [Bradley Mackey][]
+- enh(nsis) Add `!assert` compiler flag [idleberg][]
 
 Dev tool: 
 

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -114,6 +114,7 @@ export default function(hljs) {
     "addincludedir",
     "addplugindir",
     "appendfile",
+    "assert",
     "cd",
     "define",
     "delfile",

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -3,6 +3,8 @@
   for highlight.js
 */</span>
 
+<span class="hljs-keyword">!assert</span> <span class="hljs-variable">${NSIS_CHAR_SIZE}</span> = <span class="hljs-number">2</span> <span class="hljs-string">&quot;Unicode required&quot;</span>
+
 <span class="hljs-comment">; Includes</span>
 <span class="hljs-keyword">!include</span> MUI2.nsh
 

--- a/test/markup/nsis/default.txt
+++ b/test/markup/nsis/default.txt
@@ -3,6 +3,8 @@
   for highlight.js
 */
 
+!assert ${NSIS_CHAR_SIZE} = 2 "Unicode required"
+
 ; Includes
 !include MUI2.nsh
 


### PR DESCRIPTION
### Changes
- adds `!assert` command, as introduced by NSIS v3.09 (see [changelog](https://nsis.sourceforge.io/Docs/AppendixF.html#v3.09))

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
