### PR TITLE
(chore) Upgrade size report comment workflow to github-script v6

### DIFF
--- a/.github/workflows/size_report_comment.yml
+++ b/.github/workflows/size_report_comment.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "Download size report artifact"
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -37,7 +37,7 @@ jobs:
       - run: unzip -d size_report size_report.zip
 
       - name: "Comment on PR"
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/size_report_comment.yml
+++ b/.github/workflows/size_report_comment.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -25,7 +25,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "size_report"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -44,7 +44,7 @@ jobs:
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('./size_report/pull_req_nr'));
             var size_report = String(fs.readFileSync('./size_report/report.md'));
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,


### PR DESCRIPTION
### Changes
- Dependency upgrade for dev workflow
- Tested in https://github.com/bradleymackey/highlight.js/pull/49 (where `main` already has these changes merged in)
- This replaces #3848

### Checklist
- [x] ~~Added markup tests~~
- [x] ~~Updated the changelog at `CHANGES.md`~~
