### PR TITLE
Make handling of valid JS/TS ids/Type aliases consistent with the rest of rules

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -265,7 +265,7 @@ export default function(hljs) {
   const PARAMS = {
     className: 'params',
     // convert this to negative lookbehind in v12
-    begin: /(\s*)\(/, // to match the parms with 
+    begin: /(\s*)\(/, // to match the parms with
     end: /\)/,
     excludeBegin: true,
     excludeEnd: true,
@@ -317,7 +317,7 @@ export default function(hljs) {
       // Hard coded exceptions
       /\bJSON/,
       // Float32Array, OutT
-      /\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,
+      /\b[A-Z][a-z]+([A-Z][a-z]*|\d|_|\$)*/,
       // CSSFactory, CSSFactoryT
       /\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,
       // FPs, FPsT

--- a/test/markup/typescript/casing.expect.txt
+++ b/test/markup/typescript/casing.expect.txt
@@ -1,0 +1,43 @@
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">Upper_Snake</span>&lt;<span class="hljs-title class_">Upper_Param</span>&gt; = <span class="hljs-title class_">Upper_Param</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">boolean</span> ? <span class="hljs-title class_">Upper_Param</span> : <span class="hljs-built_in">never</span>
+
+<span class="hljs-keyword">const</span> typeTestConstFn = &lt;<span class="hljs-title class_">Upper_Arg</span>, <span class="hljs-title class_">Upper_Result</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Upper_Snake</span>&lt;<span class="hljs-built_in">any</span>&gt;&gt;<span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">param</span>: <span class="hljs-title class_">Upper_Result</span>&lt;<span class="hljs-title class_">Upper_Arg</span>&gt;</span>) =&gt;</span> {}
+
+<span class="hljs-keyword">const</span> camelCase = <span class="hljs-number">42</span>
+
+<span class="hljs-keyword">const</span> lower_camel_case = <span class="hljs-number">42</span>
+
+<span class="hljs-keyword">const</span> snake_case = <span class="hljs-number">42</span>
+
+<span class="hljs-keyword">const</span> <span class="hljs-title class_">Upper_Snake_Case</span> = <span class="hljs-number">42</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Upper_Snake_Case_Class</span> = {}
+
+<span class="hljs-keyword">new</span> <span class="hljs-title class_">Upper_Snake_Case_Class</span>()
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Extreme__Upper_$_Snake_Case_Class$$$</span> = {}
+
+<span class="hljs-keyword">new</span> <span class="hljs-title class_">Extreme__Upper_$_Snake_Case_Class$$$</span>()
+
+<span class="hljs-keyword">const</span> mixedObject = {
+  <span class="hljs-attr">camelCase</span>: <span class="hljs-number">42</span>,
+  <span class="hljs-attr">SCREAMING_CASE</span>: <span class="hljs-number">42</span>,
+  <span class="hljs-string">&quot;string prop&quot;</span>: <span class="hljs-number">42</span>,
+  <span class="hljs-attr">snake_case</span>: <span class="hljs-number">42</span>,
+  <span class="hljs-title class_">Upper_Snake_Case</span>: <span class="hljs-number">42</span>,
+}
+
+<span class="hljs-keyword">function</span> camelCaseFn = <span class="hljs-function">() =&gt;</span> {}
+
+<span class="hljs-keyword">function</span> snake_case_fn = <span class="hljs-function">() =&gt;</span> {}
+
+<span class="hljs-keyword">function</span> <span class="hljs-title class_">Upper_Snake_Case_Fn</span> = () {}
+
+<span class="hljs-keyword">function</span> <span class="hljs-title class_">Extreme__Case_$_Fn$</span> = <span class="hljs-function">() =&gt;</span> {}
+
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">camelCaseConstFn</span> = (<span class="hljs-params"></span>) =&gt; {}
+
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">snake_case_const_fn</span> = (<span class="hljs-params"></span>) =&gt; {}
+
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">Upper_Snake_Case_Const_Fn</span> = (<span class="hljs-params"></span>) =&gt; {}
+
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">Extreme_Case_$_Const__Fn$</span> = (<span class="hljs-params"></span>) =&gt; {}

--- a/test/markup/typescript/casing.txt
+++ b/test/markup/typescript/casing.txt
@@ -1,0 +1,43 @@
+type Upper_Snake<Upper_Param> = Upper_Param extends boolean ? Upper_Param : never
+
+const typeTestConstFn = <Upper_Arg, Upper_Result extends Upper_Snake<any>>(param: Upper_Result<Upper_Arg>) => {}
+
+const camelCase = 42
+
+const lower_camel_case = 42
+
+const snake_case = 42
+
+const Upper_Snake_Case = 42
+
+class Upper_Snake_Case_Class = {}
+
+new Upper_Snake_Case_Class()
+
+class Extreme__Upper_$_Snake_Case_Class$$$ = {}
+
+new Extreme__Upper_$_Snake_Case_Class$$$()
+
+const mixedObject = {
+  camelCase: 42,
+  SCREAMING_CASE: 42,
+  "string prop": 42,
+  snake_case: 42,
+  Upper_Snake_Case: 42,
+}
+
+function camelCaseFn = () => {}
+
+function snake_case_fn = () => {}
+
+function Upper_Snake_Case_Fn = () {}
+
+function Extreme__Case_$_Fn$ = () => {}
+
+const camelCaseConstFn = () => {}
+
+const snake_case_const_fn = () => {}
+
+const Upper_Snake_Case_Const_Fn = () => {}
+
+const Extreme_Case_$_Const__Fn$ = () => {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
Resolves #4072 

### Changes
- added a simple expansion to a regex to check for valid ids containing _ and $. This makes it consistent with the rest of rules where it previously correctly highlighted const functions and class declaration, while splitting ids and TS type aliasses into highlighted and non-highlighted parts
- added markups that check already working cases and the cases that were fixed

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
