### PR TITLE
feature: add 3rd support zig grammar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ New Grammars:
 - added 3rd party CODEOWNERS grammar to SUPPORTED_LANGUAGES [nataliia-radina][]
 - added 3rd party Luau grammar to SUPPORTED_LANGUAGES [Robloxian Demo][]
 - added 3rd party ReScript grammar to SUPPORTED_LANGUAGES [Paul Tsnobiladzé][]
+- added 3rd party Zig grammar to SUPPORTED_LANGUAGES [Hyou BunKen][]
 
 Developer Tool:
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -248,6 +248,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | YAML                    | yml, yaml              |         |
 | ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |
 | Zephir                  | zephir, zep            |         |
+| Zig                     | zig                    |[highlightjs-zig](https://github.com/fwx5618177/highlightjs-zig) |
 <!-- LANGLIST_END -->
 
 <!-- document it until we can fix it -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Add a 3rd Zig grammar at CHANGE.md and SUPPORT_LANGUAGE.md.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
