### PR TITLE
enh(delphi) Improve handling of numeric literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Core Grammars:
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
+- enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 
 New Grammars:
 
@@ -32,6 +33,7 @@ Developer Tool:
 [nataliia-radina]: https://github.com/Nataliia-Radina
 [Robloxian Demo]: https://github.com/RobloxianDemo
 [Paul Tsnobiladzé]: https://github.com/tsnobip
+[Jonah Jeleniewski]: https://github.com/cirras
 
 
 ## Version 11.9.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Core Grammars:
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 - enh(delphi) add support for digit separators [Jonah Jeleniewski][]
+- enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]
 
 New Grammars:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Core Grammars:
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
+- enh(delphi) add support for digit separators [Jonah Jeleniewski][]
 
 New Grammars:
 

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -166,7 +166,7 @@ export default function(hljs) {
     variants: [
       {
         // Hexadecimal notation, e.g., $7F.
-        begin: '\\$[0-9A-Fa-f]+' },
+        begin: '\\$[\\dA-Fa-f]+' },
       {
         // Hexadecimal literal with no digits
         begin: '\\$',

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -166,33 +166,33 @@ export default function(hljs) {
     variants: [
       {
         // Regular numbers, e.g., 123, 123.456.
-        begin: /\b\d[\d_]*(\.\d[\d_]*)?/ },
+        match: /\b\d[\d_]*(\.\d[\d_]*)?/ },
       {
         // Hexadecimal notation, e.g., $7F.
-        begin: /\$[\dA-Fa-f_]+/ },
+        match: /\$[\dA-Fa-f_]+/ },
       {
         // Hexadecimal literal with no digits
-        begin: /\$/,
+        match: /\$/,
         relevance: 0 },
       {
         // Octal notation, e.g., &42.
-        begin: /&[0-7][0-7_]*/ },
+        match: /&[0-7][0-7_]*/ },
       {
         // Binary notation, e.g., %1010.
-        begin: /%[01_]+/ },
+        match: /%[01_]+/ },
       {
         // Binary literal with no digits
-        begin: /%/,
+        match: /%/,
         relevance: 0 }
     ]
   };
   const CHAR_STRING = {
     className: 'string',
     variants: [
-      { begin: /#\d[\d_]*/ },
-      { begin: /#\$[\dA-Fa-f][\dA-Fa-f_]*/ },
-      { begin: /#&[0-7][0-7_]*/ },
-      { begin: /#%[01][01_]*/ }
+      { match: /#\d[\d_]*/ },
+      { match: /#\$[\dA-Fa-f][\dA-Fa-f_]*/ },
+      { match: /#&[0-7][0-7_]*/ },
+      { match: /#%[01][01_]*/ }
     ]
   };
   const CLASS = {

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -188,7 +188,12 @@ export default function(hljs) {
   };
   const CHAR_STRING = {
     className: 'string',
-    begin: /(#\d+)+/
+    variants: [
+      { begin: /#\d[\d_]*/ },
+      { begin: /#\$[\dA-Fa-f][\dA-Fa-f_]*/ },
+      { begin: /#&[0-7][0-7_]*/ },
+      { begin: /#%[01][01_]*/ }
+    ]
   };
   const CLASS = {
     begin: hljs.IDENT_RE + '\\s*=\\s*class\\s*\\(',

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -165,21 +165,24 @@ export default function(hljs) {
     // Source: https://www.freepascal.org/docs-html/ref/refse6.html
     variants: [
       {
+        // Regular numbers, e.g., 123, 123.456.
+        begin: /\b\d[\d_]*(\.\d[\d_]*)?/ },
+      {
         // Hexadecimal notation, e.g., $7F.
-        begin: '\\$[\\dA-Fa-f]+' },
+        begin: /\$[\dA-Fa-f_]+/ },
       {
         // Hexadecimal literal with no digits
-        begin: '\\$',
+        begin: /\$/,
         relevance: 0 },
       {
         // Octal notation, e.g., &42.
-        begin: '&[0-7]+' },
+        begin: /&[0-7][0-7_]*/ },
       {
         // Binary notation, e.g., %1010.
-        begin: '%[01]*' },
+        begin: /%[01_]+/ },
       {
         // Binary literal with no digits
-        begin: '%',
+        begin: /%/,
         relevance: 0 }
     ]
   };
@@ -227,7 +230,6 @@ export default function(hljs) {
     contains: [
       STRING,
       CHAR_STRING,
-      hljs.NUMBER_MODE,
       NUMBER,
       CLASS,
       FUNCTION,

--- a/src/languages/delphi.js
+++ b/src/languages/delphi.js
@@ -168,11 +168,19 @@ export default function(hljs) {
         // Hexadecimal notation, e.g., $7F.
         begin: '\\$[0-9A-Fa-f]+' },
       {
+        // Hexadecimal literal with no digits
+        begin: '\\$',
+        relevance: 0 },
+      {
         // Octal notation, e.g., &42.
         begin: '&[0-7]+' },
       {
         // Binary notation, e.g., %1010.
-        begin: '%[01]+' }
+        begin: '%[01]*' },
+      {
+        // Binary literal with no digits
+        begin: '%',
+        relevance: 0 }
     ]
   };
   const CHAR_STRING = {

--- a/test/markup/delphi/character-string.expect.txt
+++ b/test/markup/delphi/character-string.expect.txt
@@ -1,0 +1,12 @@
+<span class="hljs-keyword">const</span>
+  CDecimalCharacterString = <span class="hljs-string">#123</span>;
+  CHexadecimalCharacterString = <span class="hljs-string">#$7B</span>;
+  COctalCharacterString = <span class="hljs-string">#&amp;123</span>;
+  CBinaryCharacterString = <span class="hljs-string">#%1111011</span>;
+
+  CDecimalCharacterStringWithSeparator = <span class="hljs-string">#1_23</span>;
+  CHexadecimalCharacterStringWithSeparator = <span class="hljs-string">#$7_B</span>;
+  COctalCharacterStringWithSeparator = <span class="hljs-string">#&amp;123</span>;
+  CBinaryCharacterStringWithSeparator = <span class="hljs-string">#%1_111011</span>;
+
+  CMultipleCharacterStrings = <span class="hljs-string">#123</span><span class="hljs-string">#$ABC</span><span class="hljs-string">#&amp;765</span><span class="hljs-string">#%0011001</span>;

--- a/test/markup/delphi/character-string.txt
+++ b/test/markup/delphi/character-string.txt
@@ -1,0 +1,12 @@
+const
+  CDecimalCharacterString = #123;
+  CHexadecimalCharacterString = #$7B;
+  COctalCharacterString = #&123;
+  CBinaryCharacterString = #%1111011;
+
+  CDecimalCharacterStringWithSeparator = #1_23;
+  CHexadecimalCharacterStringWithSeparator = #$7_B;
+  COctalCharacterStringWithSeparator = #&123;
+  CBinaryCharacterStringWithSeparator = #%1_111011;
+
+  CMultipleCharacterStrings = #123#$ABC#&765#%0011001;

--- a/test/markup/delphi/numeric-literal.expect.txt
+++ b/test/markup/delphi/numeric-literal.expect.txt
@@ -1,0 +1,18 @@
+<span class="hljs-keyword">const</span>
+  CDecimal = <span class="hljs-number">123456</span>;
+  CFloat = <span class="hljs-number">123.456</span>;
+  CHexadecimal = <span class="hljs-number">$ABC123</span>;
+  COctal = <span class="hljs-number">&amp;123456</span>;
+  CBinary = <span class="hljs-number">%000111</span>;
+
+  CDecimalWithSeparator = <span class="hljs-number">123_456</span>;
+  CFloatWithSeparator = <span class="hljs-number">12_3.78_9</span>;
+  CHexadecimalWithSeparator = <span class="hljs-number">$ABC_123</span>;
+  COctalWithSeparator = <span class="hljs-number">&amp;123_456</span>;
+  CBinaryWithSeparator = <span class="hljs-number">%000_111</span>;
+
+  CHexadecimalWithOnlySeparator = <span class="hljs-number">$_</span>;
+  CBinaryWithOnlySeparator = <span class="hljs-number">%_</span>;
+
+  CHexadecimalWithNoDigits = <span class="hljs-number">$</span>;
+  CBinaryWithNoDigits = <span class="hljs-number">%</span>;

--- a/test/markup/delphi/numeric-literal.txt
+++ b/test/markup/delphi/numeric-literal.txt
@@ -1,0 +1,18 @@
+const
+  CDecimal = 123456;
+  CFloat = 123.456;
+  CHexadecimal = $ABC123;
+  COctal = &123456;
+  CBinary = %000111;
+
+  CDecimalWithSeparator = 123_456;
+  CFloatWithSeparator = 12_3.78_9;
+  CHexadecimalWithSeparator = $ABC_123;
+  COctalWithSeparator = &123_456;
+  CBinaryWithSeparator = %000_111;
+
+  CHexadecimalWithOnlySeparator = $_;
+  CBinaryWithOnlySeparator = %_;
+
+  CHexadecimalWithNoDigits = $;
+  CBinaryWithNoDigits = %;


### PR DESCRIPTION
### Changes

* Add support for digit separators, which were [introduced in Delphi 11](https://docwiki.embarcadero.com/RADStudio/Alexandria/en/What%27s_New#Binary_Literals_and_Digit_Separator)
    * This is also [allowed in FreePascal](https://wiki.freepascal.org/Integer#basics) via `{$modeSwitch underscoreIsSeparator+}`
* Allow all digits to be omitted for hexadecimal and binary literals (i.e. `$` and `%`)
    * This is an odd one, but it's allowed in Delphi
    * It produces a value of zero
* Add support for character strings with non-decimal numeric literals
    * e.g. `#90` = `#$5A` = `#&132` = `#%01011010` = `'Z'` 

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
