### PR TITLE
enh(perl) fix false-positive variable match at end of string (plus test)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- enh(perl) fix false-positive variable match at end of string [Josh Goebel][]
 - fix(cpp) not all kinds of number literals are highlighted correctly [Lê Duy Quang][]
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
 - enh(arcade) updated to ArcGIS Arcade version 1.24 [Kristian Ekenes][]
@@ -36,6 +37,7 @@ Developer Tool:
 [Robloxian Demo]: https://github.com/RobloxianDemo
 [Paul Tsnobiladzé]: https://github.com/tsnobip
 [Jonah Jeleniewski]: https://github.com/cirras
+[Josh Goebel]: https://github.com/joshgoebel
 
 
 ## Version 11.9.0

--- a/src/languages/perl.js
+++ b/src/languages/perl.js
@@ -270,7 +270,7 @@ export default function(hljs) {
     variants: [
       { begin: /\$\d/ },
       { begin: regex.concat(
-        /[$%@](\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,
+        /[$%@](?!")(\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,
         // negative look-ahead tries to avoid matching patterns that are not
         // Perl at all like $ident$, @ident@, etc.
         `(?![A-Za-z])(?![@$%])`
@@ -278,7 +278,7 @@ export default function(hljs) {
       },
       {
         // Only $= is a special Perl variable and one can't declare @= or %=.
-        begin: /[$%@][^\s\w{=]|\$=/,
+        begin: /[$%@](?!")[^\s\w{=]|\$=/,
         relevance: 0
       }
     ],

--- a/test/markup/perl/default.expect.txt
+++ b/test/markup/perl/default.expect.txt
@@ -25,6 +25,10 @@
   <span class="hljs-comment"># GH-117</span>
   <span class="hljs-keyword">my</span> <span class="hljs-variable">$g</span> = <span class="hljs-keyword">glob</span>(<span class="hljs-string">&quot;/usr/bin/*&quot;</span>);
 
+  <span class="hljs-comment"># GH-3934</span>
+  <span class="hljs-keyword">print</span> <span class="hljs-string">&quot;@&quot;</span>;
+  <span class="hljs-keyword">print</span>;
+
   <span class="hljs-keyword">return</span> <span class="hljs-variable">$o</span>;
 }
 

--- a/test/markup/perl/default.txt
+++ b/test/markup/perl/default.txt
@@ -25,6 +25,10 @@ sub load
   # GH-117
   my $g = glob("/usr/bin/*");
 
+  # GH-3934
+  print "@";
+  print;
+
   return $o;
 }
 


### PR DESCRIPTION
See #3934 for a full description of this issue.

Includes work from @joshgoebel who hasn't been seen online since 2023-12-01, may he rest in peace, j/k :-)

This PR is basically the same as #3935, except it *also* adds a markup test for the issue I described in #3934.

### Changes
Fixes #3934
Closes #3935

### Checklist
- [x] Added markup tests (@h3xx did this)
- [x] Updated the changelog at `CHANGES.md` (@joshgoebel did this)
