### PR TITLE
Fix markup tests not executing correctly on Windows

### DIFF
--- a/test/markup/index.js
+++ b/test/markup/index.js
@@ -16,7 +16,7 @@ function testLanguage(language, {testDir}) {
       path.join(testDir, '*.expect.txt') :
       utility.buildPath('markup', language, '*.expect.txt');
     const filePath = where;
-    const filenames = glob.sync(filePath);
+    const filenames = glob.sync(filePath, {windowsPathsNoEscape: true});
 
     filenames.forEach(function(filename) {
       const testName = path.basename(filename, '.expect.txt');


### PR DESCRIPTION
I was trying to make a pull request for a separate issue but I noticed that the markup tests aren't executed on my Windows machine.

Following the test files, I found an issue with the usage of glob. Per their documentation:
> **Note** Glob patterns should always use / as a path separator, even on Windows systems, as \ is used to escape glob characters. If you wish to use \ as a path separator instead of using it as an escape character on Windows platforms, you may set windowsPathsNoEscape:true in the options. In this mode, special glob characters cannot be escaped, making it impossible to match a literal * ? and so on in filenames.

This is not the case in the test executor.
https://github.com/highlightjs/highlight.js/blob/200c09c30c5b8fc1afe62388024f66019052b73a/test/markup/index.js#L15-L19
On Windows, `filePath` ends up something like `...\Code\highlight.js\test\markup\erlang\*.expect.txt`, which means that the * gets escaped.

Adding the recommended option solves the problem, as expected, and because we're not trying to match any literals * or ? this shouldn't cause any other issues.