### PR TITLE
enh(css) add `justify-items` and `justify-self` attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Core Grammars:
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
 - enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]
 - enh(bash) add keyword `sudo` [Alvin Joy][]
+- enh(css) add `justify-items` and `justify-self` attributes [Vasily Polovnyov][]
 
 New Grammars:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@ Themes:
 [Alvin Joy]: https://github.com/alvinsjoy
 [Lisa Ugray]: https://github.com/lugray
 [TaraLei]: https://github.com/TaraLei
+[Vasily Polovnyov]: https://github.com/vast
 
 
 ## Version 11.9.0

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -483,6 +483,8 @@ export const ATTRIBUTES = [
   'isolation',
   'kerning',
   'justify-content',
+  'justify-items',
+  'justify-self',
   'left',
   'letter-spacing',
   'lighting-color',


### PR DESCRIPTION
### Changes
Added `justify-items` and `justify-self` to list of known css attributes.

See them on MDN:
* https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self
* https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
