### PR TITLE
Fortran: fixed support of "dotted" keywords/literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Core Grammars:
 - enh(markdown) add entity support [David Schach][] [TaraLei][]
 - enh(css) add `justify-items` and `justify-self` attributes [Vasily Polovnyov][]
 - enh(css) add `accent-color`, `appearance`, `color-scheme`, `rotate`, `scale` and `translate` attributes [Carl Räfting][]
+- fix(fortran) fixes parsing of keywords delimited by dots [Julien Bloino][]
 
 New Grammars:
 
@@ -88,6 +89,7 @@ Themes:
 [Rúnar Bjarnason]: https://github.com/runarorama
 [Carl Räfting]: https://github.com/carlrafting
 [BackupMiles]: https://github.com/BackupMiles
+[Julien Bloino]: https://github.com/jbloino
 
 
 

--- a/src/languages/fortran.js
+++ b/src/languages/fortran.js
@@ -550,6 +550,7 @@ export default function(hljs) {
       'f95'
     ],
     keywords: {
+      $pattern: /\b[a-z][a-z0-9_]+\b|\.[a-z][a-z0-9_]+\./,
       keyword: KEYWORDS,
       literal: LITERALS,
       built_in: BUILT_INS

--- a/test/markup/fortran/dot_keywords.expect.txt
+++ b/test/markup/fortran/dot_keywords.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-keyword">logical</span> :: A=<span class="hljs-literal">.true.</span>, B=<span class="hljs-literal">.false.</span>, C=<span class="hljs-literal">.true.</span>, D=<span class="hljs-literal">.false.</span>
+<span class="hljs-keyword">logical</span> :: E
+
+E = <span class="hljs-number">3</span> &lt; <span class="hljs-number">4</span> <span class="hljs-keyword">.and.</span> B
+E = <span class="hljs-string">&#x27;ij&#x27;</span> &lt;= <span class="hljs-string">&#x27;ijk&#x27;</span> <span class="hljs-keyword">.and.</span> C
+E = B <span class="hljs-keyword">.or.</span> A <span class="hljs-keyword">.and.</span> D
+E = (B <span class="hljs-keyword">.or.</span> A) <span class="hljs-keyword">.and.</span> C
+E = A <span class="hljs-keyword">.and.</span> <span class="hljs-keyword">.not.</span>B

--- a/test/markup/fortran/dot_keywords.txt
+++ b/test/markup/fortran/dot_keywords.txt
@@ -1,0 +1,8 @@
+logical :: A=.true., B=.false., C=.true., D=.false.
+logical :: E
+
+E = 3 < 4 .and. B
+E = 'ij' <= 'ijk' .and. C
+E = B .or. A .and. D
+E = (B .or. A) .and. C
+E = A .and. .not.B


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This patch fixes the support of Fortran keywords and literals delimited by dots.
The matching pattern implements the directives from the standard on the accepted format of keywords in Fortran.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Resolved #3968 

### Changes
<!--- Describe your changes -->

- Added `$pattern` variable in fortran.js
- Added new markup test, `dot_keywords` testing dots-delimited keywords in Fortran.
- Updated changelog with short description of the fix.

### Checklist
- [x] Added markup test
- [x] Updated the changelog at `CHANGES.md`
