### PR TITLE
Add 32 and 64 bit ARMv8 Registers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ New Grammars:
 
 Core Grammars:
 
+- enh(armasm) added `x0-x30` and `r0-r30` ARMv8 registers [Nicholas Thompson][]
 - enh(haxe) added `final`, `is`, `macro` keywords and `$` identifiers [Robert Borghese][]
 - enh(haxe) support numeric separators and suffixes [Robert Borghese][]
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]
@@ -50,6 +51,7 @@ Dev tool:
 [qoheniac]: https://github.com/qoheniac
 [Samuel Bishop]: https://github.com/dannflor
 [gondow]: https://github.com/gondow
+[Nicholas Thompson]: https://github.com/NAThompson
 
 ## Version 11.8.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ New Grammars:
 
 Core Grammars:
 
-- enh(armasm) added `x0-x30` and `r0-r30` ARMv8 registers [Nicholas Thompson][]
+- enh(armasm) added `x0-x30` and `w0-w30` ARMv8 registers [Nicholas Thompson][]
 - enh(haxe) added `final`, `is`, `macro` keywords and `$` identifiers [Robert Borghese][]
 - enh(haxe) support numeric separators and suffixes [Robert Borghese][]
 - fix(haxe) fixed metadata arguments and support non-colon syntax [Robert Borghese][]

--- a/src/languages/armasm.js
+++ b/src/languages/armasm.js
@@ -32,6 +32,10 @@ export default function(hljs) {
         + 'ALIAS ALIGN ARM AREA ASSERT ATTR CN CODE CODE16 CODE32 COMMON CP DATA DCB DCD DCDU DCDO DCFD DCFDU DCI DCQ DCQU DCW DCWU DN ELIF ELSE END ENDFUNC ENDIF ENDP ENTRY EQU EXPORT EXPORTAS EXTERN FIELD FILL FUNCTION GBLA GBLL GBLS GET GLOBAL IF IMPORT INCBIN INCLUDE INFO KEEP LCLA LCLL LCLS LTORG MACRO MAP MEND MEXIT NOFP OPT PRESERVE8 PROC QN READONLY RELOC REQUIRE REQUIRE8 RLIST FN ROUT SETA SETL SETS SN SPACE SUBT THUMB THUMBX TTL WHILE WEND ',
       built_in:
         'r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 ' // standard registers
+        + 'w0 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 ' // 32 bit ARMv8 registers
+        + 'w16 w17 w18 w19 w20 w21 w22 w23 w24 w25 w26 w27 w28 w29 w30 '
+        + 'x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 ' // 64 bit ARMv8 registers
+        + 'x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 '
         + 'pc lr sp ip sl sb fp ' // typical regs plus backward compatibility
         + 'a1 a2 a3 a4 v1 v2 v3 v4 v5 v6 v7 v8 f0 f1 f2 f3 f4 f5 f6 f7 ' // more regs and fp
         + 'p0 p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 ' // coprocessor regs


### PR DESCRIPTION
ARMv8 provides 31 64 bit registers labelled `x0-x30`. In addition, their 32 bit low bits are labelled `w0-w30`.

Add them to the known register set in armasm.js.

See [here](https://developer.arm.com/documentation/den0024/a/ARMv8-Registers) for details.

### Checklist
- [ ] Added markup tests (need to learn how to do this!)
- [x] Updated the changelog at `CHANGES.md`
