### PR TITLE
Erlang/OTP 27 enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ CONTRIBUTORS
 [aneesh98]: https://github.com/aneesh98
 [BaliBalo]: https://github.com/BaliBalo
 [William Wilkinson]: https://github.com/wilkinson4
+[nixxquality]: https://github.com/nixxquality
 
 
 ## Version 11.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Core Grammars:
 
 - fix(makefile) - allow strings inside `$()` expressions [aneesh98][]
 - enh(css) add all properties listed on MDN (96 additions including `anchor-name`, `aspect-ratio`, `backdrop-filter`, `container`, `margin-trim`, `place-content`, `scroll-timeline`, ...) [BaliBalo][]
+- enh(erlang) OTP 27 triple-quoted strings [nixxquality][]
+- enh(erlang) OTP 27 doc attribute [nixxquality][]
+- enh(erlang) OTP 27 Sigil type [nixxquality][]
+- enh(erlang) OTP25/27 maybe statement [nixxquality][]
 
 New Grammars:
 

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -80,6 +80,11 @@ export default function(hljs) {
     scope: 'string',
     match: /\$(\\([^0-9]|[0-9]{1,3}|)|.)/,
   };
+  const TRIPLE_QUOTE = hljs.END_SAME_AS_BEGIN({
+    scope: 'string',
+    begin: /("{3,})/,
+    end: /("{3,})/,
+  });
 
   const BLOCK_STATEMENTS = {
     beginKeywords: 'fun receive if try case',
@@ -92,6 +97,7 @@ export default function(hljs) {
     hljs.inherit(hljs.APOS_STRING_MODE, { className: '' }),
     BLOCK_STATEMENTS,
     FUNCTION_CALL,
+    TRIPLE_QUOTE,
     hljs.QUOTE_STRING_MODE,
     NUMBER,
     TUPLE,
@@ -106,6 +112,7 @@ export default function(hljs) {
     NAMED_FUN,
     BLOCK_STATEMENTS,
     FUNCTION_CALL,
+    TRIPLE_QUOTE,
     hljs.QUOTE_STRING_MODE,
     NUMBER,
     TUPLE,
@@ -185,6 +192,7 @@ export default function(hljs) {
         contains: [ PARAMS ]
       },
       NUMBER,
+      TRIPLE_QUOTE,
       hljs.QUOTE_STRING_MODE,
       RECORD_ACCESS,
       VAR1,

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -89,6 +89,7 @@ export default function(hljs) {
     scope: 'string',
     contains: [ hljs.BACKSLASH_ESCAPE ],
     variants: [
+      {match: /~\w?"""("*)(?!")[\s\S]*?"""\1/},
       {begin: /~\w?\(/, end: /\)/},
       {begin: /~\w?\[/, end: /\]/},
       {begin: /~\w?{/, end: /}/},
@@ -99,7 +100,6 @@ export default function(hljs) {
       {begin: /~\w?"/, end: /"/},
       {begin: /~\w?`/, end: /`/},
       {begin: /~\w?#/, end: /#/},
-      {match: /~\w?"""("*)(?!")[\s\S]*?"""\1/},
     ],
   };
 

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -82,32 +82,25 @@ export default function(hljs) {
   };
   const TRIPLE_QUOTE = {
     scope: 'string',
-    match: /"""("*)(?!")(.|\n)*?"""\1/,
+    match: /"""("*)(?!")[\s\S]*?"""\1/,
   };
 
-  // the closing character depends on the kind of opening character.
-  const SIGIL_START_END_PAIRS = {
-    '(': ')',
-    '[': ']',
-    '{': '}',
-    '<': '>',
-  };
   const SIGIL = {
     scope: 'string',
-    begin: /~\w?("{3,}|[\(\[\{<\/|'"`#])/,
-    end: /("{3,}|[\)\]\}>\/|'"`#])/,
-    'on:begin': (m, resp) => { resp.data._beginMatch = m[1]; },
-    'on:end': (m, resp) => {
-      let closing_sequence = SIGIL_START_END_PAIRS[resp.data._beginMatch];
-      // for other start sequences, the end is the same as the start
-      if (closing_sequence === undefined) {
-        closing_sequence = resp.data._beginMatch;
-      }
-      if (m[1] !== closing_sequence) {
-        resp.ignoreMatch();
-      }
-    },
-    contains: [ hljs.BACKSLASH_ESCAPE ]
+    contains: [ hljs.BACKSLASH_ESCAPE ],
+    variants: [
+      {begin: /~\w?\(/, end: /\)/},
+      {begin: /~\w?\[/, end: /\]/},
+      {begin: /~\w?{/, end: /}/},
+      {begin: /~\w?</, end: />/},
+      {begin: /~\w?\//, end: /\//},
+      {begin: /~\w?\|/, end: /\|/},
+      {begin: /~\w?'/, end: /'/},
+      {begin: /~\w?"/, end: /"/},
+      {begin: /~\w?`/, end: /`/},
+      {begin: /~\w?#/, end: /#/},
+      {match: /~\w?"""("*)(?!")[\s\S]*?"""\1/},
+    ],
   };
 
   const BLOCK_STATEMENTS = {

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -80,11 +80,10 @@ export default function(hljs) {
     scope: 'string',
     match: /\$(\\([^0-9]|[0-9]{1,3}|)|.)/,
   };
-  const TRIPLE_QUOTE = hljs.END_SAME_AS_BEGIN({
+  const TRIPLE_QUOTE = {
     scope: 'string',
-    begin: /("{3,})/,
-    end: /("{3,})/,
-  });
+    match: /"""("*)(?!")(.|\n)*?"""\1/,
+  };
 
   // the closing character depends on the kind of opening character.
   const SIGIL_START_END_PAIRS = {

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -13,7 +13,7 @@ export default function(hljs) {
   const ERLANG_RESERVED = {
     keyword:
       'after and andalso|10 band begin bnot bor bsl bzr bxor case catch cond div end fun if '
-      + 'let not of orelse|10 query receive rem try when xor',
+      + 'let not of orelse|10 query receive rem try when xor maybe else',
     literal:
       'false true'
   };
@@ -112,7 +112,7 @@ export default function(hljs) {
   };
 
   const BLOCK_STATEMENTS = {
-    beginKeywords: 'fun receive if try case',
+    beginKeywords: 'fun receive if try case maybe',
     end: 'end',
     keywords: ERLANG_RESERVED
   };

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -135,6 +135,7 @@ export default function(hljs) {
     "-author",
     "-copyright",
     "-doc",
+    "-moduledoc",
     "-vsn",
     "-import",
     "-include",
@@ -146,7 +147,9 @@ export default function(hljs) {
     "-file",
     "-behaviour",
     "-behavior",
-    "-spec"
+    "-spec",
+    "-on_load",
+    "-nifs",
   ];
 
   const PARAMS = {
@@ -189,7 +192,11 @@ export default function(hljs) {
           $pattern: '-' + hljs.IDENT_RE,
           keyword: DIRECTIVES.map(x => `${x}|1.5`).join(" ")
         },
-        contains: [ PARAMS ]
+        contains: [
+          PARAMS,
+          TRIPLE_QUOTE,
+          hljs.QUOTE_STRING_MODE
+        ]
       },
       NUMBER,
       TRIPLE_QUOTE,

--- a/test/markup/erlang/doc_attribute.expect.txt
+++ b/test/markup/erlang/doc_attribute.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-keyword">-module</span><span class="hljs-params">(arith)</span>.
+<span class="hljs-keyword">-moduledoc</span> <span class="hljs-string">&quot;&quot;&quot;
+A module for basic arithmetic.
+&quot;&quot;&quot;</span>.
+
+<span class="hljs-keyword">-export</span><span class="hljs-params">([add/<span class="hljs-number">2</span>])</span>.
+
+<span class="hljs-keyword">-doc</span> <span class="hljs-string">&quot;Adds two numbers.&quot;</span>.
+<span class="hljs-function"><span class="hljs-title">add</span><span class="hljs-params">(One, Two)</span> -&gt;</span> One + Two.

--- a/test/markup/erlang/doc_attribute.txt
+++ b/test/markup/erlang/doc_attribute.txt
@@ -1,0 +1,9 @@
+-module(arith).
+-moduledoc """
+A module for basic arithmetic.
+""".
+
+-export([add/2]).
+
+-doc "Adds two numbers.".
+add(One, Two) -> One + Two.

--- a/test/markup/erlang/maybe.expect.txt
+++ b/test/markup/erlang/maybe.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-keyword">maybe</span>
+    {ok, A} ?= a(),
+    <span class="hljs-literal">true</span> = A &gt;= <span class="hljs-number">0</span>,
+    {ok, B} ?= b(),
+    A + B
+<span class="hljs-keyword">else</span>
+    error -&gt; error;
+    wrong -&gt; error
+<span class="hljs-keyword">end</span>

--- a/test/markup/erlang/maybe.txt
+++ b/test/markup/erlang/maybe.txt
@@ -1,0 +1,9 @@
+maybe
+    {ok, A} ?= a(),
+    true = A >= 0,
+    {ok, B} ?= b(),
+    A + B
+else
+    error -> error;
+    wrong -> error
+end

--- a/test/markup/erlang/sigil.expect.txt
+++ b/test/markup/erlang/sigil.expect.txt
@@ -1,0 +1,33 @@
+<span class="hljs-function"><span class="hljs-title">greek_quote</span><span class="hljs-params">()</span> -&gt;</span>
+    S = <span class="hljs-string">~B[&quot;Know thyself&quot; (Greek: Γνῶθι σαυτόν)]</span>,
+    io:format(<span class="hljs-string">&quot;~ts\n&quot;</span>, [S]).
+
+<span class="hljs-string">~&#x27;foo&#x27;</span>.
+
+&lt;&lt;<span class="hljs-string">&quot;\&quot;\\µA\&quot;&quot;</span>/utf8&gt;&gt; = &lt;&lt;<span class="hljs-string">$&quot;</span>,<span class="hljs-string">$\\</span>,<span class="hljs-number">194</span>,<span class="hljs-number">181</span>,<span class="hljs-string">$A</span>,<span class="hljs-string">$&quot;</span>&gt;&gt; =
+    <span class="hljs-string">~b&quot;&quot;&quot;
+        &quot;\\µA&quot;
+        &quot;&quot;&quot;</span> = <span class="hljs-string">~b&#x27;&quot;\\µA&quot;&#x27;</span> =
+    <span class="hljs-string">~B&quot;&quot;&quot;
+        &quot;\µA&quot;
+        &quot;&quot;&quot;</span> = <span class="hljs-string">~B&lt;&quot;\µA&quot;&gt;</span> =
+    <span class="hljs-string">~&quot;&quot;&quot;
+        &quot;\µA&quot;
+        &quot;&quot;&quot;</span> = <span class="hljs-string">~&quot;\&quot;\\µA\&quot;&quot;</span> = <span class="hljs-string">~/&quot;\\µA&quot;/</span>
+
+<span class="hljs-function"><span class="hljs-title">quotes</span><span class="hljs-params">()</span> -&gt;</span>
+    S = <span class="hljs-string">~&quot;&quot;&quot;
+         &quot;I always have a quotation for everything -
+         it saves original thinking.&quot; - Dorothy L. Sayers
+
+         &quot;Real stupidity beats artificial intelligence every time.&quot;
+         - Terry Pratchett
+         &quot;&quot;&quot;</span>,
+    io:put_chars(S),
+    io:nl().
+
+<span class="hljs-string">~s{&quot;abc\txyz&quot;}</span>.
+<span class="hljs-string">~(paranthesis)</span>.
+<span class="hljs-string">~&lt;alligators&gt;</span>.
+<span class="hljs-string">~`backticks`</span>.
+<span class="hljs-string">~#hashpounds#</span>.

--- a/test/markup/erlang/sigil.expect.txt
+++ b/test/markup/erlang/sigil.expect.txt
@@ -27,7 +27,8 @@
     io:nl().
 
 <span class="hljs-string">~s{&quot;abc\txyz&quot;}</span>.
-<span class="hljs-string">~(paranthesis)</span>.
+<span class="hljs-string">~(parenthesis)</span>.
 <span class="hljs-string">~&lt;alligators&gt;</span>.
 <span class="hljs-string">~`backticks`</span>.
 <span class="hljs-string">~#hashpounds#</span>.
+<span class="hljs-string">~|pipes|</span>.

--- a/test/markup/erlang/sigil.txt
+++ b/test/markup/erlang/sigil.txt
@@ -27,7 +27,8 @@ quotes() ->
     io:nl().
 
 ~s{"abc\txyz"}.
-~(paranthesis).
+~(parenthesis).
 ~<alligators>.
 ~`backticks`.
 ~#hashpounds#.
+~|pipes|.

--- a/test/markup/erlang/sigil.txt
+++ b/test/markup/erlang/sigil.txt
@@ -1,0 +1,33 @@
+greek_quote() ->
+    S = ~B["Know thyself" (Greek: Γνῶθι σαυτόν)],
+    io:format("~ts\n", [S]).
+
+~'foo'.
+
+<<"\"\\µA\""/utf8>> = <<$",$\\,194,181,$A,$">> =
+    ~b"""
+        "\\µA"
+        """ = ~b'"\\µA"' =
+    ~B"""
+        "\µA"
+        """ = ~B<"\µA"> =
+    ~"""
+        "\µA"
+        """ = ~"\"\\µA\"" = ~/"\\µA"/
+
+quotes() ->
+    S = ~"""
+         "I always have a quotation for everything -
+         it saves original thinking." - Dorothy L. Sayers
+
+         "Real stupidity beats artificial intelligence every time."
+         - Terry Pratchett
+         """,
+    io:put_chars(S),
+    io:nl().
+
+~s{"abc\txyz"}.
+~(paranthesis).
+~<alligators>.
+~`backticks`.
+~#hashpounds#.

--- a/test/markup/erlang/triple_quote_string.expect.txt
+++ b/test/markup/erlang/triple_quote_string.expect.txt
@@ -1,0 +1,23 @@
+<span class="hljs-function"><span class="hljs-title">quotes</span><span class="hljs-params">()</span> -&gt;</span>
+    S = <span class="hljs-string">&quot;&quot;&quot;
+        &quot;I always have a quotation for everything -
+        it saves original thinking.&quot; - Dorothy L. Sayers
+
+        &quot;Real stupidity beats artificial intelligence every time.&quot;
+        - Terry Pratchett
+        &quot;&quot;&quot;</span>,
+    io:put_chars(S),
+    io:nl().
+
+<span class="hljs-function"><span class="hljs-title">effect_warning</span><span class="hljs-params">()</span> -&gt;</span>
+    <span class="hljs-string">&quot;&quot;&quot;
+    f() -&gt;
+        %% Test that the compiler warns for useless tuple building.
+        {a,b,c},
+        ok.
+    &quot;&quot;&quot;</span>.
+
+<span class="hljs-function"><span class="hljs-title">extra_delim</span><span class="hljs-params">()</span> -&gt;</span>
+    <span class="hljs-string">&quot;&quot;&quot;&quot;&quot;
+    &quot;&quot;&quot;&quot;
+    &quot;&quot;&quot;&quot;&quot;</span>.

--- a/test/markup/erlang/triple_quote_string.txt
+++ b/test/markup/erlang/triple_quote_string.txt
@@ -1,0 +1,23 @@
+quotes() ->
+    S = """
+        "I always have a quotation for everything -
+        it saves original thinking." - Dorothy L. Sayers
+
+        "Real stupidity beats artificial intelligence every time."
+        - Terry Pratchett
+        """,
+    io:put_chars(S),
+    io:nl().
+
+effect_warning() ->
+    """
+    f() ->
+        %% Test that the compiler warns for useless tuple building.
+        {a,b,c},
+        ok.
+    """.
+
+extra_delim() ->
+    """""
+    """"
+    """"".


### PR DESCRIPTION
### Changes
Erlang/OTP version 27 carried a bunch of syntax enhancements.
They are summarized over on their blog: https://www.erlang.org/blog/highlights-otp-27/
I've split up each feature into its own commit so far.

These are:
- Triple-quoted strings
- doc attribute
- Sigil type
- maybe statement

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`

Please let me know how it looks.