### PR TITLE
fix(bash): Comments false positives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Core Grammars:
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
 - enh(arcade) updated to ArcGIS Arcade version 1.24 [Kristian Ekenes][]
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
+- fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 
 Developer Tool:
 
@@ -14,6 +15,7 @@ Developer Tool:
 [Kristian Ekenes]: https://github.com/ekenes
 [Aneesh Kulkarni]: https://github.com/aneesh98
 [Bruno Meneguele]: https://github.com/bmeneg
+[Felix Uhl]: https://github.com/iFreilicht
 
 
 ## Version 11.9.0

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -38,6 +38,18 @@ export default function(hljs) {
     end: /\)/,
     contains: [ hljs.BACKSLASH_ESCAPE ]
   };
+  const COMMENT = hljs.inherit(
+    hljs.COMMENT(),
+    {
+      match: [
+        /(^|\s)/,
+        /#.*$/
+      ],
+      scope: {
+        2: 'comment'
+      }
+    }
+  );
   const HERE_DOC = {
     begin: /<<-?\s*(?=\w+)/,
     starts: { contains: [
@@ -376,7 +388,7 @@ export default function(hljs) {
       hljs.SHEBANG(), // to catch unknown shells but still highlight the shebang
       FUNCTION,
       ARITHMETIC,
-      hljs.HASH_COMMENT_MODE,
+      COMMENT,
       HERE_DOC,
       PATH_MODE,
       QUOTE_STRING,

--- a/test/markup/bash/not-comments.expect.txt
+++ b/test/markup/bash/not-comments.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-built_in">echo</span> asdf#qwert yuiop
+
+<span class="hljs-built_in">echo</span> asdf <span class="hljs-comment">#qwert yuiop</span>

--- a/test/markup/bash/not-comments.txt
+++ b/test/markup/bash/not-comments.txt
@@ -1,0 +1,3 @@
+echo asdf#qwert yuiop
+
+echo asdf #qwert yuiop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In POSIX shells, the `#` needs to be after a whitespace or start-of-line to delimit a comment. Compare:

```sh
$ echo asdf#qwert
asdf#qwert
$ echo asdf #qwert
asdf
```

This is fixed with this PR.

I checked a few other languages as well that use #-delimited comments, but it seems this behaviour is unique to bash and other POSIX shells.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Fixes #3917

### Changes
Inside the bash mode, `HASH_COMMENT_MODE` was wrapped in another mode that prevents a match if the `#` is not after the start of the line or a whitespace character.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`