### PR TITLE
fix(swift) correctly highlight generics and conformances in type definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]
 - fix(javascript) incorrect function name highlighting [CY Fung][]
 - fix(1c) fix escaped symbols "+-;():=,[]" literals [Vitaly Barilko][]
+- fix(swift) correctly highlight generics and conformances in type definitions [Bradley Mackey][]
 
 New Grammars:
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -464,7 +464,7 @@ export default function(hljs) {
       Swift.identifier,
       /\s*/,
     ],
-    scope: {
+    beginScope: {
       1: "keyword",
       3: "title.class"
     },

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -457,6 +457,23 @@ export default function(hljs) {
     end: /}/
   };
 
+  const TYPE_DECLARATION = {
+    match: [
+      /(struct|protocol|class|extension|enum|actor)/,
+      /\s+/,
+      /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/
+    ],
+    scope: {
+      1: "keyword",
+      3: "title.class"
+    },
+    keywords: KEYWORDS,
+    contains: [
+      GENERIC_PARAMETERS,
+      ...KEYWORD_MODES,
+    ]
+  };
+
   // Add supported submodes to string interpolation.
   for (const variant of STRING.variants) {
     const interpolation = variant.contains.find(mode => mode.label === "interpol");
@@ -490,22 +507,7 @@ export default function(hljs) {
       ...COMMENTS,
       FUNCTION_OR_MACRO,
       INIT_SUBSCRIPT,
-      {
-        match: [
-          /(struct|protocol|class|extension|enum|actor)/,
-          /\s+/,
-          /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/
-        ],
-        scope: {
-          1: "keyword",
-          3: "title.class"
-        },
-        keywords: KEYWORDS,
-        contains: [
-          GENERIC_PARAMETERS,
-          ...KEYWORD_MODES,
-        ]
-      },
+      TYPE_DECLARATION,
       OPERATOR_DECLARATION,
       PRECEDENCEGROUP,
       {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -473,8 +473,8 @@ export default function(hljs) {
       GENERIC_PARAMETERS,
       ...KEYWORD_MODES,
       {
-        begin: /:/,
-        end: /[{]/,
+        begin: ":",
+        end: "{",
         keywords: KEYWORDS,
         contains: [
           {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -491,16 +491,19 @@ export default function(hljs) {
       FUNCTION_OR_MACRO,
       INIT_SUBSCRIPT,
       {
-        beginKeywords: 'struct protocol class extension enum actor',
-        end: '\\{',
-        excludeEnd: true,
+        match: [
+          /(struct|protocol|class|extension|enum|actor)/,
+          /\s+/,
+          /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/
+        ],
+        scope: {
+          1: "keyword",
+          3: "title.class"
+        },
         keywords: KEYWORDS,
         contains: [
-          hljs.inherit(hljs.TITLE_MODE, {
-            className: "title.class",
-            begin: /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/
-          }),
-          ...KEYWORD_MODES
+          GENERIC_PARAMETERS,
+          ...KEYWORD_MODES,
         ]
       },
       OPERATOR_DECLARATION,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -461,7 +461,7 @@ export default function(hljs) {
     match: [
       /(struct|protocol|class|extension|enum|actor)/,
       /\s+/,
-      /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/,
+      Swift.identifier,
       /\s*/,
     ],
     scope: {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -473,8 +473,8 @@ export default function(hljs) {
       GENERIC_PARAMETERS,
       ...KEYWORD_MODES,
       {
-        begin: ":",
-        end: "{",
+        begin: /:/,
+        end: /\{/,
         keywords: KEYWORDS,
         contains: [
           {

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -458,7 +458,7 @@ export default function(hljs) {
   };
 
   const TYPE_DECLARATION = {
-    match: [
+    begin: [
       /(struct|protocol|class|extension|enum|actor)/,
       /\s+/,
       Swift.identifier,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -461,7 +461,8 @@ export default function(hljs) {
     match: [
       /(struct|protocol|class|extension|enum|actor)/,
       /\s+/,
-      /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/
+      /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/,
+      /\s*/,
     ],
     scope: {
       1: "keyword",
@@ -471,6 +472,19 @@ export default function(hljs) {
     contains: [
       GENERIC_PARAMETERS,
       ...KEYWORD_MODES,
+      {
+        begin: /:/,
+        end: /[{]/,
+        keywords: KEYWORDS,
+        contains: [
+          {
+            scope: "title.class.inherited",
+            match: Swift.typeIdentifier,
+          },
+          ...KEYWORD_MODES,
+        ],
+        relevance: 0,
+      },
     ]
   };
 

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -23,7 +23,7 @@
 
 <span class="hljs-keyword">subscript</span>&lt;<span class="hljs-type">X</span>: <span class="hljs-type">A</span>&gt;(<span class="hljs-keyword">_</span> <span class="hljs-params">p</span>: <span class="hljs-meta">@attribute</span> <span class="hljs-keyword">inout</span> (x: <span class="hljs-type">Int</span>, var: <span class="hljs-type">Int</span>) <span class="hljs-operator">=</span> (<span class="hljs-number">0</span>, <span class="hljs-number">0</span>))  { }
 
-<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">Comparable</span>: <span class="hljs-title class_">Equatable</span> {
+<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">Comparable</span>: <span class="hljs-type">Equatable</span> {
 
   <span class="hljs-keyword">static</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">&lt;</span> (<span class="hljs-params">lhs</span>: <span class="hljs-keyword">Self</span>, <span class="hljs-params">rhs</span>: <span class="hljs-keyword">Self</span>) -&gt; <span class="hljs-type">Bool</span>
   <span class="hljs-keyword">static</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">&lt;=</span> (<span class="hljs-params">lhs</span>: <span class="hljs-keyword">Self</span>, <span class="hljs-params">rhs</span>: <span class="hljs-keyword">Self</span>) -&gt; <span class="hljs-type">Bool</span>

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -23,7 +23,7 @@
 
 <span class="hljs-keyword">subscript</span>&lt;<span class="hljs-type">X</span>: <span class="hljs-type">A</span>&gt;(<span class="hljs-keyword">_</span> <span class="hljs-params">p</span>: <span class="hljs-meta">@attribute</span> <span class="hljs-keyword">inout</span> (x: <span class="hljs-type">Int</span>, var: <span class="hljs-type">Int</span>) <span class="hljs-operator">=</span> (<span class="hljs-number">0</span>, <span class="hljs-number">0</span>))  { }
 
-<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">Comparable</span>: <span class="hljs-type">Equatable</span> {
+<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">Comparable</span>: <span class="hljs-title class_ inherited__">Equatable</span> {
 
   <span class="hljs-keyword">static</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">&lt;</span> (<span class="hljs-params">lhs</span>: <span class="hljs-keyword">Self</span>, <span class="hljs-params">rhs</span>: <span class="hljs-keyword">Self</span>) -&gt; <span class="hljs-type">Bool</span>
   <span class="hljs-keyword">static</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">&lt;=</span> (<span class="hljs-params">lhs</span>: <span class="hljs-keyword">Self</span>, <span class="hljs-params">rhs</span>: <span class="hljs-keyword">Self</span>) -&gt; <span class="hljs-type">Bool</span>

--- a/test/markup/swift/ownership.expect.txt
+++ b/test/markup/swift/ownership.expect.txt
@@ -5,9 +5,9 @@ doStuffUniquely(with: <span class="hljs-keyword">consume</span> x)
 <span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">copy</span> x
 doStuff(with: <span class="hljs-keyword">copy</span> x)
 
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: <span class="hljs-operator">~</span><span class="hljs-type">Copyable</span> {}
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: ~<span class="hljs-title class_ inherited__">Copyable</span> {}
 
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">B</span>: <span class="hljs-type">P</span> {
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">B</span>: <span class="hljs-title class_ inherited__">P</span> {
   <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-params">x</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>, <span class="hljs-params">y</span>: <span class="hljs-keyword">consuming</span> <span class="hljs-type">Foo</span>)
 }
 <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-keyword">_</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>)

--- a/test/markup/swift/ownership.expect.txt
+++ b/test/markup/swift/ownership.expect.txt
@@ -5,9 +5,9 @@ doStuffUniquely(with: <span class="hljs-keyword">consume</span> x)
 <span class="hljs-keyword">_</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">copy</span> x
 doStuff(with: <span class="hljs-keyword">copy</span> x)
 
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: ~<span class="hljs-title class_">Copyable</span> {}
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MoveOnly</span>: <span class="hljs-operator">~</span><span class="hljs-type">Copyable</span> {}
 
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">B</span>: <span class="hljs-title class_">P</span> {
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">B</span>: <span class="hljs-type">P</span> {
   <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-params">x</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>, <span class="hljs-params">y</span>: <span class="hljs-keyword">consuming</span> <span class="hljs-type">Foo</span>)
 }
 <span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>(<span class="hljs-keyword">_</span>: <span class="hljs-keyword">borrowing</span> <span class="hljs-type">Foo</span>)

--- a/test/markup/swift/swiftui.expect.txt
+++ b/test/markup/swift/swiftui.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">@main</span>
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MyApp</span>: <span class="hljs-type">App</span> {
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MyApp</span>: <span class="hljs-title class_ inherited__">App</span> {
     <span class="hljs-keyword">var</span> body: <span class="hljs-keyword">some</span> <span class="hljs-type">Scene</span> {
         <span class="hljs-type">WindowGroup</span> {
             <span class="hljs-keyword">#if</span> os(iOS)

--- a/test/markup/swift/swiftui.expect.txt
+++ b/test/markup/swift/swiftui.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">@main</span>
-<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MyApp</span>: <span class="hljs-title class_">App</span> {
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">MyApp</span>: <span class="hljs-type">App</span> {
     <span class="hljs-keyword">var</span> body: <span class="hljs-keyword">some</span> <span class="hljs-type">Scene</span> {
         <span class="hljs-type">WindowGroup</span> {
             <span class="hljs-keyword">#if</span> os(iOS)

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -1,6 +1,8 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span> {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClassConstraint</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-keyword">repeat</span> <span class="hljs-keyword">each</span> <span class="hljs-type">T</span>&gt; {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
 
 <span class="hljs-keyword">class</span>
 <span class="hljs-title class_">MoreThanOneLine</span>
@@ -13,7 +15,16 @@
 {}
 
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
+
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span> {}
+<span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
+
 <span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span> {}
+<span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
+
 <span class="hljs-keyword">extension</span> <span class="hljs-title class_">TestExtension</span> {}
+<span class="hljs-keyword">extension</span> <span class="hljs-title class_">TestExtension</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
+
 <span class="hljs-keyword">protocol</span> <span class="hljs-title class_">TestProtocol</span> {}
+<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">TestProtocol</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -1,8 +1,11 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-type">Superclass</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-type">Superclass</span>, <span class="hljs-type">Conform1</span>, <span class="hljs-type">Conform2</span> {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-keyword">repeat</span> <span class="hljs-keyword">each</span> <span class="hljs-type">T</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt;: <span class="hljs-type">Superclass</span> <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
 
 <span class="hljs-keyword">class</span>
 <span class="hljs-title class_">MoreThanOneLine</span>

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -2,6 +2,16 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClassConstraint</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
 
+<span class="hljs-keyword">class</span>
+<span class="hljs-title class_">MoreThanOneLine</span>
+{}
+
+<span class="hljs-keyword">final</span> <span class="hljs-keyword">class</span>
+<span class="hljs-title class_">MoreThanOneLineGeneric</span>&lt;<span class="hljs-type">T</span>&gt;
+<span class="hljs-keyword">where</span>
+<span class="hljs-type">T</span>: <span class="hljs-type">Param</span>
+{}
+
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span> {}
 <span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span> {}

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -17,6 +17,18 @@
 <span class="hljs-title class_ inherited__">Superclass</span>
 {}
 
+<span class="hljs-keyword">class</span>
+<span class="hljs-title class_">MoreThanOneLineInherit</span>
+:
+<span class="hljs-title class_ inherited__">Superclass1</span>,
+<span class="hljs-title class_ inherited__">Superclass2</span>
+{}
+
+<span class="hljs-keyword">class</span>
+<span class="hljs-title class_">MoreThanOneLineInherit</span>:
+<span class="hljs-title class_ inherited__">Superclass</span>
+{}
+
 <span class="hljs-keyword">final</span> <span class="hljs-keyword">class</span>
 <span class="hljs-title class_">MoreThanOneLineGeneric</span>&lt;<span class="hljs-type">T</span>&gt;
 <span class="hljs-keyword">where</span>
@@ -24,16 +36,21 @@
 {}
 
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
+<span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span> {}
+<span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 
 <span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span> {}
+<span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 
 <span class="hljs-keyword">extension</span> <span class="hljs-title class_">TestExtension</span> {}
+<span class="hljs-keyword">extension</span> <span class="hljs-title class_">TestExtension</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">extension</span> <span class="hljs-title class_">TestExtension</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 
 <span class="hljs-keyword">protocol</span> <span class="hljs-title class_">TestProtocol</span> {}
+<span class="hljs-keyword">protocol</span> <span class="hljs-title class_">TestProtocol</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">protocol</span> <span class="hljs-title class_">TestProtocol</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span> {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClass</span>&lt;<span class="hljs-title class_">T</span>&gt; {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClassConstraint</span>&lt;<span class="hljs-title class_">T</span>&gt; <span class="hljs-title class_">where</span> <span class="hljs-title class_">T</span>: <span class="hljs-title class_">Equatable</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClassConstraint</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
 
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span> {}

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -1,14 +1,20 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span> {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-type">Superclass</span> {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-type">Superclass</span>, <span class="hljs-type">Conform1</span>, <span class="hljs-type">Conform2</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-title class_ inherited__">Superclass</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>: <span class="hljs-title class_ inherited__">Superclass</span>, <span class="hljs-title class_ inherited__">Conform1</span>, <span class="hljs-title class_ inherited__">Conform2</span> {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-keyword">repeat</span> <span class="hljs-keyword">each</span> <span class="hljs-type">T</span>&gt; {}
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt; <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt;: <span class="hljs-type">Superclass</span> <span class="hljs-keyword">where</span> <span class="hljs-type">T</span>: <span class="hljs-type">Equatable</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span>&lt;<span class="hljs-type">T</span>&gt;: <span class="hljs-title class_ inherited__">Superclass</span> <span class="hljs-keyword">where</span> <span class="hljs-title class_ inherited__">T</span>: <span class="hljs-title class_ inherited__">Equatable</span> {}
 
 <span class="hljs-keyword">class</span>
 <span class="hljs-title class_">MoreThanOneLine</span>
+{}
+
+<span class="hljs-keyword">class</span>
+<span class="hljs-title class_">MoreThanOneLineInherit</span>
+:
+<span class="hljs-title class_ inherited__">Superclass</span>
 {}
 
 <span class="hljs-keyword">final</span> <span class="hljs-keyword">class</span>

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -1,4 +1,7 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TestClass</span> {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClass</span>&lt;<span class="hljs-title class_">T</span>&gt; {}
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">GenericClassConstraint</span>&lt;<span class="hljs-title class_">T</span>&gt; <span class="hljs-title class_">where</span> <span class="hljs-title class_">T</span>: <span class="hljs-title class_">Equatable</span> {}
+
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
 <span class="hljs-keyword">enum</span> <span class="hljs-title class_">TestEnum</span> {}
 <span class="hljs-keyword">actor</span> <span class="hljs-title class_">TestActor</span> {}

--- a/test/markup/swift/type-definition.expect.txt
+++ b/test/markup/swift/type-definition.expect.txt
@@ -35,6 +35,11 @@
 <span class="hljs-type">T</span>: <span class="hljs-type">Param</span>
 {}
 
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Outer</span> {
+  <span class="hljs-keyword">class</span> <span class="hljs-title class_">Inner</span>&lt;<span class="hljs-type">T</span>&gt; {}
+  <span class="hljs-keyword">class</span> <span class="hljs-title class_">InnerInherit</span>: <span class="hljs-title class_ inherited__">Superclass</span> {}
+}
+
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span> {}
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span>: <span class="hljs-title class_ inherited__">Conform</span> {}
 <span class="hljs-keyword">struct</span> <span class="hljs-title class_">TestStruct</span>&lt;<span class="hljs-type">T</span>, <span class="hljs-type">U</span>&gt; {}

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -1,8 +1,11 @@
 class TestClass {}
+class TestClass: Superclass {}
+class TestClass: Superclass, Conform1, Conform2 {}
 class TestClass<T> {}
 class TestClass<T, U> {}
 class TestClass<repeat each T> {}
 class TestClass<T> where T: Equatable {}
+class TestClass<T>: Superclass where T: Equatable {}
 
 class
 MoreThanOneLine

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -1,4 +1,7 @@
 class TestClass {}
+class GenericClass<T> {}
+class GenericClassConstraint<T> where T: Equatable {}
+
 struct TestStruct {}
 enum TestEnum {}
 actor TestActor {}

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -2,6 +2,16 @@ class TestClass {}
 class GenericClass<T> {}
 class GenericClassConstraint<T> where T: Equatable {}
 
+class
+MoreThanOneLine
+{}
+
+final class
+MoreThanOneLineGeneric<T>
+where
+T: Param
+{}
+
 struct TestStruct {}
 enum TestEnum {}
 actor TestActor {}

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -1,6 +1,8 @@
 class TestClass {}
-class GenericClass<T> {}
-class GenericClassConstraint<T> where T: Equatable {}
+class TestClass<T> {}
+class TestClass<T, U> {}
+class TestClass<repeat each T> {}
+class TestClass<T> where T: Equatable {}
 
 class
 MoreThanOneLine
@@ -13,7 +15,16 @@ T: Param
 {}
 
 struct TestStruct {}
+struct TestStruct<T, U> {}
+
 enum TestEnum {}
+enum TestEnum<T, U> {}
+
 actor TestActor {}
+actor TestActor<T, U> {}
+
 extension TestExtension {}
+extension TestExtension<T, U> {}
+
 protocol TestProtocol {}
+protocol TestProtocol<T, U> {}

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -11,6 +11,12 @@ class
 MoreThanOneLine
 {}
 
+class
+MoreThanOneLineInherit
+:
+Superclass
+{}
+
 final class
 MoreThanOneLineGeneric<T>
 where

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -17,6 +17,18 @@ MoreThanOneLineInherit
 Superclass
 {}
 
+class
+MoreThanOneLineInherit
+:
+Superclass1,
+Superclass2
+{}
+
+class
+MoreThanOneLineInherit:
+Superclass
+{}
+
 final class
 MoreThanOneLineGeneric<T>
 where
@@ -24,16 +36,21 @@ T: Param
 {}
 
 struct TestStruct {}
+struct TestStruct: Conform {}
 struct TestStruct<T, U> {}
 
 enum TestEnum {}
+enum TestEnum: Conform {}
 enum TestEnum<T, U> {}
 
 actor TestActor {}
+actor TestActor: Conform {}
 actor TestActor<T, U> {}
 
 extension TestExtension {}
+extension TestExtension: Conform {}
 extension TestExtension<T, U> {}
 
 protocol TestProtocol {}
+protocol TestProtocol: Conform {}
 protocol TestProtocol<T, U> {}

--- a/test/markup/swift/type-definition.txt
+++ b/test/markup/swift/type-definition.txt
@@ -35,6 +35,11 @@ where
 T: Param
 {}
 
+class Outer {
+  class Inner<T> {}
+  class InnerInherit: Superclass {}
+}
+
 struct TestStruct {}
 struct TestStruct: Conform {}
 struct TestStruct<T, U> {}


### PR DESCRIPTION
Fixes highlighting of type definitions, especially when the given type is generic.

### Changes
- Fix entire type definition being highlighted as `title.class`, only the newly defined type should be highlighted as this. Inheritance and protocol conformances should be indicated with the `title.class.inherited` class instead, as this is better modelled by this inheritance class.
- Support generic signatures for type declarations
- Add more test cases for type declarations

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
