### PR TITLE
enh(swift) add package keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Core Grammars:
 - fix(javascript) incorrect function name highlighting [CY Fung][]
 - fix(1c) fix escaped symbols "+-;():=,[]" literals [Vitaly Barilko][]
 - fix(swift) correctly highlight generics and conformances in type definitions [Bradley Mackey][]
+- enh(swift) add package keyword [Bradley Mackey][]
 
 New Grammars:
 

--- a/src/languages/lib/kws_swift.js
+++ b/src/languages/lib/kws_swift.js
@@ -92,6 +92,7 @@ export const keywords = [
   'operator',
   'optional', // contextual
   'override', // contextual
+  'package',
   'postfix', // contextual
   'precedencegroup',
   'prefix', // contextual

--- a/test/markup/swift/keywords.expect.txt
+++ b/test/markup/swift/keywords.expect.txt
@@ -17,6 +17,7 @@ x <span class="hljs-keyword">is</span> <span class="hljs-type">String</span>
 <span class="hljs-keyword">unowned(safe)</span> <span class="hljs-keyword">unowned(unsafe)</span>
 <span class="hljs-keyword">async</span> <span class="hljs-keyword">await</span>
 <span class="hljs-keyword">isolated</span> <span class="hljs-keyword">nonisolated</span>
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">private</span> <span class="hljs-keyword">package</span> <span class="hljs-keyword">internal</span> <span class="hljs-keyword">open</span>
 
 <span class="hljs-keyword">#if</span>
 <span class="hljs-keyword">#error</span>(<span class="hljs-string">&quot;Error&quot;</span>)

--- a/test/markup/swift/keywords.expect.txt
+++ b/test/markup/swift/keywords.expect.txt
@@ -17,7 +17,7 @@ x <span class="hljs-keyword">is</span> <span class="hljs-type">String</span>
 <span class="hljs-keyword">unowned(safe)</span> <span class="hljs-keyword">unowned(unsafe)</span>
 <span class="hljs-keyword">async</span> <span class="hljs-keyword">await</span>
 <span class="hljs-keyword">isolated</span> <span class="hljs-keyword">nonisolated</span>
-<span class="hljs-keyword">public</span> <span class="hljs-keyword">private</span> <span class="hljs-keyword">package</span> <span class="hljs-keyword">internal</span> <span class="hljs-keyword">open</span>
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">private</span> <span class="hljs-keyword">fileprivate</span> <span class="hljs-keyword">package</span> <span class="hljs-keyword">internal</span> <span class="hljs-keyword">open</span>
 
 <span class="hljs-keyword">#if</span>
 <span class="hljs-keyword">#error</span>(<span class="hljs-string">&quot;Error&quot;</span>)

--- a/test/markup/swift/keywords.txt
+++ b/test/markup/swift/keywords.txt
@@ -17,7 +17,7 @@ fileprivate(set) internal(set) open(set) private(set) public(set)
 unowned(safe) unowned(unsafe)
 async await
 isolated nonisolated
-public private package internal open
+public private fileprivate package internal open
 
 #if
 #error("Error")

--- a/test/markup/swift/keywords.txt
+++ b/test/markup/swift/keywords.txt
@@ -17,6 +17,7 @@ fileprivate(set) internal(set) open(set) private(set) public(set)
 unowned(safe) unowned(unsafe)
 async await
 isolated nonisolated
+public private package internal open
 
 #if
 #error("Error")


### PR DESCRIPTION
### Changes
- Adds `package` access control keyword, specified in [SE-0386](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md)

### Checklist
- [x] Added markup tests, ~~or they don't apply here because...~~
- [x] Updated the changelog at `CHANGES.md`
