### PR TITLE
Fix Preprocessor highlighting in cpp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Core Grammars:
 - fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
 - enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
 - enh(stan) updated for version 2.33 (#3859) [Brian Ward][]
+- fix(css) added '_'  css variable detection
 
 Dev tool:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,8 @@ Core Grammars:
 - fix(swift) `warn_unqualified_access` is an attribute [Bradley Mackey][]
 - enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
 - enh(stan) updated for version 2.33 (#3859) [Brian Ward][]
-- fix(css) added '_'  css variable detection
+- fix(css) added '_'  css variable detection 
+- fix(cpp) preprocessor highlighting fixed [Md Saad Akhtar][]
 
 Dev tool:
 
@@ -65,6 +66,7 @@ Dev tool:
 [Nicholas Thompson]: https://github.com/NAThompson
 [Yasith Deelaka]: https://github.com/YasithD
 [Brian Ward]: https://github.com/WardBrian
+[Md Saad Akhtar]: https://github.com/akhtarmdsaad
 
 
 ## Version 11.8.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@
 ### Individual Contributors
 
 Highlight.js has also been greatly improved over the years thanks to the help of [many other contributors](https://github.com/highlightjs/highlight.js/graphs/contributors).  A big thank you to everyone who has helped make this project what it is today!
+- Md Saad Akhtar <akhtarmdsaad@gmail.com>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Jan T. Sott <git@idleberg.com>",
     "Li Xuanji <xuanji@gmail.com>",
     "Marcos Cáceres <marcos@marcosc.com>",
-    "Sang Dang <sang.dang@polku.io>"
+    "Sang Dang <sang.dang@polku.io>",
+    "Md Saad Akhtar <akhtarmdsaad@gmail.com"
   ],
   "bugs": {
     "url": "https://github.com/highlightjs/highlight.js/issues"

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -62,7 +62,7 @@ export default function(hljs) {
   const PREPROCESSOR = {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,
-    end: /$/,
+    end: /\s/,
     keywords: { keyword:
         'if else elif endif define undef warning error line '
         + 'pragma _Pragma ifdef ifndef include' },

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -38,7 +38,7 @@ export const MODES = (hljs) => {
     },
     CSS_VARIABLE: {
       className: "attr",
-      begin: /--[A-Za-z][A-Za-z0-9_-]*/
+      begin: /--[A-Za-z_][A-Za-z0-9_-]*/
     }
   };
 };

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -27,7 +27,34 @@
     <span class="hljs-built_in">anotherthing</span>();
 <span class="hljs-meta">#<span class="hljs-keyword">endif</span></span>
 }
+<span class="hljs-meta">#<span class="hljs-keyword">include</span> </span>
+<span class="hljs-meta">#<span class="hljs-keyword">include</span>
+</span><span class="hljs-meta">#<span class="hljs-keyword">define</span> </span>what <span class="hljs-keyword">do</span>{ cout &lt;&lt; <span class="hljs-string">"Hello"</span>; } <span class="hljs-keyword">while</span>(<span class="hljs-number">0</span>);
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> </span>PI <span class="hljs-number">3.14</span>;
+<span class="hljs-meta">#<span class="hljs-keyword">pragma</span> </span><span class="hljs-built_in">warning</span>(disable : <span class="hljs-number">1234</span>) <span class="hljs-comment">// Disable a specific warning</span>
+<span class="hljs-meta">#<span class="hljs-keyword">if</span> </span>!<span class="hljs-built_in">defined</span>(CONFIG_OPTION)
+<span class="hljs-meta">#<span class="hljs-keyword">error</span> </span><span class="hljs-string">"CONFIG_OPTION is not defined."</span>
+<span class="hljs-meta">#<span class="hljs-keyword">endif</span>
+</span><span class="hljs-meta">#<span class="hljs-keyword">line</span> </span><span class="hljs-number">42</span> <span class="hljs-string">"mycode.cpp"</span>
+<span class="hljs-meta">#<span class="hljs-keyword">undef</span> </span><span class="hljs-function">PI
 
+<span class="hljs-type">int</span> <span class="hljs-title">main</span><span class="hljs-params">()</span>
+</span>{
+	<span class="hljs-keyword">using</span> <span class="hljs-keyword">namespace</span> std;
+	<span class="hljs-type">int</span> num = <span class="hljs-number">4</span>;
+	cout &lt;&lt; <span class="hljs-string">"Hello"</span>;
+	cout &lt;&lt; <span class="hljs-number">123456</span>;
+	cout &lt;&lt; <span class="hljs-number">15.965</span>;
+	
+	<span class="hljs-built_in">printf</span>(<span class="hljs-string">"Hello"</span>);
+	
+	
+	
+	<span class="hljs-keyword">struct</span> <span class="hljs-title class_">saad</span> obj;
+	<span class="hljs-keyword">do</span>{ cout &lt;&lt; <span class="hljs-string">"Hello"</span>; } <span class="hljs-keyword">while</span>(<span class="hljs-number">0</span>);
+	<span class="hljs-built_in">call</span>();
+	<span class="hljs-type">int</span> x=<span class="hljs-number">5</span>;
+}
 <span class="hljs-comment">// this is a continued\
 comment.</span>
 end

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -28,6 +28,17 @@ if (p) {
 #endif
 }
 
+#include <iostream>
+#include<iostream>
+#define what do{ cout << "Hello"; } while(0);
+#define PI 3.14;
+#pragma warning(disable : 1234) 
+#if !defined(CONFIG_OPTION)
+#error "CONFIG_OPTION is not defined."
+#endif
+#line 42 "mycode.cpp"
+#undef PI
+
 // this is a continued\
 comment.
 end

--- a/test/markup/css/variables.txt
+++ b/test/markup/css/variables.txt
@@ -7,3 +7,9 @@ body {
  --textBlue: blue;
  color: var(--textBlue);
 }
+
+body {
+ --_margin-top: 1rem;
+ margin-top: var(--_margin-top);
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The highlighting of preprocessor goes wrong. Everything after the define line has no highlighting.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
This PR resolves the Issue #3505 

### Changes
<!--- Describe your changes -->
There was a simple change in cpp.js file.
path: `src/languages/cpp.js`

<b>Before:</b>
<code>
const PREPROCESSOR = {
    className: 'meta',
    begin: /#\s*[a-z]+\b/,
    end: /$/, <----------------------------- see this
    keywords: { keyword:
        'if else elif endif define undef warning error line '
        + 'pragma _Pragma ifdef ifndef include' },
    contains: ......
</code>
![image](https://github.com/highlightjs/highlight.js/assets/57033728/6afed0e6-17f7-46e1-bb9f-968c791adcc0)

<b>After</b>
<code>
const PREPROCESSOR = {
    className: 'meta',
    begin: /#\s*[a-z]+\b/,
    end: /\s/, <----------------------- the change
    keywords: { keyword:
        'if else elif endif define undef warning error line '
        + 'pragma _Pragma ifdef ifndef include' },
    contains: ......
</code>

![image](https://github.com/highlightjs/highlight.js/assets/57033728/33434dc3-82d6-4ef7-b972-5255d0925e19)

<b>*There is a problem in include directive since beginning. It omits <....> all stuffs written inside <> braces. My code doesn't interfere with that. I will try to fix that later. </b>


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
