### PR TITLE
Add Gleam to SUPPORTED_LANGUAGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@ New Grammars:
 - added 3rd party WGSL grammar to SUPPORTED_LANGUAGES [Arman Uguray][]
 - added 3rd party Unison grammar to SUPPORTED_LANGUAGES [Rúnar Bjarnason][]
 - added 3rd party Phix grammar to SUPPORTED_LANGUAGES [PeteLomax][]
+- added 3rd party Gleam grammar to SUPPORTED_LANGUAGES [maxdeviant][]
 
 Developer Tool:
 
@@ -92,6 +93,7 @@ Themes:
 [Carl Räfting]: https://github.com/carlrafting
 [BackupMiles]: https://github.com/BackupMiles
 [Julien Bloino]: https://github.com/jbloino
+[maxdeviant]: https://github.com/maxdeviant
 
 
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -91,6 +91,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | GDScript                | godot, gdscript        | [highlightjs-gdscript](https://github.com/highlightjs/highlightjs-gdscript) |
 | Gherkin                 | gherkin                |         |
 | Glimmer and EmberJS     | hbs, glimmer, html.hbs, html.handlebars, htmlbars | [highlightjs-glimmer](https://github.com/NullVoxPopuli/highlightjs-glimmer) |
+| Gleam                   | gleam                  | [gleam-highlight.js](https://github.com/gleam-lang/gleam-highlight.js) |
 | GN for Ninja            | gn, gni                | [highlightjs-GN](https://github.com/highlightjs/highlightjs-GN) |
 | Go                      | go, golang             |         |
 | Grammatical Framework   | gf                     | [highlightjs-gf](https://github.com/johnjcamilleri/highlightjs-gf) |


### PR DESCRIPTION
This PR adds [Gleam](https://gleam.run/) to the list of supported languages.

The grammar repo is available at [`gleam-lang/gleam-highlight.js`](https://github.com/gleam-lang/gleam-highlight.js).

### Changes

Added an entry for Gleam in `SUPPORTED_LANGUAGES.md`.

### Checklist
- [x] Added markup tests, or they don't apply here because... this is a docs-only change
- [x] Updated the changelog at `CHANGES.md`
