### PR TITLE
fix(javascript) incorrect function name highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 - enh(delphi) add support for digit separators [Jonah Jeleniewski][]
 - enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]
+- fix(javascript) incorrect function name highlighting [CY Fung][]
 
 New Grammars:
 
@@ -36,6 +37,7 @@ Developer Tool:
 [Robloxian Demo]: https://github.com/RobloxianDemo
 [Paul Tsnobiladzé]: https://github.com/tsnobip
 [Jonah Jeleniewski]: https://github.com/cirras
+[CY Fung]: https://github.com/cyfung1031
 
 
 ## Version 11.9.0

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -388,8 +388,8 @@ export default function(hljs) {
         ...ECMAScript.BUILT_IN_GLOBALS,
         "super",
         "import"
-      ]),
-      IDENT_RE, regex.lookahead(/\(/)),
+      ].map(x => `${x}\\s*\\(`)),
+      IDENT_RE, regex.lookahead(/\s*\(/)),
     className: "title.function",
     relevance: 0
   };

--- a/test/markup/javascript/class.expect.txt
+++ b/test/markup/javascript/class.expect.txt
@@ -51,16 +51,16 @@
       <span class="hljs-subst">${speed}</span>.`</span>;
   }
 
-  join () {
+  <span class="hljs-title function_">join</span> () {
   }
 
-  other (a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ) ) {
+  <span class="hljs-title function_">other</span> (a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ) ) {
     <span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(a)
   }
 
-  something (a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ), b = <span class="hljs-number">1</span> ) {
+  <span class="hljs-title function_">something</span> (a = ( ( <span class="hljs-number">3</span> + <span class="hljs-number">2</span> ) ), b = <span class="hljs-number">1</span> ) {
     <span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(a)
   }
 
-  onemore (a=(<span class="hljs-number">3</span>+<span class="hljs-number">2</span>, b=(<span class="hljs-number">5</span>*<span class="hljs-number">9</span>))) {}
+  <span class="hljs-title function_">onemore</span> (a=(<span class="hljs-number">3</span>+<span class="hljs-number">2</span>, b=(<span class="hljs-number">5</span>*<span class="hljs-number">9</span>))) {}
 }


### PR DESCRIPTION
* fix #3870
* override #3871

### Before

<img width="464" alt="Screen Shot 2023-12-13 at 20 46 11" src="https://github.com/highlightjs/highlight.js/assets/44498510/4c3af25f-ea28-43a0-bc62-cbdc9dcf413b">


### After

<img width="395" alt="Screen Shot 2023-12-13 at 20 46 08" src="https://github.com/highlightjs/highlight.js/assets/44498510/c2dfd438-cb79-4106-96da-beb750623d0e">


cc @joshgoebel @arnog