### PR TITLE
Fix horizontal line grammar for Markdown

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -15,8 +15,7 @@ export default function(hljs) {
     relevance: 0
   };
   const HORIZONTAL_RULE = {
-    begin: '^[-\\*]{3,}',
-    end: '$'
+    begin: '^[ ]{0,3}([-]{3,}|[\*]{3,})[ \t]*$'
   };
   const CODE = {
     className: 'code',

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -224,13 +224,13 @@ export default function(hljs) {
     ],
     contains: [
       HEADER,
+      HORIZONTAL_RULE,
       INLINE_HTML,
       LIST,
       BOLD,
       ITALIC,
       BLOCKQUOTE,
       CODE,
-      HORIZONTAL_RULE,
       LINK,
       LINK_REFERENCE
     ]

--- a/test/markup/markdown/horizontal_line.expect.txt
+++ b/test/markup/markdown/horizontal_line.expect.txt
@@ -1,0 +1,10 @@
+start
+
+***
+horizontal <span class="hljs-emphasis">*bold*</span> lines.
+***
+
+<span class="hljs-strong">**<span class="hljs-emphasis">*but not this.
+*</span>**</span>
+
+end

--- a/test/markup/markdown/horizontal_line.txt
+++ b/test/markup/markdown/horizontal_line.txt
@@ -1,0 +1,10 @@
+start
+
+***
+horizontal *bold* lines.
+***
+
+***but not this.
+***
+
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

According to commonmark a horizontal line starts with at most 3 spaces indentation,
followed by three or more either dashes or asterisks, followed by spaces.
Previously no indentation was recognized, and any combination of dash and asterisks
was accepted.
See <https://spec.commonmark.org/0.12/#horizontal-rules> for more information.

<!-- Please link to a related issue below. -->

Resolves issue #3719 

### Changes

Created a more specific regex for horizontal rules.

### Checklist
- [x ] Added markup tests

