### PR TITLE
Adding union to be recognized as a keyword in Rust

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Core Grammars:
 - fix(typescript): params types [Mohamed Ali][]
 - fix(rust) fix escaped double quotes in string  [Mohamed Ali][]
 - fix(rust) fix for r# raw identifier not being highlighted correctly. [JaeBaek Lee][]
+- enh(rust) Adding union to be recognized as a keyword in Rust. [JaeBaek Lee][]
 - fix(yaml) fix for yaml with keys having brackets highlighted incorrectly [Aneesh Kulkarni][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -71,6 +71,7 @@ export default function(hljs) {
     "try",
     "type",
     "typeof",
+    "union",
     "unsafe",
     "unsized",
     "use",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding union to be recognized as a keyword in Rust.
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
https://github.com/highlightjs/highlight.js/issues/3948
### Changes
<!--- Describe your changes -->
Added the union keyword to the KEYWORDS array in rust.js.
![image](https://github.com/highlightjs/highlight.js/assets/103738589/55095b9c-646d-4dfc-b7cc-b2bbea715a80)

### Checklist
- [x] Added markup tests, or they don't apply here because...
  Even without adding any markup tests, the following code ensures that the highlighting is applied correctly.
``` rust
        begin: [
          /(?:trait|enum|struct|union|impl|for)/,
          /\s+/,
          UNDERSCORE_IDENT_RE
        ],
        className: {
          1: "keyword",
          3: "title.class"
        }
```
- [x] Updated the changelog at `CHANGES.md`
