### PR TITLE
Add Mirth to SUPPORTED_LANGUAGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ New Grammars:
 - added 3rd party WGSL grammar to SUPPORTED_LANGUAGES [Arman Uguray][]
 - added 3rd party Unison grammar to SUPPORTED_LANGUAGES [Rúnar Bjarnason][]
 - added 3rd party Phix grammar to SUPPORTED_LANGUAGES [PeteLomax][]
+- added 3rd party Mirth grammar to SUPPORTED_LANGUAGES [Sierra][]
 
 Developer Tool:
 
@@ -98,6 +99,7 @@ Themes:
 [Carl Räfting]: https://github.com/carlrafting
 [BackupMiles]: https://github.com/BackupMiles
 [Julien Bloino]: https://github.com/jbloino
+[Sierra]: https://github.com/casuallyblue
 
 
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -141,7 +141,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Mercury                 | mercury                |         |
 | MIPS Assembler          | mips, mipsasm          |         |
 | Mint                    | mint                   | [highlightjs-mint](https://github.com/mint-lang/highlightjs-mint) |
-| Mirth                   | mirth                  | [highlightjs-mirth](https://github.com/casuallyblue/highlightjs-mirth) |
+| Mirth                   | mirth                  | [highlightjs-mirth](https://github.com/highlightjs/highlightjs-mirth) |
 | mIRC Scripting Language | mirc, mrc              | [highlightjs-mirc](https://github.com/highlightjs/highlightjs-mirc) |
 | Mizar                   | mizar                  |         |
 | MKB                     | mkb                    | [highlightjs-mkb](https://github.com/Dereavy/highlightjs-mkb) |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -141,6 +141,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Mercury                 | mercury                |         |
 | MIPS Assembler          | mips, mipsasm          |         |
 | Mint                    | mint                   | [highlightjs-mint](https://github.com/mint-lang/highlightjs-mint) |
+| Mirth                   | mirth                  | [highlightjs-mirth](https://github.com/casuallyblue/highlightjs-mirth) |
 | mIRC Scripting Language | mirc, mrc              | [highlightjs-mirc](https://github.com/highlightjs/highlightjs-mirc) |
 | Mizar                   | mizar                  |         |
 | MKB                     | mkb                    | [highlightjs-mkb](https://github.com/Dereavy/highlightjs-mkb) |


### PR DESCRIPTION
This PR adds [Mirth](https://github.com/mirth-lang/mirth) to the list of supported languages.

The grammar repo is available at [casuallyblue/highlightjs-mirth](https://github.com/casuallyblue/highlightjs-mirth).

## Changes
* [X] Added an entry for Mirth in SUPPORTED_LANGUAGES.md.
* [X] Updated the changelog at CHANGES.md