### PR TITLE
Support namespaced tagged template strings in JavaScript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
+- enh(js/ts) support namespaced tagged template strings [Aral Balkan][]
 - enh(perl) fix false-positive variable match at end of string [Josh Goebel][]
 - fix(cpp) not all kinds of number literals are highlighted correctly [Lê Duy Quang][]
 - fix(css) fix overly greedy pseudo class matching [Bradley Mackey][]
@@ -53,6 +54,7 @@ Themes:
 
 - Added `1c-light` theme a like in the IDE 1C:Enterprise 8 (for 1c) [Vitaly Barilko][]
 
+[Aral Balkan]: https://github.com/aral
 [Lê Duy Quang]: https://github.com/leduyquang753
 [Mohamed Ali]: https://github.com/MohamedAli00949
 [JaeBaek Lee]: https://github.com/ThinkingVincent

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -133,7 +133,7 @@ export default function(hljs) {
     contains: [] // defined later
   };
   const HTML_TEMPLATE = {
-    begin: 'html`',
+    begin: '\.?html`',
     end: '',
     starts: {
       end: '`',
@@ -146,7 +146,7 @@ export default function(hljs) {
     }
   };
   const CSS_TEMPLATE = {
-    begin: 'css`',
+    begin: '\.?css`',
     end: '',
     starts: {
       end: '`',
@@ -159,7 +159,7 @@ export default function(hljs) {
     }
   };
   const GRAPHQL_TEMPLATE = {
-    begin: 'gql`',
+    begin: '\.?gql`',
     end: '',
     starts: {
       end: '`',

--- a/test/markup/javascript/inline-languages.expect.txt
+++ b/test/markup/javascript/inline-languages.expect.txt
@@ -4,6 +4,8 @@ foo = <span class="hljs-literal">false</span>;
 
 html`<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;foo&quot;</span>&gt;</span>Hello world<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>`</span>;
 
+kitten.html`<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;foo&quot;</span>&gt;</span>Hello world<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>`</span>;
+
 html`<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;foo&quot;</span>&gt;</span>Hello times </span><span class="hljs-subst">${<span class="hljs-number">10</span>}</span><span class="language-xml"> <span class="hljs-tag">&lt;<span class="hljs-name">span</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;bar&quot;</span>&gt;</span>world<span class="hljs-tag">&lt;/<span class="hljs-name">span</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>`</span>;
 
 html`<span class="language-xml">
@@ -20,7 +22,15 @@ css`<span class="language-css">
   }
 `</span>;
 
+kitten.css`<span class="language-css">
+  <span class="hljs-selector-tag">body</span> {
+    <span class="hljs-attribute">color</span>: red;
+  }
+`</span>;
+
 gql`<span class="language-graphql"><span class="hljs-keyword">query</span> <span class="hljs-punctuation">{</span> viewer <span class="hljs-punctuation">{</span> id <span class="hljs-punctuation">}</span> <span class="hljs-punctuation">}</span>`</span>;
+
+kitten.gql`<span class="language-graphql"><span class="hljs-keyword">query</span> <span class="hljs-punctuation">{</span> viewer <span class="hljs-punctuation">{</span> id <span class="hljs-punctuation">}</span> <span class="hljs-punctuation">}</span>`</span>;
 
 gql`<span class="language-graphql">
   <span class="hljs-keyword">type</span> Project <span class="hljs-punctuation">{</span>

--- a/test/markup/javascript/inline-languages.txt
+++ b/test/markup/javascript/inline-languages.txt
@@ -4,6 +4,8 @@ foo = false;
 
 html`<div id="foo">Hello world</div>`;
 
+kitten.html`<div id="foo">Hello world</div>`;
+
 html`<div id="foo">Hello times ${10} <span id="bar">world</span></div>`;
 
 html`
@@ -20,7 +22,15 @@ css`
   }
 `;
 
+kitten.css`
+  body {
+    color: red;
+  }
+`;
+
 gql`query { viewer { id } }`;
+
+kitten.gql`query { viewer { id } }`;
 
 gql`
   type Project {


### PR DESCRIPTION
Resolves #4001

### Changes

Instead of just matching `html` and `css` (and, for completeness and consistency, `gql`), `\.?html`, `\.?css`, and `\.?gql` are matched, which allows for namespaced tagged template strings (e.g., [Kitten](https://codeberg.org/kitten/app)’s `kitten.html`) to be recognised and highlighted.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
