### PR TITLE
Update Dart for digit-separators feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ CONTRIBUTORS
 [BaliBalo]: https://github.com/BaliBalo
 [William Wilkinson]: https://github.com/wilkinson4
 [nixxquality]: https://github.com/nixxquality
+[srawlins]: https://github.com/srawlins
 
 
 ## Version 11.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - enh(erlang) OTP 27 doc attribute [nixxquality][]
 - enh(erlang) OTP 27 Sigil type [nixxquality][]
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
+- enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 
 New Grammars:
 

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -25,6 +25,15 @@ export default function(hljs) {
     keywords: 'true false null this is new super'
   };
 
+  const NUMBER = {
+    className: 'number',
+    relevance: 0,
+    variants: [
+      { begin: "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][+-]?[0-9][0-9_]*)?\\b" },
+      { begin: "\\b0[xX][0-9A-Fa-f][0-9A-Fa-f_]*\\b" }
+    ]
+  };
+
   const STRING = {
     className: 'string',
     variants: [
@@ -87,7 +96,7 @@ export default function(hljs) {
     ]
   };
   BRACED_SUBST.contains = [
-    hljs.C_NUMBER_MODE,
+    NUMBER,
     STRING
   ];
 
@@ -248,7 +257,7 @@ export default function(hljs) {
           hljs.UNDERSCORE_TITLE_MODE
         ]
       },
-      hljs.C_NUMBER_MODE,
+      NUMBER,
       {
         className: 'meta',
         begin: '@[A-Za-z]+'

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -29,8 +29,8 @@ export default function(hljs) {
     className: 'number',
     relevance: 0,
     variants: [
-      { begin: "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][+-]?[0-9][0-9_]*)?\\b" },
-      { begin: "\\b0[xX][0-9A-Fa-f][0-9A-Fa-f_]*\\b" }
+      { match: /\b[0-9][0-9_]*(\.[0-9][0-9_]*)?([eE][+-]?[0-9][0-9_]*)?\b/ },
+      { match: /\b0[xX][0-9A-Fa-f][0-9A-Fa-f_]*\b/ }
     ]
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->

Fixes https://github.com/highlightjs/highlight.js/issues/4080

### Changes

Step away from `C_NUMBER_MODE`, and implement a new NUMBER mode, similar to Python, Ruby, and others.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
