### PR TITLE
Makefile String Fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
-- Nothing yet.
+- fix(makefile) - allow strings inside `$()` expressions [aneesh98][]
 
 New Grammars:
 
@@ -24,6 +24,7 @@ Themes:
 CONTRIBUTORS
 
 [Josh Goebel]: https://github.com/joshgoebel
+[aneesh98]: https://github.com/aneesh98
 
 
 ## Version 11.10.0

--- a/src/languages/makefile.js
+++ b/src/languages/makefile.js
@@ -38,7 +38,10 @@ export default function(hljs) {
         + 'word wordlist firstword lastword dir notdir suffix basename '
         + 'addsuffix addprefix join wildcard realpath abspath error warning '
         + 'shell origin flavor foreach if or and call eval file value' },
-    contains: [ VARIABLE ]
+    contains: [ 
+      VARIABLE,
+      QUOTE_STRING // Added QUOTE_STRING as they can be a part of functions
+    ]
   };
   /* Variable assignment */
   const ASSIGNMENT = { begin: '^' + hljs.UNDERSCORE_IDENT_RE + '\\s*(?=[:+?]?=)' };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3878 
### Changes
<!--- Describe your changes -->
1. I have modified the FUNC configuration for Makefile to include QUOTE_STRING so appropriate highlighting gets applied to the string mentioned within a function context

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
