### PR TITLE
Bugfix1c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 - enh(delphi) add support for digit separators [Jonah Jeleniewski][]
 - enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]
+- fix(1c) fix escaped symbols "+-;():=,[]" literals [Vitaly Barilko][]
 
 New Grammars:
 
@@ -25,6 +26,10 @@ Developer Tool:
 - enh(tools): order CSS options picklist [David Schach][]
 - enh(tools): remove duplicate CSS options [David Schach][]
 
+Themes:
+
+- Added `1c-light` theme a like in the IDE 1C:Enterprise 8 (for 1c) [Vitaly Barilko][]
+
 [Lê Duy Quang]: https://github.com/leduyquang753
 [Mohamed Ali]: https://github.com/MohamedAli00949
 [Bradley Mackey]: https://github.com/bradleymackey
@@ -36,7 +41,7 @@ Developer Tool:
 [Robloxian Demo]: https://github.com/RobloxianDemo
 [Paul Tsnobiladzé]: https://github.com/tsnobip
 [Jonah Jeleniewski]: https://github.com/cirras
-
+[Vitaly Barilko]: https://github.com/Diversus23
 
 ## Version 11.9.0
 

--- a/src/languages/1c.js
+++ b/src/languages/1c.js
@@ -443,6 +443,12 @@ export default function(hljs) {
     ]
   };
 
+  const PUNCTUATION = {
+    match: /[;|(|)|:|=|,]/,
+    className: "punctuation",
+    relevance: 0
+  };
+
   // comment : комментарии
   const COMMENTS = hljs.inherit(hljs.C_LINE_COMMENT_MODE);
 
@@ -529,7 +535,8 @@ export default function(hljs) {
       SYMBOL,
       NUMBERS,
       STRINGS,
-      DATE
+      DATE,
+      PUNCTUATION
     ]
   };
 }

--- a/src/languages/1c.js
+++ b/src/languages/1c.js
@@ -444,7 +444,7 @@ export default function(hljs) {
   };
 
   const PUNCTUATION = {
-    match: /[;|(|)|+|\-|:|=|,]/,
+    match: /[;()+\-:=,]/,
     className: "punctuation",
     relevance: 0
   };

--- a/src/languages/1c.js
+++ b/src/languages/1c.js
@@ -444,7 +444,7 @@ export default function(hljs) {
   };
 
   const PUNCTUATION = {
-    match: /[;|(|)|:|=|,]/,
+    match: /[;|(|)|+|\-|:|=|,]/,
     className: "punctuation",
     relevance: 0
   };

--- a/src/styles/1c-light.css
+++ b/src/styles/1c-light.css
@@ -1,0 +1,133 @@
+/*!
+  Theme: 1c-light
+  Description: Style IDE 1C:Enterprise 8
+  Author: (c) Barilko Vitaliy <barilkovetal@gmail.com>
+  Maintainer: @Diversus23
+  Website: https://softonit.ru/
+  License: see project LICENSE
+  Touched: 2023
+*/
+
+pre code.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
+  }
+  
+  code.hljs {
+    padding: 3px 5px;
+  }
+  /* end baseline CSS */
+  
+  .hljs {
+    font-family: "Courier New", monospace; /* This font is used in IDE the 1C:Enterprise 8 */
+    color: #0000ff;
+    background: #ffffff;
+    font-weight: normal;
+    font-style: normal;
+  }
+  
+  /* Base color: saturation 0; */
+  
+  .hljs-subst {
+    /* default */
+  }
+  
+  /* purposely ignored */
+  .hljs-formula,
+  .hljs-attr,
+  .hljs-property {}
+  
+  .hljs-comment {
+    color: #008000;
+  }
+  .hljs-tag {
+    color: #444a;
+  }
+  
+  .hljs-tag .hljs-name,
+  .hljs-tag .hljs-attr {
+    color: #444;
+  }
+  
+  .hljs-punctuation,
+  .hljs-function,
+  .hljs-keyword,
+  .hljs-attribute,
+  .hljs-selector-tag,
+  .hljs-doctag,
+  .hljs-name {
+    color: #ff0000;
+  }
+
+  .hljs-type,
+  .hljs-params {
+    color: #0000ff;
+  }
+  
+  /* User color: hue: 0 */
+
+  .hljs-string,
+  .hljs-number,
+  .hljs-selector-id,
+  .hljs-selector-class,
+  .hljs-quote,
+  .hljs-template-tag,
+  .hljs-symbol,
+  .hljs-deletion {
+    color: #000000;
+  }
+  
+  .hljs-title,
+  .hljs-section {
+    color: #0000ff;
+  }
+  
+  .hljs-regexp,
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-link,
+  .hljs-selector-attr,
+  .hljs-operator,
+  .hljs-selector-pseudo {
+    color: #ab5656;
+  }   
+  
+  /* Language color: hue: 90; */
+  
+  .hljs-literal {
+    color: #ff0000;
+  }
+  
+  .hljs-built_in,
+  .hljs-bullet,
+  .hljs-code,
+  .hljs-addition {
+    color: #0000ff;
+  }
+  
+  
+  /* Meta color: hue: 200 */
+  
+  .hljs-meta {
+    color: #963200;
+  }
+  
+  .hljs-meta .hljs-string {
+    color: #963200;
+  }
+
+  .hljs-meta .hljs-keyword {
+    color: #963200;
+  }
+  
+  /* Misc effects */
+
+  .hljs-emphasis {
+    font-style: italic;
+  }
+  
+  .hljs-strong {
+    font-weight: bold;
+  }
+  

--- a/src/styles/1c-light.css
+++ b/src/styles/1c-light.css
@@ -7,24 +7,12 @@
   License: see project LICENSE
   Touched: 2023
 */
-
-pre code.hljs {
-    display: block;
-    overflow-x: auto;
-    padding: 1em;
-  }
   
-  code.hljs {
-    padding: 3px 5px;
-  }
   /* end baseline CSS */
   
   .hljs {
-    font-family: "Courier New", monospace; /* This font is used in IDE the 1C:Enterprise 8 */
     color: #0000ff;
     background: #ffffff;
-    font-weight: normal;
-    font-style: normal;
   }
   
   /* Base color: saturation 0; */

--- a/test/markup/1c/default.expect.txt
+++ b/test/markup/1c/default.expect.txt
@@ -4,27 +4,27 @@
 	<span class="hljs-function">Функция <span class="hljs-title">ТолстыйКлиентОбычноеПриложение</span>(<span class="hljs-params"><span class="hljs-keyword">Знач</span> Параметр<span class="hljs-number">1</span> = <span class="hljs-literal">Неопределено</span></span>, <span class="hljs-comment">// комментарий</span>
 		<span class="hljs-params">Параметр2 = <span class="hljs-string">&quot;&quot;</span></span>, <span class="hljs-params">ПараметрN = <span class="hljs-number">123.45</span></span>, <span class="hljs-params">ПарамNN</span></span>) <span class="hljs-keyword">Экспорт</span> <span class="hljs-comment">// еще комментарий</span>
 		<span class="hljs-keyword">Попытка</span>
-			Результат_Булевы_Значения = <span class="hljs-keyword">Новый</span> <span class="hljs-type">Структура</span>(<span class="hljs-string">&quot;П1, П2&quot;</span>, <span class="hljs-literal">Истина</span>, <span class="hljs-literal">Ложь</span>, <span class="hljs-literal">NULL</span>, <span class="hljs-literal">Неопределено</span>);
+			Результат_Булевы_Значения <span class="hljs-punctuation">=</span> <span class="hljs-keyword">Новый</span> <span class="hljs-type">Структура</span><span class="hljs-punctuation">(</span><span class="hljs-string">&quot;П1, П2&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-literal">Истина</span><span class="hljs-punctuation">,</span> <span class="hljs-literal">Ложь</span><span class="hljs-punctuation">,</span> <span class="hljs-literal">NULL</span><span class="hljs-punctuation">,</span> <span class="hljs-literal">Неопределено</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span>
 			<span class="hljs-keyword">Перейти</span> <span class="hljs-symbol">~МеткаGOTO</span>; <span class="hljs-comment">// комментарий</span>
-			РезультатТаблицаДат = <span class="hljs-keyword">Новый</span> <span class="hljs-type">ТаблицаЗначений</span>;
-			РезультатТаблицаДат.Колонки.Добавить(<span class="hljs-string">&quot;Колонка1&quot;</span>, 
-			<span class="hljs-keyword">Новый</span> <span class="hljs-type">ОписаниеТипов</span>(<span class="hljs-string">&quot;Дата&quot;</span>, , ,
-			<span class="hljs-keyword">Новый</span> <span class="hljs-type">КвалификаторыДаты</span>(<span class="hljs-class">ЧастиДаты</span>.ДатаВремя));
-			НС = РезультатТаблицаДат.Добавить(); НС[<span class="hljs-string">&quot;Колонка1&quot;</span>] = &#x27;<span class="hljs-number">20170101120000</span>&#x27;);
+			РезультатТаблицаДат <span class="hljs-punctuation">=</span> <span class="hljs-keyword">Новый</span> <span class="hljs-type">ТаблицаЗначений</span><span class="hljs-punctuation">;</span>
+			РезультатТаблицаДат.Колонки.Добавить<span class="hljs-punctuation">(</span><span class="hljs-string">&quot;Колонка1&quot;</span><span class="hljs-punctuation">,</span> 
+			<span class="hljs-keyword">Новый</span> <span class="hljs-type">ОписаниеТипов</span><span class="hljs-punctuation">(</span><span class="hljs-string">&quot;Дата&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">,</span> <span class="hljs-punctuation">,</span>
+			<span class="hljs-keyword">Новый</span> <span class="hljs-type">КвалификаторыДаты</span><span class="hljs-punctuation">(</span><span class="hljs-class">ЧастиДаты</span>.ДатаВремя<span class="hljs-punctuation">)</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span>
+			НС <span class="hljs-punctuation">=</span> РезультатТаблицаДат.Добавить<span class="hljs-punctuation">(</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span> НС[<span class="hljs-string">&quot;Колонка1&quot;</span>] <span class="hljs-punctuation">=</span> &#x27;<span class="hljs-number">20170101120000</span>&#x27;<span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span>
 		<span class="hljs-keyword">Исключение</span>
-			<span class="hljs-built_in">ОписаниеОшибки</span> = <span class="hljs-built_in">ОписаниеОшибки</span>(); <span class="hljs-comment">// встроенная функция</span>
-			Масс = <span class="hljs-keyword">Новый</span> <span class="hljs-type">Массив</span>; <span class="hljs-comment">// встроенный тип</span>
+			<span class="hljs-built_in">ОписаниеОшибки</span> <span class="hljs-punctuation">=</span> <span class="hljs-built_in">ОписаниеОшибки</span><span class="hljs-punctuation">(</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span> <span class="hljs-comment">// встроенная функция</span>
+			Масс <span class="hljs-punctuation">=</span> <span class="hljs-keyword">Новый</span> <span class="hljs-type">Массив</span><span class="hljs-punctuation">;</span> <span class="hljs-comment">// встроенный тип</span>
 			<span class="hljs-keyword">Для</span> <span class="hljs-keyword">Каждого</span> Значение <span class="hljs-keyword">Из</span> Масс <span class="hljs-keyword">Цикл</span>
-				<span class="hljs-built_in">Сообщить</span>(Значение + <span class="hljs-class">Символы</span>.ПС + <span class="hljs-string">&quot;</span>
-				<span class="hljs-string">|продолжение строки&quot;</span>); <span class="hljs-comment">// продолжение многострочной строки</span>
-				<span class="hljs-keyword">Продолжить</span>; <span class="hljs-keyword">Прервать</span>;
-			<span class="hljs-keyword">КонецЦикла</span>;
-			СправочникСсылка   = <span class="hljs-built_in">Справочники</span>.Языки.НайтиПоНаименованию(<span class="hljs-string">&quot;ru&quot;</span>); <span class="hljs-comment">// встроенные типы</span>
-			СправочникОбъект   = СправочникСсылка.ПолучитьОбъект();
-			ПеречислениеСсылка = <span class="hljs-built_in">Перечисления</span>.ВидыМодификацииДанных.Изменен;
-			<span class="hljs-keyword">ВызватьИсключение</span> <span class="hljs-built_in">ОписаниеОшибки</span>;
-		<span class="hljs-keyword">КонецПопытки</span>;
+				<span class="hljs-built_in">Сообщить</span><span class="hljs-punctuation">(</span>Значение <span class="hljs-punctuation">+</span> <span class="hljs-class">Символы</span>.ПС <span class="hljs-punctuation">+</span> <span class="hljs-string">&quot;</span>
+				<span class="hljs-string">|продолжение строки&quot;</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span> <span class="hljs-comment">// продолжение многострочной строки</span>
+				<span class="hljs-keyword">Продолжить</span><span class="hljs-punctuation">;</span> <span class="hljs-keyword">Прервать</span><span class="hljs-punctuation">;</span>
+			<span class="hljs-keyword">КонецЦикла</span><span class="hljs-punctuation">;</span>
+			СправочникСсылка   <span class="hljs-punctuation">=</span> <span class="hljs-built_in">Справочники</span>.Языки.НайтиПоНаименованию<span class="hljs-punctuation">(</span><span class="hljs-string">&quot;ru&quot;</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span> <span class="hljs-comment">// встроенные типы</span>
+			СправочникОбъект   <span class="hljs-punctuation">=</span> СправочникСсылка.ПолучитьОбъект<span class="hljs-punctuation">(</span><span class="hljs-punctuation">)</span><span class="hljs-punctuation">;</span>
+			ПеречислениеСсылка <span class="hljs-punctuation">=</span> <span class="hljs-built_in">Перечисления</span>.ВидыМодификацииДанных.Изменен<span class="hljs-punctuation">;</span>
+			<span class="hljs-keyword">ВызватьИсключение</span> <span class="hljs-built_in">ОписаниеОшибки</span><span class="hljs-punctuation">;</span>
+		<span class="hljs-keyword">КонецПопытки</span><span class="hljs-punctuation">;</span>
 		<span class="hljs-symbol">~МеткаGOTO</span>: <span class="hljs-comment">// еще комментарий</span>
-		ВД = <span class="hljs-class">ВидДвиженияБухгалтерии</span>.Дебет;
+		ВД <span class="hljs-punctuation">=</span> <span class="hljs-class">ВидДвиженияБухгалтерии</span>.Дебет<span class="hljs-punctuation">;</span>
 	<span class="hljs-function">КонецФункции</span> <span class="hljs-comment">// ТолстыйКлиентОбычноеПриложение()</span>
 <span class="hljs-meta">#<span class="hljs-keyword">КонецЕсли</span></span>

--- a/tools/developer.html
+++ b/tools/developer.html
@@ -70,6 +70,7 @@
         <button id="show-structure">Show/hide structure</button>
         Language: <select class="languages"><option value="">(Auto)</option></select>
         Theme: <select class="theme">
+          <option>1c-light.css</option>          
           <option>a11y-dark.css</option>
           <option>a11y-light.css</option>
           <option>agate.css</option>


### PR DESCRIPTION
### Changes

* fix(1c) fix escaped symbols "+-;():=,[]" literals
* Added `1c-light` theme a like in the IDE 1C:Enterprise 8 (for 1c)

In IDE 1C:Enterprise 8:
![image](https://github.com/highlightjs/highlight.js/assets/19926084/bff1f04f-6482-46f9-adf3-939d24a59e11)

New theme `1c-light`:
![image](https://github.com/highlightjs/highlight.js/assets/19926084/8543618a-8ada-4d11-9d7b-1c48e98708b0)

### Checklist

- [x] Update markup tests
- [X] Updated the changelog at `CHANGES.md`
