### PR TITLE
Add highlighting for hard line breaks in markdown.

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -216,6 +216,11 @@ export default function(hljs) {
     end: '$'
   };
 
+  const LINEBREAK = {
+    className: 'addition',
+    begin: /(  |\\)$/
+  };
+
   return {
     name: 'Markdown',
     aliases: [
@@ -233,7 +238,8 @@ export default function(hljs) {
       CODE,
       HORIZONTAL_RULE,
       LINK,
-      LINK_REFERENCE
+      LINK_REFERENCE,
+      LINEBREAK
     ]
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Highlights hard line breaks as an "addition" in markdown.

### Changes

Added a LINEBREAK regex case for hard line breaks.
