### PR TITLE
enh(sql) added `tables` keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,12 @@ Core Grammars:
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
 - enh(arcade) updated to ArcGIS Arcade version 1.24 [Kristian Ekenes][]
 - enh(perl) add support for the new class system [Bruno Meneguele][]
+- enh(sql) added `tables` keyword [Murat Motz][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 [Kristian Ekenes]: https://github.com/ekenes
 [Bruno Meneguele]: https://github.com/bmeneg
+[Murat Motz]: https://github.com/ztomm
 
 
 ## Version 11.9.0

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -417,6 +417,7 @@ export default function(hljs) {
     "system_time",
     "system_user",
     "table",
+    "tables",
     "tablesample",
     "tan",
     "tanh",


### PR DESCRIPTION
### Changes
Change contains the missing keyword "TABLES" for the SQL language.

Syntax example:

```
SHOW TABLES;
```

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
