### PR TITLE
Add record and var keywords to Groovy syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@ Core Grammars:
 - enh(swift) macro attributes are highlighted as keywords [Bradley Mackey][]
 - enh(stan) updated for version 2.33 (#3859) [Brian Ward][]
 - fix(css) added '_'  css variable detection [Md Saad Akhtar][]
+- enh(groovy) add `record` and `var` as keywords [Guillaume Laforge][]
 
 Dev tool:
 
@@ -97,7 +98,6 @@ Core Grammars:
 - enh(php) detect newer more flexible NOWdoc syntax (#3679) [Timur Kamaev][]
 - enh(python) improve autodetection of code with type hinting any function's return type (making the `->` operator legal) [Keyacom][]
 - enh(bash) add `select` and `until` as keywords
-- enh(groovy) add `record` and `var` as keywords [Guillaume Laforge][]
 
 [arnoudbuzing]: https://github.com/arnoudbuzing
 [aliaegik]: https://github.com/aliaegik
@@ -118,6 +118,7 @@ Core Grammars:
 [Boris Verkhovskiy]: https://github.com/verhovsky
 [Cyrus Kao]: https://github.com/CyrusKao
 [Zlondrej]: https://github.com/zlondrej
+[Guillaume Laforge]: https://github.com/glaforge
 
 ## Version 11.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@ Dev tool:
 [Yasith Deelaka]: https://github.com/YasithD
 [Brian Ward]: https://github.com/WardBrian
 [Md Saad Akhtar]: https://github.com/akhtarmdsaad
+[Guillaume Laforge]: https://github.com/glaforge
+
 
 ## Version 11.8.0
 
@@ -118,7 +120,7 @@ Core Grammars:
 [Boris Verkhovskiy]: https://github.com/verhovsky
 [Cyrus Kao]: https://github.com/CyrusKao
 [Zlondrej]: https://github.com/zlondrej
-[Guillaume Laforge]: https://github.com/glaforge
+
 
 ## Version 11.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,7 @@ Core Grammars:
 - enh(php) detect newer more flexible NOWdoc syntax (#3679) [Timur Kamaev][]
 - enh(python) improve autodetection of code with type hinting any function's return type (making the `->` operator legal) [Keyacom][]
 - enh(bash) add `select` and `until` as keywords
+- enh(groovy) add `record` and `var` as keywords [Guillaume Laforge][]
 
 [arnoudbuzing]: https://github.com/arnoudbuzing
 [aliaegik]: https://github.com/aliaegik

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -66,7 +66,7 @@ export default function(hljs) {
 
   const CLASS_DEFINITION = {
     match: [
-      /(class|interface|trait|enum|extends|implements)/,
+      /(class|interface|trait|enum|record|extends|implements)/,
       /\s+/,
       hljs.UNDERSCORE_IDENT_RE
     ],
@@ -126,7 +126,8 @@ export default function(hljs) {
     "import",
     "package",
     "return",
-    "instanceof"
+    "instanceof",
+    "var"
   ];
 
   return {


### PR DESCRIPTION
Groovy added support for `record`s like Java, and also allows the use of `var` (in addition to `def`) to define variables or specified non-typed arguments.
