### PR TITLE
Fix horizontal line grammar for Markdown.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,13 @@ Core Grammars:
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
 - enh(arcade) updated to ArcGIS Arcade version 1.24 [Kristian Ekenes][]
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
+- add raw string highlighting for C# 11. [Tara][]
 
 [Bradley Mackey]: https://github.com/bradleymackey
 [Kristian Ekenes]: https://github.com/ekenes
 [Aneesh Kulkarni]: https://github.com/aneesh98
 [Bruno Meneguele]: https://github.com/bmeneg
-
+[Tara]: https://github.com/taralei
 
 ## Version 11.9.0
 

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -164,6 +164,11 @@ export default function(hljs) {
     ],
     relevance: 0
   };
+  const RAW_STRING = {
+    className: 'string',
+    begin: /"""("*)(?!")(.|\n)*?"""\1/,
+    relevance: -1
+  };
   const VERBATIM_STRING = {
     className: 'string',
     begin: '@"',
@@ -229,6 +234,7 @@ export default function(hljs) {
     hljs.inherit(hljs.C_BLOCK_COMMENT_MODE, { illegal: /\n/ })
   ];
   const STRING = { variants: [
+    RAW_STRING,
     INTERPOLATED_VERBATIM_STRING,
     INTERPOLATED_STRING,
     VERBATIM_STRING,

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -15,8 +15,7 @@ export default function(hljs) {
     relevance: 0
   };
   const HORIZONTAL_RULE = {
-    begin: '^[-\\*]{3,}',
-    end: '$'
+    begin: '^[ ]{0,3}([-]{3,}|[\*]{3,})[ \t]*$'
   };
   const CODE = {
     className: 'code',

--- a/test/markup/csharp/string-raw.expect.txt
+++ b/test/markup/csharp/string-raw.expect.txt
@@ -1,0 +1,17 @@
+<span class="hljs-comment">// String raw literals since C# 11. &lt;https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string&gt;</span>
+
+<span class="hljs-built_in">string</span> longMessage1 = <span class="hljs-string">&quot;&quot;&quot;&quot;
+    This is a long message.
+    It has several lines.
+        Some are indented
+                more than others.
+    Some have &quot;&quot;&quot;quoted text&quot;&quot;&quot; in them. \&quot;
+    &quot;&quot;&quot;&quot;</span>;
+    
+<span class="hljs-built_in">string</span> longMessage2 = <span class="hljs-string">&quot;&quot;&quot;
+    This is a long message.
+    It has several lines.
+        Some are indented
+                more than others.
+    Some have &quot;&quot;quoted text&quot;&quot; in them. \&quot;
+    &quot;&quot;&quot;</span>;

--- a/test/markup/csharp/string-raw.txt
+++ b/test/markup/csharp/string-raw.txt
@@ -1,0 +1,17 @@
+// String raw literals since C# 11. <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string>
+
+string longMessage1 = """"
+    This is a long message.
+    It has several lines.
+        Some are indented
+                more than others.
+    Some have """quoted text""" in them. \"
+    """";
+    
+string longMessage2 = """
+    This is a long message.
+    It has several lines.
+        Some are indented
+                more than others.
+    Some have ""quoted text"" in them. \"
+    """;


### PR DESCRIPTION
According to commonmark a horizontal line starts with at most 3 spaces indentation, followed by three or more either dashes or asterisks, followed by spaces. Previously no indentation was recognized, and any combination of dash and asterisks was accepted.
See <https://spec.commonmark.org/0.12/#horizontal-rules> for more information.


### Changes
Used a more specific regular expression

### Checklist
Did not add markup test since horizontal lines are generally not highlighted.
