### PR TITLE
fix(monokai attr & number yaml syntax)

### DIFF
--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -12,6 +12,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-selector-tag,
 .hljs-literal,
 .hljs-strong,
+.hljs-number,
 .hljs-name {
   color: #f92672;
 }
@@ -21,6 +22,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 }
 
 .hljs-attribute,
+.hljs-attr,
 .hljs-symbol,
 .hljs-regexp,
 .hljs-link {


### PR DESCRIPTION
Monokai attr & number missing for yaml syntax

### Changes

```diff

index ef10ef8c..5b28d7bb 100644
--- a/src/styles/monokai.css
+++ b/src/styles/monokai.css
@@ -12,6 +12,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 .hljs-selector-tag,
 .hljs-literal,
 .hljs-strong,
+.hljs-number,
 .hljs-name {
   color: #f92672;
 }
@@ -21,6 +22,7 @@ Monokai style - ported by Luigi Maselli - http://grigio.org
 }
 


 .hljs-attribute,
+.hljs-attr,
 .hljs-symbol,
 .hljs-regexp,
 .hljs-link {
```

![DEMO](https://github.com/highlightjs/highlight.js/assets/23425839/c82aa7f2-d00f-46e1-b212-1632a316f7f5)
