### PR TITLE
Python self

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Core Grammars:
 - fix(csharp) add raw string highlighting for C# 11. [Tara][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
+- enh(python) adds a scope to the `self` variable [Lee Falin][]
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 - enh(delphi) add support for digit separators [Jonah Jeleniewski][]
 - enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -373,6 +373,7 @@ export default function(hljs) {
       NUMBER,
       {
         // very common convention
+        scope: 'variable.language',
         begin: /\bself\b/
       },
       {

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -374,7 +374,7 @@ export default function(hljs) {
       {
         // very common convention
         scope: 'variable.language',
-        begin: /\bself\b/
+        match: /\bself\b/
       },
       {
         // eat "if" prior to string so that it won't accidentally be

--- a/test/markup/python/class_self.expect.txt
+++ b/test/markup/python/class_self.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">SelfTest</span>:
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-variable language_">self</span>.text = <span class="hljs-literal">True</span>
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">method</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">pass</span>

--- a/test/markup/python/class_self.txt
+++ b/test/markup/python/class_self.txt
@@ -1,0 +1,6 @@
+class SelfTest:
+    def __init__(self):
+        self.text = True
+
+    def method(self):
+        pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change assigns a scope to the `self` variable in Python, similar to the PHP definition. This variable was already identified in the grammar parser (presumably for recognition), but no scope was assigned. 

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #4024 

### Changes
- Assigns a scope to the `self` variable in the python language definition.
- Adds a markup test for the above change. 

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
