### PR TITLE
Fix linting error with 'import' keyword

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,7 +110,7 @@ module.exports = {
     {
       files: ["tools/**/*.js"],
       parserOptions: {
-        ecmaVersion: 2018
+        ecmaVersion: 2020
       },
       rules: {
         camelcase: "off"

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const config = require("../build_config.js");
 
 async function clean(directory) {
-  let del = await import('del');
+  const del = await import('del');
   del.deleteSync([directory]);
   fs.mkdirSync(directory, { recursive: true });
 }


### PR DESCRIPTION
The `del` package became ESM only in v7.0.0 (https://github.com/sindresorhus/del/releases/tag/v7.0.0) and so we used the [`await import()` trick](https://dmitripavlutin.com/ecmascript-modules-dynamic-import/) as mentioned in [Sindre's ESM help docs](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). Support for the `await import` syntax was introduced in ECMAScript 2020, so let's bump the parser setting for eslint so that it knows about the syntax.

Fixes #3915

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
