### PR TITLE
enh(c): Added typeof and typeof_qual to the list of keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
+- enc(c) added more C23 keywords [Melkor-1][]
 - enh(json) added jsonc as an alias [BackupMiles][]
 - enh(gml) updated to latest language version (GML v2024.2) [gnysek][]
 - enh(c) added more C23 keywords and preprcoessor directives [Eisenwave][]
@@ -63,6 +64,7 @@ Themes:
 
 - Added `1c-light` theme a like in the IDE 1C:Enterprise 8 (for 1c) [Vitaly Barilko][]
 
+[Melkor-1]: https://github.com/Melkor-1
 [PeteLomax]: https://github.com/petelomax
 [gnysek]: https://github.com/gnysek
 [Eisenwave]: https://github.com/Eisenwave 

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -114,6 +114,8 @@ export default function(hljs) {
     "restrict",
     "return",
     "sizeof",
+    "typeof",
+    "typeof_unqual",
     "struct",
     "switch",
     "typedef",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
Added C23's new `typeof` and `typeof_unqual` to `C_KEYWORDS` list.

### Checklist
- [x] Markup tests don't apply here because only two new `keywords` have been added.
- [x] Updated the changelog at `CHANGES.md`.
