### PR TITLE
fix: fixed #3870 Function names with a prefix shared with a built-in …

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -384,7 +384,7 @@ export default function(hljs) {
     match: regex.concat(
       /\b/,
       noneOf([
-        ...ECMAScript.BUILT_IN_GLOBALS,
+        ...ECMAScript.BUILT_IN_GLOBALS.map((x) => x + '\\('),
         "super",
         "import"
       ]),


### PR DESCRIPTION
…global are confused for a global

Don't exclude a built-in global (e.g. `eval`) followed by an identifier , but exclude built-in global followed by  an open paren (i.e. `eval(`)

See #3870 for an example.
