### PR TITLE
(chore) update Node.js test versions

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        # All 'LTS' and 'Current' versions
+        # All 'LTS' and 'Current' versions (https://nodejs.org/en/about/previous-releases)
         node-version: [18.x, 20.x, 21.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 

--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -19,7 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        # All 'LTS' and 'Current' versions
+        node-version: [18.x, 20.x, 21.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:

--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 11.10.0 (Next Release)
 
+CAVEATS / POTENTIALLY BREAKING CHANGES
+
+- Drops support for Node 16.x, which is no longer supported by Node.js.
+
 Core Grammars:
 
 - enh(perl) fix false-positive variable match at end of string [Josh Goebel][]


### PR DESCRIPTION
### Changes
- Drop Node 16 support from test matrix, this is no longer supported or receiving security updates.
- Start testing "Current" versions as well, starting with v21. This will allow us to catch issues caused by new releases ASAP.

### Checklist
- ~~[ ] Added markup tests, or they don't apply here because..~~.
- [x] Updated the changelog at `CHANGES.md`
