### PR TITLE
Fix zsh alias issues

### DIFF
--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -368,7 +368,10 @@ export default function(hljs) {
 
   return {
     name: 'Bash',
-    aliases: [ 'sh' ],
+    aliases: [
+      'sh',
+      'zsh'
+    ],
     keywords: {
       $pattern: /\b[a-z][a-z0-9._-]+\b/,
       keyword: KEYWORDS,


### PR DESCRIPTION
#3942 https://highlightjs.readthedocs.io/en/latest/supported-languages.html bash has zsh alias, but it doesn't work.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
Add bash alias 'zsh' (such as macOS)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
