### PR TITLE
fix(swift) `warn_unqualified_access` is an attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Core Grammars:
 - fix(haskell) do not treat double dashes inside infix operators as comments [Zlondrej][]
 - enh(rust) added `eprintln!` macro [qoheniac][]
 - enh(leaf) update syntax to 4.0 [Samuel Bishop][]
+- fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
 
 Dev tool:
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -169,7 +169,6 @@ export const numberSignKeywords = [
   '#line',
   '#selector',
   '#sourceLocation',
-  '#warn_unqualified_access',
   '#warning'
 ];
 
@@ -314,7 +313,8 @@ export const keywordAttributes = [
   'UIApplicationMain',
   'unchecked',
   'unknown',
-  'usableFromInline'
+  'usableFromInline',
+  'warn_unqualified_access'
 ];
 
 // Contextual keywords used in @available and #(un)available.

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -7,5 +7,6 @@
 <span class="hljs-keyword">@resultBuilder</span>
 <span class="hljs-keyword">@Sendable</span>
 <span class="hljs-keyword">@unchecked</span>
+<span class="hljs-keyword">@warn_unqualified_access</span>
 
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -7,5 +7,6 @@
 @resultBuilder
 @Sendable
 @unchecked
+@warn_unqualified_access
 
 @ notAnAttribute


### PR DESCRIPTION
According to the docs for [attributes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#), `warn_unqualified_access` is an attribute. It is not a number sign keyword.

### Changes
- Highlight `@warn_unqualified_access` as a keyword

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
