### PR TITLE
fix: C# raw string literals

### DIFF
--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -166,7 +166,7 @@ export default function(hljs) {
   };
   const RAW_STRING = {
     className: 'string',
-    begin: /"""("*)(?!")(.|\n)*?"""\1/,
+    begin: /("{3,})(?!")(.|\n)*?\1/,
     relevance: 1
   };
   const VERBATIM_STRING = {

--- a/test/markup/csharp/string-raw.expect.txt
+++ b/test/markup/csharp/string-raw.expect.txt
@@ -15,3 +15,7 @@
                 more than others.
     Some have &quot;&quot;quoted text&quot;&quot; in them. \&quot;
     &quot;&quot;&quot;</span>;
+
+<span class="hljs-keyword">var</span> MultiLineQuotes = <span class="hljs-string">&quot;&quot;&quot;&quot;
+            &quot;&quot;&quot;Raw string literals&quot;&quot;&quot; can start and end with more than three double-quotes when needed.
+            &quot;&quot;&quot;&quot;</span>;

--- a/test/markup/csharp/string-raw.txt
+++ b/test/markup/csharp/string-raw.txt
@@ -15,3 +15,7 @@ string longMessage2 = """
                 more than others.
     Some have ""quoted text"" in them. \"
     """;
+
+var MultiLineQuotes = """"
+            """Raw string literals""" can start and end with more than three double-quotes when needed.
+            """";


### PR DESCRIPTION
Fix highlighting with nested double quotes. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string

I tweaked a bit the Regex and it seems to better handle the previous examples: https://regex101.com/r/16Vn7X/1