### PR TITLE
Fix go number highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Core Grammars:
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
 - enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]
 - enh(bash) add keyword `sudo` [Alvin Joy][]
+- fix(go) fix go number literals to accept `_` separators, add hex p exponents [Lisa Ugray][]
 
 New Grammars:
 
@@ -62,6 +63,7 @@ Themes:
 [Vitaly Barilko]: https://github.com/Diversus23
 [Patrick Chiu]: https://github.com/patrick-kw-chiu
 [Alvin Joy]: https://github.com/alvinsjoy
+[Lisa Ugray]: https://github.com/lugray
 
 
 ## Version 11.9.0

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -109,23 +109,23 @@ export default function(hljs) {
         className: 'number',
         variants: [
           {
-            match: '-?\\b0[xX]\\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\\d(_?\\d)*i?', // hex without a present digit before . (making a digit afterwards required)
+            match: /-?\b0[xX]\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\d(_?\d)*i?/, // hex without a present digit before . (making a digit afterwards required)
             relevance: 0
           },
           {
-            match: '-?\\b0[xX](_?[a-fA-F0-9])+((\\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\\d(_?\\d)*)?i?', // hex with a present digit before . (making a digit afterwards optional)
+            match: /-?\b0[xX](_?[a-fA-F0-9])+((\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\d(_?\d)*)?i?/, // hex with a present digit before . (making a digit afterwards optional)
             relevance: 0
           },
           {
-            match: '-?\\b0[oO](_?[0-7])*i?', // leading 0o octal
+            match: /-?\b0[oO](_?[0-7])*i?/, // leading 0o octal
             relevance: 0
           },
           {
-            match: '-?\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?i?', // decimal without a present digit before . (making a digit afterwards required)
+            match: /-?\.\d(_?\d)*([eE][+-]?\d(_?\d)*)?i?/, // decimal without a present digit before . (making a digit afterwards required)
             relevance: 0
           },
           {
-            match: '-?\\b\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?([eE][+-]?\\d(_?\\d)*)?i?', // decimal with a present digit before . (making a digit afterwards optional)
+            match: /-?\b\d(_?\d)*(\.(\d(_?\d)*)?)?([eE][+-]?\d(_?\d)*)?i?/, // decimal with a present digit before . (making a digit afterwards optional)
             relevance: 0
           }
         ]

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -109,27 +109,27 @@ export default function(hljs) {
         className: 'number',
         variants: [
           {
-            begin: '-?\\b0[xX]\\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\\d(_?\\d)*i?', // hex without a present digit before . (making a digit afterwards required)
+            match: '-?\\b0[xX]\\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\\d(_?\\d)*i?', // hex without a present digit before . (making a digit afterwards required)
             relevance: 0
           },
           {
-            begin: '-?\\b0[xX](_?[a-fA-F0-9])+((\\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\\d(_?\\d)*)?i?', // hex with a present digit before . (making a digit afterwards optional)
+            match: '-?\\b0[xX](_?[a-fA-F0-9])+((\\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\\d(_?\\d)*)?i?', // hex with a present digit before . (making a digit afterwards optional)
             relevance: 0
           },
           {
-            begin: '-?\\b0[oO](_?[0-7])*i?', // leading 0o octal
+            match: '-?\\b0[oO](_?[0-7])*i?', // leading 0o octal
             relevance: 0
           },
           {
-            begin: '-?\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?i?', // decimal without a present digit before . (making a digit afterwards required)
+            match: '-?\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?i?', // decimal without a present digit before . (making a digit afterwards required)
             relevance: 0
           },
           {
-            begin: '-?\\b\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?([eE][+-]?\\d(_?\\d)*)?i?', // decimal with a present digit before . (making a digit afterwards optional)
+            match: '-?\\b\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?([eE][+-]?\\d(_?\\d)*)?i?', // decimal with a present digit before . (making a digit afterwards optional)
             relevance: 0
           },
           {
-            begin: '-?\\b0(_?[0-7])*i?', // leading 0 octal
+            match: '-?\\b0(_?[0-7])*i?', // leading 0 octal
             relevance: 0
           }
         ]

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -109,10 +109,29 @@ export default function(hljs) {
         className: 'number',
         variants: [
           {
-            begin: hljs.C_NUMBER_RE + '[i]',
-            relevance: 1
+            begin: '-?\\b0[xX]\\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\\d(_?\\d)*i?', // hex without a present digit before . (making a digit afterwards required)
+            relevance: 0
           },
-          hljs.C_NUMBER_MODE
+          {
+            begin: '-?\\b0[xX](_?[a-fA-F0-9])+((\\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\\d(_?\\d)*)?i?', // hex with a present digit before . (making a digit afterwards optional)
+            relevance: 0
+          },
+          {
+            begin: '-?\\b0[oO](_?[0-7])*i?', // leading 0o octal
+            relevance: 0
+          },
+          {
+            begin: '-?\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?i?', // decimal without a present digit before . (making a digit afterwards required)
+            relevance: 0
+          },
+          {
+            begin: '-?\\b\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?([eE][+-]?\\d(_?\\d)*)?i?', // decimal with a present digit before . (making a digit afterwards optional)
+            relevance: 0
+          },
+          {
+            begin: '-?\\b0(_?[0-7])*i?', // leading 0 octal
+            relevance: 0
+          }
         ]
       },
       { begin: /:=/ // relevance booster

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -127,10 +127,6 @@ export default function(hljs) {
           {
             match: '-?\\b\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?([eE][+-]?\\d(_?\\d)*)?i?', // decimal with a present digit before . (making a digit afterwards optional)
             relevance: 0
-          },
-          {
-            match: '-?\\b0(_?[0-7])*i?', // leading 0 octal
-            relevance: 0
           }
         ]
       },

--- a/test/markup/go/numbers.expect.txt
+++ b/test/markup/go/numbers.expect.txt
@@ -1,3 +1,64 @@
+-- Numbers
+
 float_var := <span class="hljs-number">1.0e10</span>
 complex_var := <span class="hljs-number">1.2e5</span>+<span class="hljs-number">2.3i</span>
 hex_int := <span class="hljs-number">0xcf3e4028ac084aea</span>
+
+int_simple := <span class="hljs-number">42</span>
+int_underscore := <span class="hljs-number">4_2</span>
+octal := <span class="hljs-number">0600</span>
+octal_underscore := <span class="hljs-number">0_600</span>
+octal_o := <span class="hljs-number">0o600</span>
+octal_upper_o := <span class="hljs-number">0O600</span>
+hex_mixed_case := <span class="hljs-number">0xBadFace</span>
+hex_underscore := <span class="hljs-number">0xBad_Face</span>
+hex_many_underscore := <span class="hljs-number">0x_67_7a_2f_cc_40_c6</span>
+long_int := <span class="hljs-number">170141183460469231731687303715884105727</span>
+long_int_underscore := <span class="hljs-number">170_141183_460469_231731_687303_715884_105727</span>
+
+float_no_post := <span class="hljs-number">0.</span>
+float_simple := <span class="hljs-number">72.40</span>
+float_leading_zero := <span class="hljs-number">072.40</span>
+float_e := <span class="hljs-number">1.e+0</span>
+float_e_neg := <span class="hljs-number">6.67428e-11</span>
+float_e_no_decimal := <span class="hljs-number">1E6</span>
+float_no_pre := <span class="hljs-number">.25</span>
+float_e_no_pre := <span class="hljs-number">.12345E+5</span>
+float_underscore := <span class="hljs-number">1_5.</span>
+float_underscore_in_e := <span class="hljs-number">0.15e+0_2</span>
+
+float_hex_p := <span class="hljs-number">0x1p-2</span>
+float_hex_p_no_post := <span class="hljs-number">0x2.p10</span>
+float_hex_p_sign := <span class="hljs-number">0x1.Fp+0</span>
+float_hex_p_neg := <span class="hljs-number">0X.8p-0</span>
+float_hex_underscore := <span class="hljs-number">0X_1FFFP-16</span>
+
+complex_zero := <span class="hljs-number">0i</span>
+complex_leading_zero := <span class="hljs-number">0123i</span>
+complex_octal := <span class="hljs-number">0o123i</span>
+complex_hex := <span class="hljs-number">0xabci</span>
+complex_float_zero := <span class="hljs-number">0.i</span>
+complex_float_simple := <span class="hljs-number">2.71828i</span>
+complex_float_e := <span class="hljs-number">1.e+0i</span>
+complex_float_e_neg := <span class="hljs-number">6.67428e-11i</span>
+complex_float_e_no_decimal := <span class="hljs-number">1E6i</span>
+complex_float_no_pre := <span class="hljs-number">.25i</span>
+complex_float_e_no_pre := <span class="hljs-number">.12345E+5i</span>
+complex_float_hex_p := <span class="hljs-number">0x1p-2i</span>
+
+-- Non-numbers
+
+identifier := _42
+trailing_underscore := <span class="hljs-number">42</span>_
+multiple_underscore := <span class="hljs-number">4</span>__2
+underscore_in_hex_prefix := <span class="hljs-number">0</span>_xBadFace
+
+float_minus_int := <span class="hljs-number">0x15e</span><span class="hljs-number">-2</span>
+no_mantissa_digits := <span class="hljs-number">0</span>x.p1
+p_exponent_on_decimal := <span class="hljs-number">1</span>p<span class="hljs-number">-2</span>
+missing_p_exponent := <span class="hljs-number">0x1</span><span class="hljs-number">.5e-2</span>
+underscore_before_decimal := <span class="hljs-number">1</span>_<span class="hljs-number">.5</span>
+underscore_after_decimal := <span class="hljs-number">1.</span>_5
+underscore_before_e := <span class="hljs-number">1.5</span>_e1
+underscore_after_e := <span class="hljs-number">1.5</span>e_1
+trailing_underscore_in_exponent := <span class="hljs-number">1.5e1</span>_

--- a/test/markup/go/numbers.txt
+++ b/test/markup/go/numbers.txt
@@ -1,3 +1,64 @@
+-- Numbers
+
 float_var := 1.0e10
 complex_var := 1.2e5+2.3i
 hex_int := 0xcf3e4028ac084aea
+
+int_simple := 42
+int_underscore := 4_2
+octal := 0600
+octal_underscore := 0_600
+octal_o := 0o600
+octal_upper_o := 0O600
+hex_mixed_case := 0xBadFace
+hex_underscore := 0xBad_Face
+hex_many_underscore := 0x_67_7a_2f_cc_40_c6
+long_int := 170141183460469231731687303715884105727
+long_int_underscore := 170_141183_460469_231731_687303_715884_105727
+
+float_no_post := 0.
+float_simple := 72.40
+float_leading_zero := 072.40
+float_e := 1.e+0
+float_e_neg := 6.67428e-11
+float_e_no_decimal := 1E6
+float_no_pre := .25
+float_e_no_pre := .12345E+5
+float_underscore := 1_5.
+float_underscore_in_e := 0.15e+0_2
+
+float_hex_p := 0x1p-2
+float_hex_p_no_post := 0x2.p10
+float_hex_p_sign := 0x1.Fp+0
+float_hex_p_neg := 0X.8p-0
+float_hex_underscore := 0X_1FFFP-16
+
+complex_zero := 0i
+complex_leading_zero := 0123i
+complex_octal := 0o123i
+complex_hex := 0xabci
+complex_float_zero := 0.i
+complex_float_simple := 2.71828i
+complex_float_e := 1.e+0i
+complex_float_e_neg := 6.67428e-11i
+complex_float_e_no_decimal := 1E6i
+complex_float_no_pre := .25i
+complex_float_e_no_pre := .12345E+5i
+complex_float_hex_p := 0x1p-2i
+
+-- Non-numbers
+
+identifier := _42
+trailing_underscore := 42_
+multiple_underscore := 4__2
+underscore_in_hex_prefix := 0_xBadFace
+
+float_minus_int := 0x15e-2
+no_mantissa_digits := 0x.p1
+p_exponent_on_decimal := 1p-2
+missing_p_exponent := 0x1.5e-2
+underscore_before_decimal := 1_.5
+underscore_after_decimal := 1._5
+underscore_before_e := 1.5_e1
+underscore_after_e := 1.5e_1
+trailing_underscore_in_exponent := 1.5e1_


### PR DESCRIPTION
Go number literals are considerably more complex than previously expressed. Most notable, `_` is allowed in several contexts to allow digit grouping, hex numbers can take `p` exponents, and a number with a radix (`.`) requires digits before or after but not both. The additional test cases were pulled from https://go.dev/ref/spec.

### Changes
Add test cases from https://go.dev/ref/spec, and make the tests pass.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
