### PR TITLE
fix(haxe) fix new keyword false positives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 - Drops support for Node 16.x, which is no longer supported by Node.js.
 
 Core Grammars:
-
 - enh(perl) fix false-positive variable match at end of string [Josh Goebel][]
 - fix(cpp) not all kinds of number literals are highlighted correctly [Lê Duy Quang][]
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
@@ -28,6 +27,7 @@ Core Grammars:
 - fix(types) fix interface LanguageDetail > keywords [Patrick Chiu]
 - enh(java) add `goto` to be recognized as a keyword in Java [Alvin Joy][]
 - enh(bash) add keyword `sudo` [Alvin Joy][]
+- fix(haxe) captures `new` keyword without capturing it within variables/class names [Cameron Taylor][]
 
 New Grammars:
 
@@ -136,6 +136,7 @@ Developer Tool:
 [Brian Ward]: https://github.com/WardBrian
 [Md Saad Akhtar]: https://github.com/akhtarmdsaad
 [Guillaume Laforge]: https://github.com/glaforge
+[Cameron Taylor]: https://github.com/ninjamuffin99
 
 
 ## Version 11.8.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 - Drops support for Node 16.x, which is no longer supported by Node.js.
 
 Core Grammars:
+
 - enh(perl) fix false-positive variable match at end of string [Josh Goebel][]
 - fix(cpp) not all kinds of number literals are highlighted correctly [Lê Duy Quang][]
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -89,7 +89,7 @@ export default function(hljs) {
       },
       {
         className: 'type', // instantiation
-        begin: /\bnew\b/,
+        beginKeywords: 'new',
         end: /\W/,
         excludeBegin: true,
         excludeEnd: true

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -89,7 +89,7 @@ export default function(hljs) {
       },
       {
         className: 'type', // instantiation
-        begin: /new */,
+        begin: /\bnew\b/,
         end: /\W/,
         excludeBegin: true,
         excludeEnd: true

--- a/test/markup/haxe/default.expect.txt
+++ b/test/markup/haxe/default.expect.txt
@@ -84,7 +84,7 @@
 
 <span class="hljs-title class_"><span class="hljs-keyword">class</span> <span class="hljs-title">Main</span> <span class="hljs-keyword"><span class="hljs-keyword">extends</span> <span class="hljs-type">BaseClass</span></span> <span class="hljs-keyword"><span class="hljs-keyword">implements</span> <span class="hljs-type">SomeFunctionality</span></span> </span>{
     <span class="hljs-keyword">var</span> callback:<span class="hljs-type">Void-&gt;Void </span>= <span class="hljs-literal">null</span>;
-    <span class="hljs-keyword">var</span> myArray:<span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt; = <span class="hljs-keyword">new</span> <span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt;();
+    <span class="hljs-keyword">var</span> myArray:<span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt; = <span class="hljs-keyword">new</span><span class="hljs-type"></span> <span class="hljs-keyword">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt;();
     <span class="hljs-keyword">var</span> arr = [<span class="hljs-number">4</span>,<span class="hljs-number">8</span>,<span class="hljs-number">0</span>,<span class="hljs-number">3</span>,<span class="hljs-number">9</span>,<span class="hljs-number">1</span>,<span class="hljs-number">5</span>,<span class="hljs-number">2</span>,<span class="hljs-number">6</span>,<span class="hljs-number">7</span>];
 
     <span class="hljs-keyword">public</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">new</span></span>(x) {
@@ -120,8 +120,8 @@
             done = <span class="hljs-literal">true</span>;
         }
 
-        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">42</span>);
-        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
+        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span><span class="hljs-type"></span> MyAbstract(<span class="hljs-number">42</span>);
+        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span><span class="hljs-type"></span> MyAbstract(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
 
         <span class="hljs-keyword">try</span> {
             <span class="hljs-keyword">throw</span> <span class="hljs-string">&quot;error&quot;</span>;
@@ -130,7 +130,7 @@
             <span class="hljs-built_in">trace</span>(err);
         }
         
-        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span> <span class="hljs-type">haxe</span>.ds.IntMap&lt;<span class="hljs-keyword">String</span>&gt;();
+        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span><span class="hljs-type"></span> haxe.ds.IntMap&lt;<span class="hljs-keyword">String</span>&gt;();
         <span class="hljs-keyword">var</span> f = map.<span class="hljs-keyword">set</span>.bind(<span class="hljs-literal">_</span>, <span class="hljs-string">&quot;12&quot;</span>);
     }
 
@@ -175,4 +175,10 @@
         <span class="hljs-keyword">if</span>( lo &lt; j ) quicksort( lo, j );
         <span class="hljs-keyword">if</span>( i &lt; hi ) quicksort( i, hi );
     }
+
+    <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">generateNewArray</span></span>(newArray:<span class="hljs-type">Array</span>):<span class="hljs-type">Void </span>{
+        <span class="hljs-keyword">var</span> i = newArray;
+        <span class="hljs-keyword">var</span> array = <span class="hljs-keyword">new</span><span class="hljs-type"></span> <span class="hljs-keyword">Array</span>();
+    }
+
 }

--- a/test/markup/haxe/default.txt
+++ b/test/markup/haxe/default.txt
@@ -175,4 +175,10 @@ class Main extends BaseClass implements SomeFunctionality {
         if( lo < j ) quicksort( lo, j );
         if( i < hi ) quicksort( i, hi );
     }
+
+    function generateNewArray(newArray:Array):Void {
+        var i = newArray;
+        var array = new Array();
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the regex in the haxe.js highlighting to only highlight `new` as a keyword if it's not used within a variable/class name, using `beginKeywords: 'new'` instead of `new *`
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #3992 
### Changes
<!--- Describe your changes -->
Chnages the regex to use `beginKeywords: 'new'` instead of *, so that it can capture `new` as a keyword, but not when it's used within a variable name
### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
