### PR TITLE
add (markdown) emphasis escaping

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -152,11 +152,11 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
-        begin: /\*(?![*\s])/,
+        begin: /(?<!\\)\*(?![*\s])/,
         end: /\*/
       },
       {
-        begin: /_(?![_\s])/,
+        begin: /(?<!\\)_(?![_\s])/,
         end: /_/,
         relevance: 0
       }


### PR DESCRIPTION
## This feature adds the possibility of escaping italic on markdown

Before the only way to write a word with underscore (e.g. SYS_ADMIN) was placing a space after the underscore, now it's possible to escape it with a backslash so it won't trigger the italic feature.

## Change
The change consist on combining the actual negative look-ahead for a space with a negative look-behind for a backslash
