### PR TITLE
add highlighting for markdown entities

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -216,6 +216,11 @@ export default function(hljs) {
     end: '$'
   };
 
+  const ENTITY = {
+    className: 'literal',
+    begin: /&([a-zA-Z0-9]+|#[0-9]{1,8}|#[Xx][0-9a-fA-F]{1,8});/
+  };
+
   return {
     name: 'Markdown',
     aliases: [
@@ -233,7 +238,8 @@ export default function(hljs) {
       CODE,
       HORIZONTAL_RULE,
       LINK,
-      LINK_REFERENCE
+      LINK_REFERENCE,
+      ENTITY
     ]
   };
 }

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -217,8 +217,8 @@ export default function(hljs) {
   };
 
   const ENTITY = {
-    className: 'literal',
-    begin: /&([a-zA-Z0-9]+|#[0-9]{1,8}|#[Xx][0-9a-fA-F]{1,8});/
+    scope: 'literal',
+    match: /&([a-zA-Z0-9]+|#[0-9]{1,8}|#[Xx][0-9a-fA-F]{1,8});/
   };
 
   return {

--- a/test/markup/markdown/entity.expect.txt
+++ b/test/markup/markdown/entity.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-bullet">-</span> named entities: <span class="hljs-literal">&amp;amp;</span>, <span class="hljs-literal">&amp;frac34;</span>, <span class="hljs-literal">&amp;AElig;</span>
+<span class="hljs-bullet">-</span> decimal entities: <span class="hljs-literal">&amp;#65;</span> <span class="hljs-literal">&amp;#164;</span>
+<span class="hljs-bullet">-</span> hexadecimal entities: <span class="hljs-literal">&amp;#xFFFD;</span> <span class="hljs-literal">&amp;#x48;</span>.

--- a/test/markup/markdown/entity.txt
+++ b/test/markup/markdown/entity.txt
@@ -1,0 +1,3 @@
+- named entities: &amp;, &frac34;, &AElig;
+- decimal entities: &#65; &#164;
+- hexadecimal entities: &#xFFFD; &#x48;.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add highlighting of entities in markdown.
See <https://spec.commonmark.org/0.12/#entities> for the commonmark spec.

### Changes

Add ENTITY regex for markdown.

### Checklist
- [x] Added markup tests

