### PR TITLE
enh(nsis) improve highlighter rules and tests

### DIFF
--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -107,7 +107,8 @@ export default function(hljs) {
     "READONLY",
     "SHCTX",
     "SHELL_CONTEXT",
-    "SYSTEM|TEMPORARY",
+    "SYSTEM",
+    "TEMPORARY",
   ];
 
   const COMPILER_FLAGS = [
@@ -348,7 +349,7 @@ export default function(hljs) {
     "ManifestSupportedOS",
     "MessageBox",
     "MiscButtonText",
-    "Name|0",
+    "Name",
     "Nop",
     "OutFile",
     "Page",

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -5,8 +5,6 @@ Author: Jan T. Sott <jan.sott@gmail.com>
 Website: https://nsis.sourceforge.io/Main_Page
 */
 
-import * as regex from '../lib/regex.js';
-
 export default function(hljs) {
   const regex = hljs.regex;
   const LANGUAGE_CONSTANTS = [

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -18,7 +18,7 @@
 
 <span class="hljs-comment">; Runtime Condition</span>
 <span class="hljs-keyword">!if</span> <span class="hljs-literal">true</span> == <span class="hljs-literal">false</span>
-<span class="hljs-keyword">!error</span>
+  <span class="hljs-keyword">!error</span>
 <span class="hljs-keyword">!endif</span>
 
 <span class="hljs-comment">; Settings</span>

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -27,7 +27,7 @@
 <span class="hljs-keyword">RequestExecutionLevel</span> <span class="hljs-literal">user</span>
 <span class="hljs-keyword">CRCCheck</span> <span class="hljs-literal">on</span>
 
-<span class="hljs-keyword">!if</span>def <span class="hljs-variable">${x64}</span>
+<span class="hljs-keyword">!ifdef</span> <span class="hljs-variable">${x64}</span>
   <span class="hljs-keyword">InstallDir</span> <span class="hljs-string">&quot;<span class="hljs-variable constant_">$PROGRAMFILES64</span>\installer_name&quot;</span>
 <span class="hljs-keyword">!else</span>
   <span class="hljs-keyword">InstallDir</span> <span class="hljs-string">&quot;<span class="hljs-variable constant_">$PROGRAMFILES</span>\installer_name&quot;</span>

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -16,6 +16,11 @@
   <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">&quot;Hello <span class="hljs-variable">${Name}</span>&quot;</span>
 <span class="hljs-keyword">!macroend</span>
 
+<span class="hljs-comment">; Runtime Condition</span>
+<span class="hljs-keyword">!if</span> <span class="hljs-literal">true</span> == <span class="hljs-literal">false</span>
+<span class="hljs-keyword">!error</span>
+<span class="hljs-keyword">!endif</span>
+
 <span class="hljs-comment">; Settings</span>
 <span class="hljs-keyword">Name</span> <span class="hljs-string">&quot;installer_name&quot;</span>
 <span class="hljs-keyword">OutFile</span> <span class="hljs-string">&quot;installer_name.exe&quot;</span>

--- a/test/markup/nsis/default.expect.txt
+++ b/test/markup/nsis/default.expect.txt
@@ -11,6 +11,11 @@
 <span class="hljs-comment">; Defines</span>
 <span class="hljs-keyword">!define</span> x64 <span class="hljs-string">&quot;true&quot;</span>
 
+<span class="hljs-comment">; Macros</span>
+<span class="hljs-keyword">!macro</span> Greeter Name
+  <span class="hljs-keyword">DetailPrint</span> <span class="hljs-string">&quot;Hello <span class="hljs-variable">${Name}</span>&quot;</span>
+<span class="hljs-keyword">!macroend</span>
+
 <span class="hljs-comment">; Settings</span>
 <span class="hljs-keyword">Name</span> <span class="hljs-string">&quot;installer_name&quot;</span>
 <span class="hljs-keyword">OutFile</span> <span class="hljs-string">&quot;installer_name.exe&quot;</span>

--- a/test/markup/nsis/default.txt
+++ b/test/markup/nsis/default.txt
@@ -11,6 +11,11 @@
 ; Defines
 !define x64 "true"
 
+; Macros
+!macro Greeter Name
+  DetailPrint "Hello ${Name}"
+!macroend
+
 ; Settings
 Name "installer_name"
 OutFile "installer_name.exe"

--- a/test/markup/nsis/default.txt
+++ b/test/markup/nsis/default.txt
@@ -16,6 +16,11 @@
   DetailPrint "Hello ${Name}"
 !macroend
 
+; Runtime Condition
+!if true == false
+  !error
+!endif
+
 ; Settings
 Name "installer_name"
 OutFile "installer_name.exe"


### PR DESCRIPTION
I have identified several highlighting issues and reported them https://github.com/highlightjs/highlight.js/issues/3821. In my *memory*, these inconsistencies did not exist in earlier versions, but I could be wrong.

This PR adds some tests to identify the problems Obviously, the highlighting rules need to be updated before a merge, so I consider this PR *work in progress*.

Specifically, I tried adding block-keywords such as `!macro` / `!macroend` to the [beginKeywords](https://github.com/highlightjs/highlight.js/blob/700626f10a6acb4f4eb6bdcbe3bf618d4b8e0fa7/src/languages/nsis.js#L544) block, but this did not solve the problem. Could the exclamation mark, as a non-word character cause this problem? Also, defining `!macroend` *before* the `!macro` keyword did not have an effect. I'm looking for some direction on how to tackle these issues!

### Changes

- ✅ add test for macro definitions
- ✅ add test for runtime condition
- ✅ fix expected markup for !ifdef keyword
- ✅ fix issues caused by manual editing
- ✅ remove unused import

### Todo

- identify and write missing test cases
- fix specific highlighter issues

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
