### PR TITLE
enh(sql) add limit keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Core Grammars:
 - fix(haskell) do not treat double dashes inside infix operators as comments [Zlondrej][]
 - enh(rust) added `eprintln!` macro [qoheniac][]
 - enh(leaf) update syntax to 4.0 [Samuel Bishop][]
+- enh(sql) add `limit` keyword [CoffeelessProgrammer][]
 
 Dev tool:
 
@@ -38,6 +39,7 @@ Dev tool:
 [Bradley Mackey]: https://github.com/bradleymackey
 [qoheniac]: https://github.com/qoheniac
 [Samuel Bishop]: https://github.com/dannflor
+[CoffeelessProgrammer]: https://github.com/CoffeelessProgrammer
 
 
 ## Version 11.8.0

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -276,6 +276,7 @@ export default function(hljs) {
     "left",
     "like",
     "like_regex",
+    "limit",
     "listagg",
     "ln",
     "local",

--- a/test/markup/sql/keywords.expect.txt
+++ b/test/markup/sql/keywords.expect.txt
@@ -1,1 +1,1 @@
-<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.select <span class="hljs-keyword">is</span> <span class="hljs-keyword">null</span>;
+<span class="hljs-keyword">select</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">from</span> t <span class="hljs-keyword">where</span> t.select <span class="hljs-keyword">is</span> <span class="hljs-keyword">null</span> <span class="hljs-keyword">limit</span> 5;

--- a/test/markup/sql/keywords.txt
+++ b/test/markup/sql/keywords.txt
@@ -1,1 +1,1 @@
-select * from t where t.select is null;
+select * from t where t.select is null limit 5;


### PR DESCRIPTION
### Changes
Added `limit` keyword to sql syntax highlighting. Limit is commonly in SQL flavors to specify number of records/rows to be returned by a query.

### Checklist
- [X] Added markup tests
- [X] Updated the changelog at `CHANGES.md`
