### PR TITLE
Fix interface LanguageDetail > keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Core Grammars:
 - fix(swift) correctly highlight generics and conformances in type definitions [Bradley Mackey][]
 - enh(swift) add package keyword [Bradley Mackey][]
 - fix(swift) ensure keyword attributes highlight correctly [Bradley Mackey][]
+- fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
 
 New Grammars:
 
@@ -57,6 +58,7 @@ Themes:
 [Josh Goebel]: https://github.com/joshgoebel
 [CY Fung]: https://github.com/cyfung1031
 [Vitaly Barilko]: https://github.com/Diversus23
+[Patrick Chiu]: https://github.com/patrick-kw-chiu
 
 
 ## Version 11.9.0

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -169,7 +169,7 @@ declare module 'highlight.js' {
         disableAutodetect?: boolean
         contains: (Mode)[]
         case_insensitive?: boolean
-        keywords?: string | string[] | Record<string, string | string[]>
+        keywords?: string | string[] | Record<string, string | string[] | RegExp>
         isCompiled?: boolean,
         exports?: any,
         classNameAliases?: Record<string, string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
Resolves #3936 (though the issue is closed as completed)

### Changes
<!--- Describe your changes -->
Added `RegExp` to `keywords`, to reflect the `$pattern` field in `python` and `dart`.

https://github.com/highlightjs/highlight.js/blob/6a52185d9b855130b5acaccef143a7bd602e7885/src/languages/python.js#L148-L154

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
