### PR TITLE
fix(swift) ensure keyword attributes highlight correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Core Grammars:
 - fix(1c) fix escaped symbols "+-;():=,[]" literals [Vitaly Barilko][]
 - fix(swift) correctly highlight generics and conformances in type definitions [Bradley Mackey][]
 - enh(swift) add package keyword [Bradley Mackey][]
+- fix(swift) ensure keyword attributes highlight correctly [Bradley Mackey][]
 
 New Grammars:
 

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -257,14 +257,17 @@ export default function(hljs) {
       }
     ] }
   };
+
   const KEYWORD_ATTRIBUTE = {
     scope: 'keyword',
-    match: concat(/@/, either(...Swift.keywordAttributes))
+    match: concat(/@/, either(...Swift.keywordAttributes), lookahead(either(/\(/, /\s+/))),
   };
+
   const USER_DEFINED_ATTRIBUTE = {
     scope: 'meta',
     match: concat(/@/, Swift.identifier)
   };
+
   const ATTRIBUTES = [
     AVAILABLE_ATTRIBUTE,
     KEYWORD_ATTRIBUTE,

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -15,3 +15,13 @@
 <span class="hljs-meta">@SendableCustom</span>
 
 @ notAnAttribute
+
+<span class="hljs-comment">// keywords delimited by whitespace</span>
+<span class="hljs-keyword">@objc</span> <span class="hljs-keyword">@objcMembers</span> <span class="hljs-meta">@Custom</span> <span class="hljs-meta">@Custom</span>(param: <span class="hljs-string">&quot;test&quot;</span>)
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Something</span> {}
+
+<span class="hljs-keyword">@objc</span>
+<span class="hljs-keyword">@objcMembers</span>
+<span class="hljs-meta">@Custom</span>
+<span class="hljs-meta">@Custom</span>(param: <span class="hljs-string">&quot;test&quot;</span>)
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Something</span> {}

--- a/test/markup/swift/attributes.expect.txt
+++ b/test/markup/swift/attributes.expect.txt
@@ -5,8 +5,13 @@
 <span class="hljs-keyword">@propertyWrapper</span>
 <span class="hljs-meta">@SomeWrapper</span>(value: <span class="hljs-number">1.0</span>, other: <span class="hljs-string">&quot;string&quot;</span>, bool: <span class="hljs-literal">false</span>)
 <span class="hljs-keyword">@resultBuilder</span>
-<span class="hljs-keyword">@Sendable</span>
 <span class="hljs-keyword">@unchecked</span>
 <span class="hljs-keyword">@warn_unqualified_access</span>
+
+<span class="hljs-keyword">@objc</span>
+<span class="hljs-keyword">@objcMembers</span>
+<span class="hljs-meta">@CustomAttribute</span>
+<span class="hljs-keyword">@Sendable</span>
+<span class="hljs-meta">@SendableCustom</span>
 
 @ notAnAttribute

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -15,3 +15,13 @@
 @SendableCustom
 
 @ notAnAttribute
+
+// keywords delimited by whitespace
+@objc @objcMembers @Custom @Custom(param: "test")
+class Something {}
+
+@objc
+@objcMembers
+@Custom
+@Custom(param: "test")
+class Something {}

--- a/test/markup/swift/attributes.txt
+++ b/test/markup/swift/attributes.txt
@@ -5,8 +5,13 @@
 @propertyWrapper
 @SomeWrapper(value: 1.0, other: "string", bool: false)
 @resultBuilder
-@Sendable
 @unchecked
 @warn_unqualified_access
+
+@objc
+@objcMembers
+@CustomAttribute
+@Sendable
+@SendableCustom
 
 @ notAnAttribute

--- a/test/markup/swift/macro.expect.txt
+++ b/test/markup/swift/macro.expect.txt
@@ -6,4 +6,7 @@
 <span class="hljs-keyword">@attached</span>(member)
 <span class="hljs-keyword">macro</span> <span class="hljs-title function_">OptionSetMembers</span>()
 
+<span class="hljs-keyword">@attached</span>(peer, names: overloaded)
+<span class="hljs-keyword">macro</span> <span class="hljs-title function_">OptionSetMembers</span>()
+
 #myMacro()

--- a/test/markup/swift/macro.txt
+++ b/test/markup/swift/macro.txt
@@ -6,4 +6,7 @@ macro error(_ message: String) = #externalMacro(module: "MyMacros", type: "Error
 @attached(member)
 macro OptionSetMembers()
 
+@attached(peer, names: overloaded)
+macro OptionSetMembers()
+
 #myMacro()


### PR DESCRIPTION
### Changes
- Prevent keyword attributes from greedily matching non-keyword attributes
- Lookahead to either a trailing whitespace character or an opening paren to ensure matches are exact for the keywords.
- Prevents issues like `@objcMembers` being prematurely highlighted as `@objc` only.
- Also prevents issues where `meta` attributes may have the same prefix as a keyword

### Checklist
- [x] Added markup tests, ~~or they don't apply here because...~~
- [x] Updated the changelog at `CHANGES.md`
