### PR TITLE
Fix/issue 3823

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Core Grammars:
 - fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
 - enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
 - enh(stan) updated for version 2.33 (#3859) [Brian Ward][]
+- fix(css) added '_'  css variable detection [Md Saad Akhtar][]
 
 Dev tool:
 
@@ -64,7 +65,7 @@ Dev tool:
 [Nicholas Thompson]: https://github.com/NAThompson
 [Yasith Deelaka]: https://github.com/YasithD
 [Brian Ward]: https://github.com/WardBrian
-
+[Md Saad Akhtar]: https://github.com/akhtarmdsaad
 
 ## Version 11.8.0
 

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -38,7 +38,7 @@ export const MODES = (hljs) => {
     },
     CSS_VARIABLE: {
       className: "attr",
-      begin: /--[A-Za-z][A-Za-z0-9_-]*/
+      begin: /--[A-Za-z_][A-Za-z0-9_-]*/
     }
   };
 };

--- a/test/markup/css/variables.expect.txt
+++ b/test/markup/css/variables.expect.txt
@@ -7,3 +7,8 @@
  <span class="hljs-attr">--textBlue</span>: blue;
  <span class="hljs-attribute">color</span>: <span class="hljs-built_in">var</span>(--textBlue);
 }
+
+<span class="hljs-selector-tag">body</span> {
+ <span class="hljs-attr">--_margin-top</span>: <span class="hljs-number">1rem</span>;
+ <span class="hljs-attribute">margin-top</span>: <span class="hljs-built_in">var</span>(--_margin-top);
+}

--- a/test/markup/css/variables.txt
+++ b/test/markup/css/variables.txt
@@ -7,3 +7,9 @@ body {
  --textBlue: blue;
  color: var(--textBlue);
 }
+
+body {
+ --_margin-top: 1rem;
+ margin-top: var(--_margin-top);
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Fixed CSS variable detection Syntax

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
It resolves the issue #3823  

### Changes
<!--- Describe your changes -->
There is a bug in src/languages/lib/css-shared.js file. 
adding an underscore( _ ) in CSS_VARIABLES fixes the problem.
Code Before:
<code>
CSS_VARIABLE: {
      className: "attr",
      begin: /--[A-Za-z][A-Za-z0-9_-]*/  
    }
</code>
![image](https://github.com/highlightjs/highlight.js/assets/57033728/dbc37f39-87f5-4ed5-ae61-4e7cdb72a397)

Code After:
<code>
CSS_VARIABLE: {
      className: "attr",
      begin: /--[A-Za-z_][A-Za-z0-9_-]*/  
      //Look change in ^ here
    }
</code>
![after](https://github.com/highlightjs/highlight.js/assets/57033728/e0c603da-4847-49c6-85b6-5ffb09e88f17)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
