### PR TITLE
(chore) drop support for Node.js 14

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 11.9.0 (next release)
 
+Supported Node.js versions:
+
+- (chore) Drops support for Node 14.x, which is no longer supported by Node.js.
+
 Parser:
 
 - (enh) prevent rehighlighting of an element [joshgoebel][]


### PR DESCRIPTION
Node.js 14 reached EOL on 2023-04-30. As it is no longer officially supported or receiving security updates, we should drop it from official support and testing.

This follows the precendent of dropping 12.x support this time last year.

This isn't a breaking change for clients.

### Changes
- Drop official support for Node.js 14.x by no longer testing it
- Run CI on actively supported Node versions, including 20.x, which enters LTS on 2023-10-24.

### Checklist
- [x] ~~Added markup tests~~ they don't apply here because this is a CI change only
- [x] Updated the changelog at `CHANGES.md`
