### PR TITLE
(chore) Fix updated default.txt for swift

### DIFF
--- a/test/detect/swift/default.txt
+++ b/test/detect/swift/default.txt
@@ -6,7 +6,9 @@ public struct Stack<T>: Equatable where T: Equatable {
     self.items = items
   }
 
-  public mutating func push(item: T) { /* /* ... */ */ }
+  public mutating func push(item: T) { items.append(item) }
+
+  /* /* ... */ */
 
   fileprivate var description: String {
     if items.isEmpty {

--- a/test/detect/swift/default.txt
+++ b/test/detect/swift/default.txt
@@ -12,7 +12,7 @@ public struct Stack<T>: Equatable where T: Equatable {
     if items.isEmpty {
       "The stack is empty"
     } else {
-      "\(count) items in the stack"
+      "\(items.count) items in the stack"
     }
   }
 }


### PR DESCRIPTION
### Changes
- Oops, a last-minute change in the PR for #3956 left the example so it wouldn't compile (within the `description` property).
- Also, actually implement `push` since it's trivial and show nested comment support beneath it (implying this is leaving `pop` as an exercise for the reader)

### Checklist
- [x] ~~Added markup tests~~ this is a detect test case
- [ ] ~~Updated the changelog at `CHANGES.md`~~
