### PR TITLE
fix(rust): add support for r# raw identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Core Grammars:
 - enh(arcade) updated to ArcGIS Arcade version 1.24 [Kristian Ekenes][]
 - fix(typescript): params types [Mohamed Ali][]
 - fix(rust) fix escaped double quotes in string  [Mohamed Ali][]
+- fix(rust) fix for r# raw identifier not being highlighted correctly. [JaeBaek Lee][]
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
@@ -33,6 +34,7 @@ Themes:
 
 [Lê Duy Quang]: https://github.com/leduyquang753
 [Mohamed Ali]: https://github.com/MohamedAli00949
+[JaeBaek Lee]: https://github.com/ThinkingVincent
 [Bradley Mackey]: https://github.com/bradleymackey
 [Kristian Ekenes]: https://github.com/ekenes
 [Aneesh Kulkarni]: https://github.com/aneesh98

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -368,7 +368,10 @@ export default function(hljs) {
 
   return {
     name: 'Bash',
-    aliases: [ 'sh' ],
+    aliases: [
+      'sh',
+      'zsh'
+    ],
     keywords: {
       $pattern: /\b[a-z][a-z0-9._-]+\b/,
       keyword: KEYWORDS,

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -9,13 +9,13 @@ Category: common, system
 /** @type LanguageFn */
 
 export default function(hljs) {
+  const regex = hljs.regex;
   // ============================================
   // Added to support the r# keyword, which is a raw identifier in Rust.
-  const RAW_IDENTIFIER = '(r#)?';
-  const UNDERSCORE_IDENT_RE = RAW_IDENTIFIER + hljs.UNDERSCORE_IDENT_RE;
-  const IDENT_RE = RAW_IDENTIFIER + hljs.IDENT_RE;
+  const RAW_IDENTIFIER = /(r#)?/;
+  const UNDERSCORE_IDENT_RE = regex.concat(RAW_IDENTIFIER, hljs.UNDERSCORE_IDENT_RE);
+  const IDENT_RE = regex.concat(RAW_IDENTIFIER, hljs.IDENT_RE);
   // ============================================
-  const regex = hljs.regex;
   const FUNCTION_INVOKE = {
     className: "title.function.invoke",
     relevance: 0,

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -7,6 +7,13 @@ Category: common, system
 */
 
 /** @type LanguageFn */
+
+// ============================================
+// Added to support the r# keyword, which is a raw identifier in Rust.
+const UNDERSCORE_IDENT_RE = '(r#)?[a-zA-Z_]\\w*';
+const IDENT_RE = '(r#)?[a-zA-Z]\\w*';
+// ============================================
+
 export default function(hljs) {
   const regex = hljs.regex;
   const FUNCTION_INVOKE = {
@@ -15,7 +22,7 @@ export default function(hljs) {
     begin: regex.concat(
       /\b/,
       /(?!let|for|while|if|else|match\b)/,
-      hljs.IDENT_RE,
+      IDENT_RE,
       regex.lookahead(/\s*\(/))
   };
   const NUMBER_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
@@ -176,7 +183,7 @@ export default function(hljs) {
     name: 'Rust',
     aliases: [ 'rs' ],
     keywords: {
-      $pattern: hljs.IDENT_RE + '!?',
+      $pattern: IDENT_RE + '!?',
       type: TYPES,
       keyword: KEYWORDS,
       literal: LITERALS,
@@ -216,7 +223,7 @@ export default function(hljs) {
         begin: [
           /fn/,
           /\s+/,
-          hljs.UNDERSCORE_IDENT_RE
+          UNDERSCORE_IDENT_RE
         ],
         className: {
           1: "keyword",
@@ -243,7 +250,7 @@ export default function(hljs) {
           /let/,
           /\s+/,
           /(?:mut\s+)?/,
-          hljs.UNDERSCORE_IDENT_RE
+          UNDERSCORE_IDENT_RE
         ],
         className: {
           1: "keyword",
@@ -256,7 +263,7 @@ export default function(hljs) {
         begin: [
           /for/,
           /\s+/,
-          hljs.UNDERSCORE_IDENT_RE,
+          UNDERSCORE_IDENT_RE,
           /\s+/,
           /in/
         ],
@@ -270,7 +277,7 @@ export default function(hljs) {
         begin: [
           /type/,
           /\s+/,
-          hljs.UNDERSCORE_IDENT_RE
+          UNDERSCORE_IDENT_RE
         ],
         className: {
           1: "keyword",
@@ -281,7 +288,7 @@ export default function(hljs) {
         begin: [
           /(?:trait|enum|struct|union|impl|for)/,
           /\s+/,
-          hljs.UNDERSCORE_IDENT_RE
+          UNDERSCORE_IDENT_RE
         ],
         className: {
           1: "keyword",
@@ -289,7 +296,7 @@ export default function(hljs) {
         }
       },
       {
-        begin: hljs.IDENT_RE + '::',
+        begin: IDENT_RE + '::',
         keywords: {
           keyword: "Self",
           built_in: BUILTINS,

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -183,7 +183,7 @@ export default function(hljs) {
     name: 'Rust',
     aliases: [ 'rs' ],
     keywords: {
-      $pattern: IDENT_RE + '!?',
+      $pattern: hljs.IDENT_RE + '!?',
       type: TYPES,
       keyword: KEYWORDS,
       literal: LITERALS,

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -8,13 +8,13 @@ Category: common, system
 
 /** @type LanguageFn */
 
-// ============================================
-// Added to support the r# keyword, which is a raw identifier in Rust.
-const UNDERSCORE_IDENT_RE = '(r#)?[a-zA-Z_]\\w*';
-const IDENT_RE = '(r#)?[a-zA-Z]\\w*';
-// ============================================
-
 export default function(hljs) {
+  // ============================================
+  // Added to support the r# keyword, which is a raw identifier in Rust.
+  const RAW_IDENTIFIER = '(r#)?';
+  const UNDERSCORE_IDENT_RE = RAW_IDENTIFIER + hljs.UNDERSCORE_IDENT_RE;
+  const IDENT_RE = RAW_IDENTIFIER + hljs.IDENT_RE;
+  // ============================================
   const regex = hljs.regex;
   const FUNCTION_INVOKE = {
     className: "title.function.invoke",

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -296,7 +296,7 @@ export default function(hljs) {
         }
       },
       {
-        begin: IDENT_RE + '::',
+        begin: hljs.IDENT_RE + '::',
         keywords: {
           keyword: "Self",
           built_in: BUILTINS,

--- a/test/markup/rust/variables.expect.txt
+++ b/test/markup/rust/variables.expect.txt
@@ -1,3 +1,4 @@
 <span class="hljs-keyword">let</span> <span class="hljs-variable">foo</span>;
 <span class="hljs-keyword">let</span> <span class="hljs-keyword">mut </span><span class="hljs-variable">bar</span>;
 <span class="hljs-keyword">let</span> <span class="hljs-variable">_foo_bar</span>;
+<span class="hljs-keyword">let</span> <span class="hljs-variable">r#foo</span>;

--- a/test/markup/rust/variables.txt
+++ b/test/markup/rust/variables.txt
@@ -1,3 +1,4 @@
 let foo;
 let mut bar;
 let _foo_bar;
+let r#foo;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
https://github.com/highlightjs/highlight.js/issues/3924
### Changes
<!--- Describe your changes -->
In order to support raw identifiers in Rust, the regular expressions for `UNDERSCORE_IDENT_RE` and `IDENT_RE` need to be modified to include the r# keyword. However, since modes.js is shared by other languages, we need to ensure that only rust supports the r# keyword.

**Original (modes.js)**
```js
const UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
const IDENT_RE = '[a-zA-Z]\\w*';
```

**Change (rust.js)**

So, add the following code to rust.js to support the r# keyword only in rust.
``` js
const UNDERSCORE_IDENT_RE = '(r#)?[a-zA-Z_]\\w*';
const IDENT_RE = '(r#)?[a-zA-Z]\\w*';
```

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
