### PR TITLE
(enh) add lib/common.js to sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
   "sideEffects": [
+    "./es/common.js",
+    "./lib/common.js",
     "*.css",
     "*.scss"
   ],


### PR DESCRIPTION
vite/rollup will treeshake side effect imports (whereas webpack will not) if the files themselves are not marked in package.json

<!--- Provide a general summary of your changes in the Title above -->
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Resolves #3827

### Changes
<!--- Describe your changes -->

Mark `./lib/common.js` and `./es/common.js` as files with side effects

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
