### PR TITLE
Fix: Added nagative look-ahead keywords for function invocations in the Rust Language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ New Grammars:
 
 Core Grammars:
 
+- fix(rust) added negative-lookahead for callable keywords `if` `while` `for` [Omar Hussein][]
 - enh(armasm) added `x0-x30` and `w0-w30` ARMv8 registers [Nicholas Thompson][]
 - enh(haxe) added `final`, `is`, `macro` keywords and `$` identifiers [Robert Borghese][]
 - enh(haxe) support numeric separators and suffixes [Robert Borghese][]

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -14,7 +14,7 @@ export default function(hljs) {
     relevance: 0,
     begin: regex.concat(
       /\b/,
-      /(?!let\b)/,
+      /(?!let|for|while|if|else|match\b)/,
       hljs.IDENT_RE,
       regex.lookahead(/\s*\(/))
   };

--- a/test/detect/rust/default.txt
+++ b/test/detect/rust/default.txt
@@ -12,5 +12,12 @@ impl From<&'a str> for State {
             "closed" => State::Closed,
             _ => unreachable!(),
         }
+
+        if (str == "trans") {
+            State::Transient;
+        }
+        else if str == "start" {
+            State::Start;
+        }
     }
 }

--- a/test/markup/rust/invoked-keywords.expect.txt
+++ b/test/markup/rust/invoked-keywords.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-keyword">if</span> (<span class="hljs-literal">true</span>) {}
+<span class="hljs-keyword">if</span> <span class="hljs-literal">true</span> {}
+<span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-literal">true</span>) {}
+<span class="hljs-keyword">while</span> (<span class="hljs-literal">true</span>) {}
+<span class="hljs-keyword">while</span> <span class="hljs-literal">true</span> {}
+<span class="hljs-keyword">for</span> (a, b) <span class="hljs-title function_ invoke__">in</span> (<span class="hljs-number">0</span>..<span class="hljs-number">10</span>).<span class="hljs-title function_ invoke__">enumerate</span>() {}
+<span class="hljs-keyword">for</span> <span class="hljs-variable">a</span> <span class="hljs-keyword">in</span> <span class="hljs-number">0</span>..<span class="hljs-number">10</span> {}
+<span class="hljs-keyword">match</span> <span class="hljs-type">str</span> {}
+<span class="hljs-keyword">match</span> (<span class="hljs-type">str</span>) {}

--- a/test/markup/rust/invoked-keywords.txt
+++ b/test/markup/rust/invoked-keywords.txt
@@ -1,0 +1,9 @@
+if (true) {}
+if true {}
+else if (true) {}
+while (true) {}
+while true {}
+for (a, b) in (0..10).enumerate() {}
+for a in 0..10 {}
+match str {}
+match (str) {}


### PR DESCRIPTION
Rust language

Resolves [#3881 ](https://github.com/highlightjs/highlight.js/issues/3881) 

### Changes

Updated Rust function invocation regex handler to address keywords that can be used with parentheses.

![image](https://github.com/highlightjs/highlight.js/assets/77292466/96b3ec74-6d4c-479d-90b9-689cd85b40c6)
 
Negative look-ahead addresses the following keywords:

- `if`
- `else if`
- `for`
- `while`
- `match`

Before:
![image](https://github.com/highlightjs/highlight.js/assets/77292466/661a8173-50cc-4b9a-8aab-a017b6ebf236)

After:
![image](https://github.com/highlightjs/highlight.js/assets/77292466/5e322159-883b-459a-b633-b2a336e7cc01)



### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
