### PR TITLE
enh(swift) macro attributes are highlighted as keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Core Grammars:
 - enh(rust) added `eprintln!` macro [qoheniac][]
 - enh(leaf) update syntax to 4.0 [Samuel Bishop][]
 - fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
+- enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
 
 Dev tool:
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -282,13 +282,16 @@ export const typeIdentifier = concat(/[A-Z]/, identifierCharacter, '*');
 
 // Built-in attributes, which are highlighted as keywords.
 // @available is handled separately.
+// https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes
 export const keywordAttributes = [
+  'attached',
   'autoclosure',
   concat(/convention\(/, either('swift', 'block', 'c'), /\)/),
   'discardableResult',
   'dynamicCallable',
   'dynamicMemberLookup',
   'escaping',
+  'freestanding',
   'frozen',
   'GKInspectable',
   'IBAction',

--- a/test/markup/swift/macro.expect.txt
+++ b/test/markup/swift/macro.expect.txt
@@ -1,6 +1,9 @@
 <span class="hljs-keyword">macro</span> <span class="hljs-title function_">warning</span>(<span class="hljs-keyword">_</span> <span class="hljs-params">message</span>: <span class="hljs-type">String</span>) <span class="hljs-operator">=</span> #externalMacro(module: <span class="hljs-string">&quot;MyMacros&quot;</span>, type: <span class="hljs-string">&quot;WarningMacro&quot;</span>)
 
-<span class="hljs-meta">@freestanding</span>(declaration)
+<span class="hljs-keyword">@freestanding</span>(declaration)
 <span class="hljs-keyword">macro</span> <span class="hljs-title function_">error</span>(<span class="hljs-keyword">_</span> <span class="hljs-params">message</span>: <span class="hljs-type">String</span>) <span class="hljs-operator">=</span> #externalMacro(module: <span class="hljs-string">&quot;MyMacros&quot;</span>, type: <span class="hljs-string">&quot;ErrorMacro&quot;</span>)
+
+<span class="hljs-keyword">@attached</span>(member)
+<span class="hljs-keyword">macro</span> <span class="hljs-title function_">OptionSetMembers</span>()
 
 #myMacro()

--- a/test/markup/swift/macro.txt
+++ b/test/markup/swift/macro.txt
@@ -3,4 +3,7 @@ macro warning(_ message: String) = #externalMacro(module: "MyMacros", type: "War
 @freestanding(declaration)
 macro error(_ message: String) = #externalMacro(module: "MyMacros", type: "ErrorMacro")
 
+@attached(member)
+macro OptionSetMembers()
+
 #myMacro()


### PR DESCRIPTION
Macro attributes in Swift should be highlighted as keywords, according to [the docs](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#).

### Changes
- `@attached` and `@freestanding` are keyword attributes

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
