### PR TITLE
fix(tools): remove duplicate CSS picklist entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ New Grammars:
 Developer Tool:
 
 - enh(tools): order CSS options picklist [David Schach][]
+- enh(tools): remove duplicate CSS options [David Schach][]
 
 [Lê Duy Quang]: https://github.com/leduyquang753
 [Mohamed Ali]: https://github.com/MohamedAli00949

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -272,10 +272,7 @@
           <option>github-gist.css</option>
           <option>github.css</option>
           <option>gml.css</option>
-          <option>gml.css</option>
           <option>googlecode.css</option>
-          <option>googlecode.css</option>
-          <option>gradient-dark.css</option>
           <option>gradient-dark.css</option>
           <option>gradient-light.css</option>
           <option>grayscale.css</option>

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -300,7 +300,6 @@
           <option>paraiso-dark.css</option>
           <option>paraiso-light.css</option>
           <option>pojoaque.css</option>
-          <option>pojoaque.jpg</option>
           <option>purebasic.css</option>
           <option>qtcreator-dark.css</option>
           <option>qtcreator-light.css</option>


### PR DESCRIPTION
Styles were alphabetized but had duplicates that were not removed.

<!--- Provide a general summary of your changes in the Title above -->

The CSS picklist was alphabetized, but duplicates remained. They were there before but I did not catch them.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Removed duplicate entries on developer.html CSS picklist

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
