### PR TITLE
Add jsonc alias to json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
+- enh(json) added jsonc as an alias [BackupMiles][]
 - enh(gml) updated to latest language version (GML v2024.2) [gnysek][]
 - enh(c) added more C23 keywords and preprcoessor directives [Eisenwave][]
 - enh(js/ts) support namespaced tagged template strings [Aral Balkan][]
@@ -86,6 +87,7 @@ Themes:
 [Arman Uguray]: https://github.com/armansito
 [Rúnar Bjarnason]: https://github.com/runarorama
 [Carl Räfting]: https://github.com/carlrafting
+[BackupMiles]: https://github.com/BackupMiles
 
 
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -111,7 +111,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Inform7                 | inform7, i7            |         |
 | IRPF90                  | irpf90                 |         |
 | Iptables                | iptables               | [highlightjs-iptables](https://github.com/highlightjs/highlightjs-iptables) |
-| JSON                    | json                   |         |
+| JSON                    | json, jsonc            |         |
 | Java                    | java, jsp              |         |
 | JavaScript              | javascript, js, jsx    |         |
 | Jolie                   | jolie, iol, ol         | [highlightjs-jolie](https://github.com/xiroV/highlightjs-jolie) |

--- a/src/languages/json.js
+++ b/src/languages/json.js
@@ -34,6 +34,7 @@ export default function(hljs) {
 
   return {
     name: 'JSON',
+    aliases: ['jsonc'],
     keywords:{
       literal: LITERALS,
     },


### PR DESCRIPTION
Added jsonc as an alias to the json language.

Resolves #4018 

### Changes
- added jsonc alias
- updated changelog and supported languages

The object returned from the exported function inside json.js now provides 'jsonc' as an alias.

### Checklist
- [x] No test was added, since the json language already supports comments
- [x] Updated the changelog at `CHANGES.md`
