### PR TITLE
enh(typescript) add support for satisfies keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
+- enh(typescript) add support for `satisfies` operator [Kisaragi Hiu][]
 - enc(c) added more C23 keywords [Melkor-1][]
 - enh(json) added jsonc as an alias [BackupMiles][]
 - enh(gml) updated to latest language version (GML v2024.2) [gnysek][]
@@ -64,6 +65,7 @@ Themes:
 
 - Added `1c-light` theme a like in the IDE 1C:Enterprise 8 (for 1c) [Vitaly Barilko][]
 
+[Kisaragi Hiu]: https://github.com/kisaragi-hiu
 [Melkor-1]: https://github.com/Melkor-1
 [PeteLomax]: https://github.com/petelomax
 [gnysek]: https://github.com/gnysek

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -65,7 +65,8 @@ export default function(hljs) {
     "abstract",
     "readonly",
     "enum",
-    "override"
+    "override",
+    "satisfies"
   ];
 
   /*

--- a/test/markup/typescript/satisfies-and-as.expect.txt
+++ b/test/markup/typescript/satisfies-and-as.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-keyword">const</span> test3 = <span class="hljs-string">&#x27;test3&#x27;</span> <span class="hljs-keyword">as</span> <span class="hljs-title class_">ValidName</span>
+<span class="hljs-keyword">const</span> test4 = <span class="hljs-string">&#x27;test4&#x27;</span> <span class="hljs-keyword">satisfies</span> <span class="hljs-title class_">ValidName</span>

--- a/test/markup/typescript/satisfies-and-as.txt
+++ b/test/markup/typescript/satisfies-and-as.txt
@@ -1,0 +1,2 @@
+const test3 = 'test3' as ValidName
+const test4 = 'test4' satisfies ValidName


### PR DESCRIPTION
### Changes

TypeScript added the `satisfies` operator [in TypeScript 4.9, in November 2022](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#satisfies). This PR adds support for it.

| before | after |
|-|-|
| ![A TypeScript sample with the satisfies and the as operators. "as" is highlighted while "satisfies" is not.](https://github.com/highlightjs/highlight.js/assets/11722318/4e6e4ead-90bb-470b-907f-e7755b4d5d7c) | ![The same TypeScript sample with the satisfies and the as operators. Both "as" and "satisfies" are highlighted.](https://github.com/highlightjs/highlight.js/assets/11722318/455b9ec6-c664-4aa2-8cc3-26376e397fc5) |

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
