### PR TITLE
enh(bash) add `sudo` keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Core Grammars:
 - fix(swift) ensure keyword attributes highlight correctly [Bradley Mackey][]
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
 - enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]
+- enh(bash) add keyword `sudo` [Alvin Joy][]
 
 New Grammars:
 

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -183,6 +183,7 @@ export default function(hljs) {
     "read",
     "readarray",
     "source",
+    "sudo",
     "type",
     "typeset",
     "ulimit",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `sudo` to the list of bash built in keywords.
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3957 
### Changes
<!--- Describe your changes -->
![image](https://github.com/highlightjs/highlight.js/assets/89687635/4895f9bf-7a14-4759-90b8-0b1f9a0317e0)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
