### PR TITLE
Add categories to a lot of uncategorized grammars

### DIFF
--- a/src/languages/abnf.js
+++ b/src/languages/abnf.js
@@ -2,6 +2,7 @@
 Language: Augmented Backus-Naur Form
 Author: Alex McKibben <alex@nullscope.net>
 Website: https://tools.ietf.org/html/rfc5234
+Category: syntax
 Audit: 2020
 */
 

--- a/src/languages/arduino.js
+++ b/src/languages/arduino.js
@@ -3,6 +3,7 @@ Language: Arduino
 Author: Stefania Mellai <s.mellai@arduino.cc>
 Description: The Arduino® Language is a superset of C++. This rules are designed to highlight the Arduino® source code. For info about language see http://www.arduino.cc.
 Website: https://www.arduino.cc
+Category: system
 */
 
 import cPlusPlus from './cpp.js';

--- a/src/languages/aspectj.js
+++ b/src/languages/aspectj.js
@@ -3,6 +3,7 @@ Language: AspectJ
 Author: Hakan Ozler <ozler.hakan@gmail.com>
 Website: https://www.eclipse.org/aspectj/
 Description: Syntax Highlighting for the AspectJ Language which is a general-purpose aspect-oriented extension to the Java programming language.
+Category: system
 Audit: 2020
 */
 

--- a/src/languages/awk.js
+++ b/src/languages/awk.js
@@ -3,6 +3,7 @@ Language: Awk
 Author: Matthew Daly <matthewbdaly@gmail.com>
 Website: https://www.gnu.org/software/gawk/manual/gawk.html
 Description: language definition for Awk scripts
+Category: scripting
 */
 
 /** @type LanguageFn */

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -3,7 +3,7 @@ Language: Bash
 Author: vah <vahtenberg@gmail.com>
 Contributrors: Benjamin Pannell <contact@sierrasoftworks.com>
 Website: https://www.gnu.org/software/bash/
-Category: common
+Category: common, scripting
 */
 
 /** @type LanguageFn */

--- a/src/languages/basic.js
+++ b/src/languages/basic.js
@@ -3,6 +3,7 @@ Language: BASIC
 Author: Raphaël Assénat <raph@raphnet.net>
 Description: Based on the BASIC reference from the Tandy 1000 guide
 Website: https://en.wikipedia.org/wiki/Tandy_1000
+Category: system
 */
 
 /** @type LanguageFn */

--- a/src/languages/bnf.js
+++ b/src/languages/bnf.js
@@ -1,6 +1,7 @@
 /*
 Language: Backus–Naur Form
 Website: https://en.wikipedia.org/wiki/Backus–Naur_form
+Category: syntax
 Author: Oleg Efimov <efimovov@gmail.com>
 */
 

--- a/src/languages/cal.js
+++ b/src/languages/cal.js
@@ -3,6 +3,7 @@ Language: C/AL
 Author: Kenneth Fuglsang Christensen <kfuglsang@gmail.com>
 Description: Provides highlighting of Microsoft Dynamics NAV C/AL code files
 Website: https://docs.microsoft.com/en-us/dynamics-nav/programming-in-c-al
+Category: enterprise
 */
 
 /** @type LanguageFn */

--- a/src/languages/ceylon.js
+++ b/src/languages/ceylon.js
@@ -2,6 +2,7 @@
 Language: Ceylon
 Author: Lucas Werkmeister <mail@lucaswerkmeister.de>
 Website: https://ceylon-lang.org
+Category: system
 */
 
 /** @type LanguageFn */

--- a/src/languages/cmake.js
+++ b/src/languages/cmake.js
@@ -3,6 +3,7 @@ Language: CMake
 Description: CMake is an open-source cross-platform system for build automation.
 Author: Igor Kalnitsky <igor@kalnitsky.org>
 Website: https://cmake.org
+Category: build-system
 */
 
 /** @type LanguageFn */

--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -2,6 +2,7 @@
 Language: Crystal
 Author: TSUYUSATO Kitsune <make.just.on@gmail.com>
 Website: https://crystal-lang.org
+Category: system
 */
 
 /** @type LanguageFn */

--- a/src/languages/csp.js
+++ b/src/languages/csp.js
@@ -3,6 +3,7 @@ Language: CSP
 Description: Content Security Policy definition highlighting
 Author: Taras <oxdef@oxdef.info>
 Website: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+Category: web
 
 vim: ts=2 sw=2 st=2
 */

--- a/src/languages/d.js
+++ b/src/languages/d.js
@@ -4,6 +4,7 @@ Author: Aleksandar Ruzicic <aleksandar@ruzicic.info>
 Description: D is a language with C-like syntax and static typing. It pragmatically combines efficiency, control, and modeling power, with safety and programmer productivity.
 Version: 1.0a
 Website: https://dlang.org
+Category: system
 Date: 2012-04-08
 */
 

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -1,6 +1,7 @@
 /*
 Language: Delphi
 Website: https://www.embarcadero.com/products/delphi
+Category: system
 */
 
 /** @type LanguageFn */

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -3,6 +3,7 @@ Language: Batch file (DOS)
 Author: Alexander Makarov <sam@rmcreative.ru>
 Contributors: Anton Kochkov <anton.kochkov@gmail.com>
 Website: https://en.wikipedia.org/wiki/Batch_file
+Category: scripting
 */
 
 /** @type LanguageFn */

--- a/src/languages/ebnf.js
+++ b/src/languages/ebnf.js
@@ -2,6 +2,7 @@
 Language: Extended Backus-Naur Form
 Author: Alex McKibben <alex@nullscope.net>
 Website: https://en.wikipedia.org/wiki/Extended_Backus–Naur_form
+Category: syntax
 */
 
 /** @type LanguageFn */

--- a/src/languages/excel.js
+++ b/src/languages/excel.js
@@ -3,6 +3,7 @@ Language: Excel formulae
 Author: Victor Zhou <OiCMudkips@users.noreply.github.com>
 Description: Excel formulae
 Website: https://products.office.com/en-us/excel/
+Category: enterprise
 */
 
 /** @type LanguageFn */

--- a/src/languages/gcode.js
+++ b/src/languages/gcode.js
@@ -3,6 +3,7 @@
  Contributors: Adam Joseph Cook <adam.joseph.cook@gmail.com>
  Description: G-code syntax highlighter for Fanuc and other common CNC machine tool controls.
  Website: https://www.sis.se/api/document/preview/911952/
+ Category: hardware
  */
 
 export default function(hljs) {

--- a/src/languages/golo.js
+++ b/src/languages/golo.js
@@ -3,6 +3,7 @@ Language: Golo
 Author: Philippe Charriere <ph.charriere@gmail.com>
 Description: a lightweight dynamic language for the JVM
 Website: http://golo-lang.org/
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/gradle.js
+++ b/src/languages/gradle.js
@@ -3,6 +3,7 @@ Language: Gradle
 Description: Gradle is an open-source build automation tool focused on flexibility and performance.
 Website: https://gradle.org
 Author: Damian Mee <mee.damian@gmail.com>
+Category: build-system
 */
 
 export default function(hljs) {

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -3,6 +3,7 @@
  Author: Guillaume Laforge <glaforge@gmail.com>
  Description: Groovy programming language implementation inspired from Vsevolod's Java mode
  Website: https://groovy-lang.org
+ Category: system
  */
 
 function variants(variants, obj = {}) {

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -4,6 +4,7 @@ Description: Haxe is an open source toolkit based on a modern, high level, stric
 Author: Christopher Kaster <ikasoki@gmail.com> (Based on the actionscript.js language file by Alexander Myadzel)
 Contributors: Kenton Hamaluik <kentonh@gmail.com>
 Website: https://haxe.org
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/inform7.js
+++ b/src/languages/inform7.js
@@ -3,6 +3,7 @@ Language: Inform 7
 Author: Bruno Dias <bruno.r.dias@gmail.com>
 Description: Language definition for Inform 7, a DSL for writing parser interactive fiction.
 Website: http://inform7.com
+Category: gaming
 */
 
 export default function(hljs) {

--- a/src/languages/julia-repl.js
+++ b/src/languages/julia-repl.js
@@ -4,6 +4,7 @@ Description: Julia REPL sessions
 Author: Morten Piibeleht <morten.piibeleht@gmail.com>
 Website: https://julialang.org
 Requires: julia.js
+Category: system
 
 The Julia REPL code blocks look something like the following:
 

--- a/src/languages/julia-repl.js
+++ b/src/languages/julia-repl.js
@@ -4,7 +4,7 @@ Description: Julia REPL sessions
 Author: Morten Piibeleht <morten.piibeleht@gmail.com>
 Website: https://julialang.org
 Requires: julia.js
-Category: system
+Category: scientific
 
 The Julia REPL code blocks look something like the following:
 

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -4,6 +4,7 @@ Description: Julia is a high-level, high-performance, dynamic programming langua
 Author: Kenta Sato <bicycle1885@gmail.com>
 Contributors: Alex Arslan <ararslan@comcast.net>, Fredrik Ekre <ekrefredrik@gmail.com>
 Website: https://julialang.org
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -4,7 +4,7 @@ Description: Julia is a high-level, high-performance, dynamic programming langua
 Author: Kenta Sato <bicycle1885@gmail.com>
 Contributors: Alex Arslan <ararslan@comcast.net>, Fredrik Ekre <ekrefredrik@gmail.com>
 Website: https://julialang.org
-Category: system
+Category: scientific
 */
 
 export default function(hljs) {

--- a/src/languages/lasso.js
+++ b/src/languages/lasso.js
@@ -3,6 +3,7 @@ Language: Lasso
 Author: Eric Knibbe <eric@lassosoft.com>
 Description: Lasso is a language and server platform for database-driven web applications. This definition handles Lasso 9 syntax and LassoScript for Lasso 8.6 and earlier.
 Website: http://www.lassosoft.com/What-Is-Lasso
+Category: database, web
 */
 
 export default function(hljs) {

--- a/src/languages/lua.js
+++ b/src/languages/lua.js
@@ -2,7 +2,7 @@
 Language: Lua
 Description: Lua is a powerful, efficient, lightweight, embeddable scripting language.
 Author: Andrew Fedorov <dmmdrs@mail.ru>
-Category: common, scripting
+Category: common, gaming, scripting
 Website: https://www.lua.org
 */
 

--- a/src/languages/makefile.js
+++ b/src/languages/makefile.js
@@ -3,7 +3,7 @@ Language: Makefile
 Author: Ivan Sagalaev <maniac@softwaremaniacs.org>
 Contributors: Joël Porquet <joel@porquet.org>
 Website: https://www.gnu.org/software/make/manual/html_node/Introduction.html
-Category: common
+Category: common, build-system
 */
 
 export default function(hljs) {

--- a/src/languages/mercury.js
+++ b/src/languages/mercury.js
@@ -3,6 +3,7 @@ Language: Mercury
 Author: mucaho <mkucko@gmail.com>
 Description: Mercury is a logic/functional programming language which combines the clarity and expressiveness of declarative programming with advanced static analysis and error detection features.
 Website: https://www.mercurylang.org
+Category: functional
 */
 
 export default function(hljs) {

--- a/src/languages/monkey.js
+++ b/src/languages/monkey.js
@@ -3,6 +3,7 @@ Language: Monkey
 Description: Monkey2 is an easy to use, cross platform, games oriented programming language from Blitz Research.
 Author: Arthur Bikmullin <devolonter@gmail.com>
 Website: https://blitzresearch.itch.io/monkey2
+Category: gaming
 */
 
 export default function(hljs) {

--- a/src/languages/n1ql.js
+++ b/src/languages/n1ql.js
@@ -4,6 +4,7 @@
  Contributors: Rene Saarsoo <nene@triin.net>
  Description: Couchbase query language
  Website: https://www.couchbase.com/products/n1ql
+ Category: database
  */
 
 export default function(hljs) {

--- a/src/languages/nix.js
+++ b/src/languages/nix.js
@@ -3,6 +3,7 @@ Language: Nix
 Author: Domen Kožar <domen@dev.si>
 Description: Nix functional language
 Website: http://nixos.org/nix
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/nsis.js
+++ b/src/languages/nsis.js
@@ -3,6 +3,7 @@ Language: NSIS
 Description: Nullsoft Scriptable Install System
 Author: Jan T. Sott <jan.sott@gmail.com>
 Website: https://nsis.sourceforge.io/Main_Page
+Category: scripting
 */
 
 import * as regex from '../lib/regex.js';

--- a/src/languages/oxygene.js
+++ b/src/languages/oxygene.js
@@ -3,6 +3,7 @@ Language: Oxygene
 Author: Carlo Kok <ck@remobjects.com>
 Description: Oxygene is built on the foundation of Object Pascal, revamped and extended to be a modern language for the twenty-first century.
 Website: https://www.elementscompiler.com/elements/default.aspx
+Category: build-system
 */
 
 export default function(hljs) {

--- a/src/languages/pgsql.js
+++ b/src/languages/pgsql.js
@@ -14,6 +14,7 @@ Description:
     - Function names deliberately are not highlighted. There is no way to tell function
       call from other constructs, hence we can't highlight _all_ function names. And
       some names highlighted while others not looks ugly.
+Category: database
 */
 
 export default function(hljs) {

--- a/src/languages/pony.js
+++ b/src/languages/pony.js
@@ -4,6 +4,7 @@ Author: Joe Eli McIlvain <joe.eli.mac@gmail.com>
 Description: Pony is an open-source, object-oriented, actor-model,
              capabilities-secure, high performance programming language.
 Website: https://www.ponylang.io
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -4,6 +4,7 @@ Description: PowerShell is a task-based command-line shell and scripting languag
 Author: David Mohundro <david@mohundro.com>
 Contributors: Nicholas Blumhardt <nblumhardt@nblumhardt.com>, Victor Zhou <OiCMudkips@users.noreply.github.com>, Nicolas Le Gall <contact@nlegall.fr>
 Website: https://docs.microsoft.com/en-us/powershell/
+Category: scripting
 */
 
 export default function(hljs) {

--- a/src/languages/prolog.js
+++ b/src/languages/prolog.js
@@ -3,6 +3,7 @@ Language: Prolog
 Description: Prolog is a general purpose logic programming language associated with artificial intelligence and computational linguistics.
 Author: Raivo Laanemets <raivo@infdot.com>
 Website: https://en.wikipedia.org/wiki/Prolog
+Category: functional
 */
 
 export default function(hljs) {

--- a/src/languages/purebasic.js
+++ b/src/languages/purebasic.js
@@ -4,6 +4,7 @@ Author: Tristano Ajmone <tajmone@gmail.com>
 Description: Syntax highlighting for PureBASIC (v.5.00-5.60). No inline ASM highlighting. (v.1.2, May 2017)
 Credits: I've taken inspiration from the PureBasic language file for GeSHi, created by Gustavo Julio Fiorenza (GuShH).
 Website: https://www.purebasic.com
+Category: system
 */
 
 // Base deafult colors in PB IDE: background: #FFFFDF; foreground: #000000;

--- a/src/languages/q.js
+++ b/src/languages/q.js
@@ -4,6 +4,7 @@ Description: Q is a vector-based functional paradigm programming language built 
              (K/Q/Kdb+ from Kx Systems)
 Author: Sergey Vidyuk <svidyuk@gmail.com>
 Website: https://kx.com/connect-with-us/developers/
+Category: enterprise, functional, database
 */
 
 export default function(hljs) {

--- a/src/languages/routeros.js
+++ b/src/languages/routeros.js
@@ -3,6 +3,7 @@ Language: MikroTik RouterOS script
 Author: Ivan Dementev <ivan_div@mail.ru>
 Description: Scripting host provides a way to automate some router maintenance tasks by means of executing user-defined scripts bounded to some event occurrence
 Website: https://wiki.mikrotik.com/wiki/Manual:Scripting
+Category: scripting
 */
 
 // Colors from RouterOS terminal:

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -4,7 +4,7 @@ Description: Ruby is a dynamic, open source programming language with a focus on
 Website: https://www.ruby-lang.org/
 Author: Anton Kovalyov <anton@kovalyov.net>
 Contributors: Peter Leonov <gojpeg@yandex.ru>, Vasily Polovnyov <vast@whiteants.net>, Loren Segal <lsegal@soen.ca>, Pascal Hurni <phi@ruby-reactive.org>, Cedric Sohrauer <sohrauer@googlemail.com>
-Category: common
+Category: common, system
 */
 
 export default function(hljs) {

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -4,7 +4,7 @@ Description: Ruby is a dynamic, open source programming language with a focus on
 Website: https://www.ruby-lang.org/
 Author: Anton Kovalyov <anton@kovalyov.net>
 Contributors: Peter Leonov <gojpeg@yandex.ru>, Vasily Polovnyov <vast@whiteants.net>, Loren Segal <lsegal@soen.ca>, Pascal Hurni <phi@ruby-reactive.org>, Cedric Sohrauer <sohrauer@googlemail.com>
-Category: common, system
+Category: common, scripting
 */
 
 export default function(hljs) {

--- a/src/languages/sas.js
+++ b/src/languages/sas.js
@@ -2,6 +2,7 @@
 Language: SAS
 Author: Mauricio Caceres <mauricio.caceres.bravo@gmail.com>
 Description: Syntax Highlighting for SAS
+Category: scientific
 */
 
 /** @type LanguageFn */

--- a/src/languages/smali.js
+++ b/src/languages/smali.js
@@ -3,6 +3,7 @@ Language: Smali
 Author: Dennis Titze <dennis.titze@gmail.com>
 Description: Basic Smali highlighting
 Website: https://github.com/JesusFreke/smali
+Category: assembler
 */
 
 export default function(hljs) {

--- a/src/languages/smalltalk.js
+++ b/src/languages/smalltalk.js
@@ -3,6 +3,7 @@ Language: Smalltalk
 Description: Smalltalk is an object-oriented, dynamically typed reflective programming language.
 Author: Vladimir Gubarkov <xonixx@gmail.com>
 Website: https://en.wikipedia.org/wiki/Smalltalk
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/step21.js
+++ b/src/languages/step21.js
@@ -3,6 +3,7 @@ Language: STEP Part 21
 Contributors: Adam Joseph Cook <adam.joseph.cook@gmail.com>
 Description: Syntax highlighter for STEP Part 21 files (ISO 10303-21).
 Website: https://en.wikipedia.org/wiki/ISO_10303-21
+Category: syntax
 */
 
 export default function(hljs) {

--- a/src/languages/subunit.js
+++ b/src/languages/subunit.js
@@ -2,6 +2,7 @@
 Language: SubUnit
 Author: Sergey Bronnikov <sergeyb@bronevichok.ru>
 Website: https://pypi.org/project/python-subunit/
+Category: protocols
 */
 
 export default function(hljs) {

--- a/src/languages/taggerscript.js
+++ b/src/languages/taggerscript.js
@@ -3,6 +3,7 @@ Language: Tagger Script
 Author: Philipp Wolfer <ph.wolfer@gmail.com>
 Description: Syntax Highlighting for the Tagger Script as used by MusicBrainz Picard.
 Website: https://picard.musicbrainz.org
+Category: scripting
  */
 export default function(hljs) {
   const NOOP = {

--- a/src/languages/tcl.js
+++ b/src/languages/tcl.js
@@ -3,6 +3,7 @@ Language: Tcl
 Description: Tcl is a very simple programming language.
 Author: Radek Liska <radekliska@gmail.com>
 Website: https://www.tcl.tk/about/language.html
+Category: scripting
 */
 
 export default function(hljs) {

--- a/src/languages/tp.js
+++ b/src/languages/tp.js
@@ -2,6 +2,7 @@
 Language: TP
 Author: Jay Strybis <jay.strybis@gmail.com>
 Description: FANUC TP programming language (TPP).
+Category: hardware
 */
 
 export default function(hljs) {

--- a/src/languages/vala.js
+++ b/src/languages/vala.js
@@ -3,6 +3,7 @@ Language: Vala
 Author: Antono Vasiljev <antono.vasiljev@gmail.com>
 Description: Vala is a new programming language that aims to bring modern programming language features to GNOME developers without imposing any additional runtime requirements and without using a different ABI compared to applications and libraries written in C.
 Website: https://wiki.gnome.org/Projects/Vala
+Category: system
 */
 
 export default function(hljs) {

--- a/src/languages/verilog.js
+++ b/src/languages/verilog.js
@@ -4,6 +4,7 @@ Author: Jon Evans <jon@craftyjon.com>
 Contributors: Boone Severson <boone.severson@gmail.com>
 Description: Verilog is a hardware description language used in electronic design automation to describe digital and mixed-signal systems. This highlighter supports Verilog and SystemVerilog through IEEE 1800-2012.
 Website: http://www.verilog.com
+Category: hardware
 */
 
 export default function(hljs) {

--- a/src/languages/vhdl.js
+++ b/src/languages/vhdl.js
@@ -4,6 +4,7 @@ Author: Igor Kalnitsky <igor@kalnitsky.org>
 Contributors: Daniel C.K. Kho <daniel.kho@tauhop.com>, Guillaume Savaton <guillaume.savaton@eseo.fr>
 Description: VHDL is a hardware description language used in electronic design automation to describe digital and mixed-signal systems.
 Website: https://en.wikipedia.org/wiki/VHDL
+Category: hardware
 */
 
 export default function(hljs) {

--- a/src/languages/zephir.js
+++ b/src/languages/zephir.js
@@ -3,6 +3,7 @@
  Description: Zephir, an open source, high-level language designed to ease the creation and maintainability of extensions for PHP with a focus on type and memory safety.
  Author: Oleg Efimov <efimovov@gmail.com>
  Website: https://zephir-lang.com/en
+ Category: web
  Audit: 2020
  */
 


### PR DESCRIPTION
With the changes introduced to address https://github.com/highlightjs/highlightjs.org/issues/9, it became apparent that there are quite a few languages that are uncategorized.

<img width="1233" alt="image" src="https://github.com/highlightjs/highlight.js/assets/1246453/514a276f-f949-443b-bf32-c0ecec8b93d6">

### Changes

I've done my best to categorize the languages. I left some uncategorized because they seemed unique and I did introduce some new categories as well.

Here's what is left uncategorized after this PR,

<img width="730" alt="image" src="https://github.com/highlightjs/highlight.js/assets/1246453/7f19ad93-72a9-4b75-af24-9468cca7130d">

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
