### PR TITLE
(chore) Remove discontinued badges from README

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Core Grammars:
 
 Dev tool:
 
+- (chore) Remove discontinued badges from README [Bradley Mackey][]
 - (chore) Update dev tool to use the new `highlight` API. [Shah Shabbir Ahmmed][]
 - (enh) Auto-update the highlighted output when the language dropdown changes. [Shah Shabbir Ahmmed][]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![jsDelivr CDN downloads](https://badgen.net/jsdelivr/hits/gh/highlightjs/cdn-release?label=jsDelivr+CDN&color=purple)](https://www.jsdelivr.com/package/gh/highlightjs/cdn-release)
 
 [![ci status](https://badgen.net/github/checks/highlightjs/highlight.js/main?label=build)](https://github.com/highlightjs/highlight.js/actions/workflows/tests.js.yml)
+[![CodeQL](https://github.com/highlightjs/highlight.js/workflows/CodeQL/badge.svg)](https://github.com/highlightjs/highlight.js/actions/workflows/github-code-scanning/codeql)
 [![vulnerabilities](https://badgen.net/snyk/highlightjs/highlight.js)](https://snyk.io/test/github/highlightjs/highlight.js?targetFile=package.json)
 
 [![discord](https://badgen.net/badge/icon/discord?icon=discord&label&color=pink)](https://discord.gg/M24EbU7ja9)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@
 [![jsDelivr CDN downloads](https://badgen.net/jsdelivr/hits/gh/highlightjs/cdn-release?label=jsDelivr+CDN&color=purple)](https://www.jsdelivr.com/package/gh/highlightjs/cdn-release)
 
 [![ci status](https://badgen.net/github/checks/highlightjs/highlight.js/main?label=build)](https://github.com/highlightjs/highlight.js/actions/workflows/tests.js.yml)
-[![code quality](https://badgen.net/lgtm/grade/g/highlightjs/highlight.js/js?label=code+quality)](https://lgtm.com/projects/g/highlightjs/highlight.js/?mode=list)
 [![vulnerabilities](https://badgen.net/snyk/highlightjs/highlight.js)](https://snyk.io/test/github/highlightjs/highlight.js?targetFile=package.json)
-![dev deps](https://badgen.net/david/dev/highlightjs/highlight.js?label=dev+deps)
-
 
 [![discord](https://badgen.net/badge/icon/discord?icon=discord&label&color=pink)](https://discord.gg/M24EbU7ja9)
 [![open issues](https://badgen.net/github/open-issues/highlightjs/highlight.js?label=issues)](https://github.com/highlightjs/highlight.js/issues)


### PR DESCRIPTION
### Changes
- Remove broken `dev deps` badge from README
- Update code quality to CodeQL, with github badge:

<img src="https://github.com/highlightjs/highlight.js/workflows/CodeQL/badge.svg">


### Checklist
- [x] ~~Added markup tests~~
- [x] Updated the changelog at `CHANGES.md`
