### PR TITLE
fix(css) fix overly greedy pseudo class matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Core Grammars:
 - fix(reasonml) simplify syntax and align it with ocaml [jchavarri][]
 - fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
 - enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
+- fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
 
 Dev tool:
 

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -118,6 +118,9 @@ export const TAGS = [
   'video'
 ];
 
+// Sorting, then reversing makes sure longer attributes/elements like
+// `font-weight` are matched fully instead of getting false positives on say `font`
+
 export const MEDIA_FEATURES = [
   'any-hover',
   'any-pointer',
@@ -595,8 +598,6 @@ export const ATTRIBUTES = [
   'word-wrap',
   'writing-mode',
   'z-index'
-  // reverse makes sure longer attributes `font-weight` are matched fully
-  // instead of getting false positives on say `font`
 ].sort().reverse();
 
 // some grammars use them all as a single group

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -153,7 +153,7 @@ export const MEDIA_FEATURES = [
   'max-width',
   'min-height',
   'max-height'
-];
+].sort().reverse();
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
 export const PSEUDO_CLASSES = [
@@ -216,7 +216,7 @@ export const PSEUDO_CLASSES = [
   'valid',
   'visited',
   'where' // where()
-];
+].sort().reverse();
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
 export const PSEUDO_ELEMENTS = [
@@ -234,7 +234,7 @@ export const PSEUDO_ELEMENTS = [
   'selection',
   'slotted',
   'spelling-error'
-];
+].sort().reverse();
 
 export const ATTRIBUTES = [
   'align-content',
@@ -597,7 +597,7 @@ export const ATTRIBUTES = [
   'z-index'
   // reverse makes sure longer attributes `font-weight` are matched fully
   // instead of getting false positives on say `font`
-].reverse();
+].sort().reverse();
 
 // some grammars use them all as a single group
 export const PSEUDO_SELECTORS = PSEUDO_CLASSES.concat(PSEUDO_ELEMENTS);

--- a/test/markup/css/pseudo-selector.expect.txt
+++ b/test/markup/css/pseudo-selector.expect.txt
@@ -16,3 +16,9 @@
 <span class="hljs-selector-pseudo">:last-of-type</span> {
   <span class="hljs-attribute">padding</span>: <span class="hljs-number">0</span>;
 }
+
+<span class="hljs-selector-tag">p</span><span class="hljs-selector-pseudo">::first-letter</span> {
+  <span class="hljs-attribute">font-size</span>: <span class="hljs-number">1.5rem</span>;
+  <span class="hljs-attribute">font-weight</span>: bold;
+  <span class="hljs-attribute">color</span>: brown;
+}

--- a/test/markup/css/pseudo-selector.expect.txt
+++ b/test/markup/css/pseudo-selector.expect.txt
@@ -1,2 +1,18 @@
 <span class="hljs-selector-tag">li</span><span class="hljs-selector-pseudo">:not</span>(<span class="hljs-selector-class">.red</span>){}
 <span class="hljs-selector-tag">li</span><span class="hljs-selector-pseudo">:not</span>(<span class="hljs-selector-class">.red</span>)<span class="hljs-selector-pseudo">:not</span>(<span class="hljs-selector-class">.green</span>){}
+
+<span class="hljs-selector-pseudo">:first-child</span> {
+  <span class="hljs-attribute">padding</span>: <span class="hljs-number">0</span>;
+}
+
+<span class="hljs-selector-pseudo">:first-of-type</span> {
+  <span class="hljs-attribute">padding</span>: <span class="hljs-number">0</span>;
+}
+
+<span class="hljs-selector-pseudo">:last-child</span> {
+  <span class="hljs-attribute">padding</span>: <span class="hljs-number">0</span>;
+}
+
+<span class="hljs-selector-pseudo">:last-of-type</span> {
+  <span class="hljs-attribute">padding</span>: <span class="hljs-number">0</span>;
+}

--- a/test/markup/css/pseudo-selector.txt
+++ b/test/markup/css/pseudo-selector.txt
@@ -1,2 +1,18 @@
 li:not(.red){}
 li:not(.red):not(.green){}
+
+:first-child {
+  padding: 0;
+}
+
+:first-of-type {
+  padding: 0;
+}
+
+:last-child {
+  padding: 0;
+}
+
+:last-of-type {
+  padding: 0;
+}

--- a/test/markup/css/pseudo-selector.txt
+++ b/test/markup/css/pseudo-selector.txt
@@ -16,3 +16,9 @@ li:not(.red):not(.green){}
 :last-of-type {
   padding: 0;
 }
+
+p::first-letter {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: brown;
+}


### PR DESCRIPTION
Resolves #3815 

### Changes
- Ensure CSS attributes/elements are both sorted, then reversed to ensure matching does not greedily match shorter strings.
- `ATTRIBUTES` already used this trick, but we should sort as well to ensure that an ordering issue does not affect this behaviour.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
