### PR TITLE
fix(python) fix `or` conflicts with string highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Core Grammars:
 - fix(rust) fix escaped double quotes in string  [Mohamed Ali][]
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
+- fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
 
 New Grammars:
 

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -176,7 +176,7 @@ export default function(hljs) {
     contains: [ hljs.BACKSLASH_ESCAPE ],
     variants: [
       {
-        begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
+        begin: /(\W|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -185,7 +185,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
+        begin: /(\W|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -194,7 +194,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /([fF][rR]|[rR][fF]|[fF])'''/,
+        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -204,7 +204,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /([fF][rR]|[rR][fF]|[fF])"""/,
+        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -214,25 +214,25 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /([uU]|[rR])'/,
+        begin: /(\W|^)([uU]|[rR])'/,
         end: /'/,
         relevance: 10
       },
       {
-        begin: /([uU]|[rR])"/,
+        begin: /(\W|^)([uU]|[rR])"/,
         end: /"/,
         relevance: 10
       },
       {
-        begin: /([bB]|[bB][rR]|[rR][bB])'/,
+        begin: /(\W|^)([bB]|[bB][rR]|[rR][bB])'/,
         end: /'/
       },
       {
-        begin: /([bB]|[bB][rR]|[rR][bB])"/,
+        begin: /(\W|^)([bB]|[bB][rR]|[rR][bB])"/,
         end: /"/
       },
       {
-        begin: /([fF][rR]|[rR][fF]|[fF])'/,
+        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])'/,
         end: /'/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -241,7 +241,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /([fF][rR]|[rR][fF]|[fF])"/,
+        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])"/,
         end: /"/,
         contains: [
           hljs.BACKSLASH_ESCAPE,

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -214,7 +214,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /(([uU]|[rR]))'/,
+        begin: /([uU]|[rR])'/,
         end: /'/,
         relevance: 10
       },

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -176,7 +176,7 @@ export default function(hljs) {
     contains: [ hljs.BACKSLASH_ESCAPE ],
     variants: [
       {
-        begin: /(\W|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
+        begin: /((?<!\w)|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -185,7 +185,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /(\W|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
+        begin: /((?<!\w)|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -194,7 +194,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])'''/,
+        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -204,7 +204,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])"""/,
+        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -214,25 +214,25 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /(\W|^)([uU]|[rR])'/,
+        begin: /(((?<!\w)|^)([uU]|[rR]))'/,
         end: /'/,
         relevance: 10
       },
       {
-        begin: /(\W|^)([uU]|[rR])"/,
+        begin: /((?<!\w)|^)([uU]|[rR])"/,
         end: /"/,
         relevance: 10
       },
       {
-        begin: /(\W|^)([bB]|[bB][rR]|[rR][bB])'/,
+        begin: /((?<!\w)|^)([bB]|[bB][rR]|[rR][bB])'/,
         end: /'/
       },
       {
-        begin: /(\W|^)([bB]|[bB][rR]|[rR][bB])"/,
+        begin: /((?<!\w)|^)([bB]|[bB][rR]|[rR][bB])"/,
         end: /"/
       },
       {
-        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])'/,
+        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])'/,
         end: /'/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -241,7 +241,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /(\W|^)([fF][rR]|[rR][fF]|[fF])"/,
+        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])"/,
         end: /"/,
         contains: [
           hljs.BACKSLASH_ESCAPE,

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -176,7 +176,7 @@ export default function(hljs) {
     contains: [ hljs.BACKSLASH_ESCAPE ],
     variants: [
       {
-        begin: /((?<!\w)|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
+        begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -185,7 +185,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /((?<!\w)|^)([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
+        begin: /([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -194,7 +194,7 @@ export default function(hljs) {
         relevance: 10
       },
       {
-        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])'''/,
+        begin: /([fF][rR]|[rR][fF]|[fF])'''/,
         end: /'''/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -204,7 +204,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])"""/,
+        begin: /([fF][rR]|[rR][fF]|[fF])"""/,
         end: /"""/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -214,25 +214,25 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /(((?<!\w)|^)([uU]|[rR]))'/,
+        begin: /(([uU]|[rR]))'/,
         end: /'/,
         relevance: 10
       },
       {
-        begin: /((?<!\w)|^)([uU]|[rR])"/,
+        begin: /([uU]|[rR])"/,
         end: /"/,
         relevance: 10
       },
       {
-        begin: /((?<!\w)|^)([bB]|[bB][rR]|[rR][bB])'/,
+        begin: /([bB]|[bB][rR]|[rR][bB])'/,
         end: /'/
       },
       {
-        begin: /((?<!\w)|^)([bB]|[bB][rR]|[rR][bB])"/,
+        begin: /([bB]|[bB][rR]|[rR][bB])"/,
         end: /"/
       },
       {
-        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])'/,
+        begin: /([fF][rR]|[rR][fF]|[fF])'/,
         end: /'/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -241,7 +241,7 @@ export default function(hljs) {
         ]
       },
       {
-        begin: /((?<!\w)|^)([fF][rR]|[rR][fF]|[fF])"/,
+        begin: /([fF][rR]|[rR][fF]|[fF])"/,
         end: /"/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
@@ -381,6 +381,7 @@ export default function(hljs) {
         beginKeywords: "if",
         relevance: 0
       },
+      { match: /\bor\b/, scope: "keyword" },
       STRING,
       COMMENT_TYPE,
       hljs.HASH_COMMENT_MODE,

--- a/test/markup/python/f-strings.expect.txt
+++ b/test/markup/python/f-strings.expect.txt
@@ -28,10 +28,8 @@ rff<span class="hljs-string">&quot;hello&quot;</span>
 ...
 &quot;</span><span class="hljs-string">&quot;&quot;/span>
 <span class="hljs-string">br&quot;https://&quot;</span>
-orbr<span class="hljs-string">&quot;https://&quot;</span>
 <span class="hljs-keyword">or</span> <span class="hljs-string">br&quot;https://&quot;</span>
 <span class="hljs-string">rb&quot;https://&quot;</span>
-orrb<span class="hljs-string">&quot;https://&quot;</span>
 <span class="hljs-keyword">or</span> <span class="hljs-string">rb&quot;https://&quot;</span>
 test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;&quot;</span>
 

--- a/test/markup/python/f-strings.expect.txt
+++ b/test/markup/python/f-strings.expect.txt
@@ -11,7 +11,6 @@
 <span class="hljs-string">f&quot;{{ }}&quot;</span>
 <span class="hljs-keyword">if</span><span class="hljs-string">&quot;text&quot;</span>==<span class="hljs-string">&quot;text&quot;</span>:
     <span class="hljs-string">&quot;good&quot;</span>
-
 <span class="hljs-string">rf&quot;https://www.<span class="hljs-subst">{domain}</span>.com&quot;</span>
 <span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">fr&quot;&quot;&quot;
 <span class="hljs-meta">... </span>https://www.example.com/{{age}/360}
@@ -23,8 +22,8 @@
 <span class="hljs-keyword">or</span> <span class="hljs-string">rb&quot;https://&quot;</span>
 test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;&quot;</span>
 
-<span class="hljs-string">"my ...
-... name"</span>
+<span class="hljs-string">&quot;my ...
+... name&quot;</span>
 <span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">&quot;my ...
 ... name&quot;</span>
 

--- a/test/markup/python/f-strings.expect.txt
+++ b/test/markup/python/f-strings.expect.txt
@@ -13,20 +13,10 @@
     <span class="hljs-string">&quot;good&quot;</span>
 
 <span class="hljs-string">rf&quot;https://www.<span class="hljs-subst">{domain}</span>.com&quot;</span>
-rrf<span class="hljs-string">&quot;hello, from {&#x27;https://www.{domain}.com&#x27;}&quot;</span>
-rff<span class="hljs-string">&quot;hello&quot;</span>
-<span class="hljs-meta">&gt;&gt;&gt; </span>rrf<span class="hljs-string">&#x27;&#x27;</span><span class="hljs-string">&#x27;
-... hello, 
-... from {&#x27;</span>https://www.{domain}.com<span class="hljs-string">&#x27;}
-&#x27;</span><span class="hljs-string">&#x27;&#x27;</span>
 <span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">fr&quot;&quot;&quot;
 <span class="hljs-meta">... </span>https://www.example.com/{{age}/360}
 ...
 &quot;&quot;&quot;</span>
-<span class="hljs-meta">&gt;&gt;&gt; </span>ffr<span class="hljs-string">&quot;&quot;</span><span class="hljs-string">&quot;
-... https://www.example.com/{{age}/360}
-...
-&quot;</span><span class="hljs-string">&quot;&quot;/span>
 <span class="hljs-string">br&quot;https://&quot;</span>
 <span class="hljs-keyword">or</span> <span class="hljs-string">br&quot;https://&quot;</span>
 <span class="hljs-string">rb&quot;https://&quot;</span>

--- a/test/markup/python/f-strings.expect.txt
+++ b/test/markup/python/f-strings.expect.txt
@@ -11,3 +11,39 @@
 <span class="hljs-string">f&quot;{{ }}&quot;</span>
 <span class="hljs-keyword">if</span><span class="hljs-string">&quot;text&quot;</span>==<span class="hljs-string">&quot;text&quot;</span>:
     <span class="hljs-string">&quot;good&quot;</span>
+
+<span class="hljs-string">rf&quot;https://www.<span class="hljs-subst">{domain}</span>.com&quot;</span>
+rrf<span class="hljs-string">&quot;hello, from {&#x27;https://www.{domain}.com&#x27;}&quot;</span>
+rff<span class="hljs-string">&quot;hello&quot;</span>
+<span class="hljs-meta">&gt;&gt;&gt; </span>rrf<span class="hljs-string">&#x27;&#x27;</span><span class="hljs-string">&#x27;
+... hello, 
+... from {&#x27;</span>https://www.{domain}.com<span class="hljs-string">&#x27;}
+&#x27;</span><span class="hljs-string">&#x27;&#x27;</span>
+<span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">fr&quot;&quot;&quot;
+<span class="hljs-meta">... </span>https://www.example.com/{{age}/360}
+...
+&quot;&quot;&quot;</span>
+<span class="hljs-meta">&gt;&gt;&gt; </span>ffr<span class="hljs-string">&quot;&quot;</span><span class="hljs-string">&quot;
+... https://www.example.com/{{age}/360}
+...
+&quot;</span><span class="hljs-string">&quot;&quot;/span>
+<span class="hljs-string">br&quot;https://&quot;</span>
+orbr<span class="hljs-string">&quot;https://&quot;</span>
+<span class="hljs-keyword">or</span> <span class="hljs-string">br&quot;https://&quot;</span>
+<span class="hljs-string">rb&quot;https://&quot;</span>
+orrb<span class="hljs-string">&quot;https://&quot;</span>
+<span class="hljs-keyword">or</span> <span class="hljs-string">rb&quot;https://&quot;</span>
+test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;&quot;</span>
+
+<span class="hljs-string">"my ...
+... name"</span>
+<span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">&quot;my ...
+... name&quot;</span>
+
+<span class="hljs-built_in">print</span>(<span class="hljs-string">&quot;kkds&quot;</span>+<span class="hljs-string">&quot;kdjsa&quot;</span>)
+<span class="hljs-built_in">print</span>(<span class="hljs-string">&quot;kkds&quot;</span>+<span class="hljs-string">b&quot;kdjsa&quot;</span>)
+<span class="hljs-built_in">print</span>(test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;kdjs&quot;</span>)
+<span class="hljs-built_in">print</span>(test()<span class="hljs-keyword">or</span> <span class="hljs-string">&quot;kdjs&quot;</span>)
+<span class="hljs-built_in">print</span>(test()<span class="hljs-keyword">or</span> <span class="hljs-string">f&quot;kdjs&quot;</span>)
+test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;me&quot;</span>
+<span class="hljs-built_in">print</span>(test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;me&quot;</span>)

--- a/test/markup/python/f-strings.txt
+++ b/test/markup/python/f-strings.txt
@@ -27,10 +27,8 @@ rff"hello"
 ...
 """
 br"https://"
-orbr"https://"
 or br"https://"
 rb"https://"
-orrb"https://"
 or rb"https://"
 test()or""
 

--- a/test/markup/python/f-strings.txt
+++ b/test/markup/python/f-strings.txt
@@ -11,3 +11,38 @@ f"{name + f'{name}'}"
 f"{{ }}"
 if"text"=="text":
     "good"
+rf"https://www.{domain}.com"
+rrf"hello, from {'https://www.{domain}.com'}"
+rff"hello"
+>>> rrf'''
+... hello, 
+... from {'https://www.{domain}.com'}
+'''
+>>> fr"""
+... https://www.example.com/{{age}/360}
+...
+"""
+>>> ffr"""
+... https://www.example.com/{{age}/360}
+...
+"""
+br"https://"
+orbr"https://"
+or br"https://"
+rb"https://"
+orrb"https://"
+or rb"https://"
+test()or""
+
+"my ...
+... name"
+>>> "my ...
+... name"
+
+print("kkds"+"kdjsa")
+print("kkds"+b"kdjsa")
+print(test()or"kdjs")
+print(test()or "kdjs")
+print(test()or f"kdjs")
+test()or"me"
+print(test()or"me")

--- a/test/markup/python/f-strings.txt
+++ b/test/markup/python/f-strings.txt
@@ -12,17 +12,7 @@ f"{{ }}"
 if"text"=="text":
     "good"
 rf"https://www.{domain}.com"
-rrf"hello, from {'https://www.{domain}.com'}"
-rff"hello"
->>> rrf'''
-... hello, 
-... from {'https://www.{domain}.com'}
-'''
 >>> fr"""
-... https://www.example.com/{{age}/360}
-...
-"""
->>> ffr"""
 ... https://www.example.com/{{age}/360}
 ...
 """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I have fixed the error of highlighting the reserved words such as 'or' in the below code.
```
print(test()or'string')
```
That should be in the below image.
![image](https://github.com/highlightjs/highlight.js/assets/76850143/06f4b5c3-18bc-4f2f-9d45-9a2ad7959adf)
Not as this highlight.
![image](https://github.com/highlightjs/highlight.js/assets/76850143/5805a432-1f3e-4b7b-be6c-fbb39b4bc267)

That happens because of the string prefixes (f, r, u, and b) or (F, R, U, and B).

This issue has been described at #3798

### Changes
I have found that happens from string variants begin RegExes with the prefix `(\W|^)`.

### Checklist
- [x] Update the string variants begin RegExes with the prefix `(\W|^)`.