### PR TITLE
(JAVA) Add `goto` to be recognized as a keyword in Java

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(swift) add package keyword [Bradley Mackey][]
 - fix(swift) ensure keyword attributes highlight correctly [Bradley Mackey][]
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
+- enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]\
 
 New Grammars:
 
@@ -59,6 +60,7 @@ Themes:
 [CY Fung]: https://github.com/cyfung1031
 [Vitaly Barilko]: https://github.com/Diversus23
 [Patrick Chiu]: https://github.com/patrick-kw-chiu
+[Alvin Joy]: https://github.com/alvinsjoy
 
 
 ## Version 11.9.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ Core Grammars:
 - enh(swift) add package keyword [Bradley Mackey][]
 - fix(swift) ensure keyword attributes highlight correctly [Bradley Mackey][]
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
-- enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]\
+- enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]
 
 New Grammars:
 

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -74,7 +74,8 @@ export default function(hljs) {
     'do',
     'sealed',
     'yield',
-    'permits'
+    'permits',
+    'goto'
   ];
 
   const BUILT_INS = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added goto to be recognised as a main keyword in Java.
<!-- Please link to a related issue below. -->
Resolves #3962 

### Changes
<!--- Describe your changes -->
Added `goto` to MAIN_KEYWORDS as [Java keyword list](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html) specifies `goto` as a keyword.
![image](https://github.com/highlightjs/highlight.js/assets/89687635/e51c9934-3712-4b08-b443-3e561c263644)

### Checklist
- [X] Added markup tests, or they don't apply here because `goto` is marked as "not used" by [Java keyword list](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html)
- [X] Updated the changelog at `CHANGES.md`
