### PR TITLE
Added missing query keyword 'USE' to sql.js

### DIFF
--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -445,6 +445,7 @@ export default function(hljs) {
     "upper",
     "user",
     "using",
+    "use",
     "value",
     "values",
     "value_of",


### PR DESCRIPTION
The "USE" keyword should also be highlighted, considering it is used in a query to select a database. For example, "USE DATABASE_NAME;".

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
