### PR TITLE
Respect --no-minify when building CDN assets

### DIFF
--- a/tools/build_cdn.js
+++ b/tools/build_cdn.js
@@ -163,14 +163,17 @@ async function buildDistributable(language, options) {
 }
 
 async function buildCDNLanguage(language, options) {
-  const name = `languages/${language.name}.min.js`;
-
+  const name = `languages/${language.name}${options.minify ? '.min' : ''}.js`;
   await language.compile({ terser: config.terser });
-  shas[name] = bundling.sha384(language.minified);
-  await fs.writeFile(`${process.env.BUILD_DIR}/${name}`, language.minified);
+
+  const source = options.minify ? language.minified : language.module;
+  shas[name] = bundling.sha384(source);
+  await fs.writeFile(`${process.env.BUILD_DIR}/${name}`, source);
+
   if (options.esm) {
-    shas[`es/${name}`] = bundling.sha384(language.minifiedESM);
-    await fs.writeFile(`${process.env.BUILD_DIR}/es/${name}`, language.minifiedESM);
+    const sourceESM = options.minify ? language.minifiedESM : language.esm;
+    shas[`es/${name}`] = bundling.sha384(sourceESM);
+    await fs.writeFile(`${process.env.BUILD_DIR}/es/${name}`, sourceESM);
   }
 }
 

--- a/tools/lib/language.js
+++ b/tools/lib/language.js
@@ -96,6 +96,7 @@ async function compileLanguage(language, options) {
   const esm = `${HEADER}\n${data};\nexport default hljsGrammar;`;
 
   language.module = iife;
+  language.esm = esm;
   const miniESM = await Terser.minify(esm, options.terser);
   const miniIIFE = await Terser.minify(iife, options.terser);
   language.minified = miniIIFE.code;


### PR DESCRIPTION
When building the grammars for CDN, they will _always_ be minified in the build directory, regardless of the `--no-minify` flag given to `tools/build.js`.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

I know CDN assets will never be published in a non-minified format. However, if these grammars are built in a non-minified way, they can be used to address https://github.com/highlightjs/highlightjs.org/issues/5. Since the `/download` bundle uses a concatenated version of minified grammars, the non-minified distribution should use the same grammars.