### PR TITLE
Fix block parameter handling ruby

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
-- fix(ruby) - render block arguments with |= operator [Aboobacker MK]
+- fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 
 New Grammars:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
+- fix(ruby) - render block arguments with |= operator [Aboobacker MK]
 
 New Grammars:
 
@@ -37,6 +38,7 @@ CONTRIBUTORS
 [nixxquality]: https://github.com/nixxquality
 [srawlins]: https://github.com/srawlins
 [Alvin Joy]: https://github.com/alvinsjoy
+[Aboobacker MK]: https://github.com/tachyons
 
 
 ## Version 11.10.0

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -350,7 +350,7 @@ export default function(hljs) {
     },
     {
       className: 'params',
-      begin: /\|/,
+      begin: /\|(?!=)/,
       end: /\|/,
       excludeBegin: true,
       excludeEnd: true,

--- a/test/markup/ruby/blocks.expect.txt
+++ b/test/markup/ruby/blocks.expect.txt
@@ -1,0 +1,7 @@
+[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>].each <span class="hljs-keyword">do</span> |<span class="hljs-params">num</span>|
+  puts num
+<span class="hljs-keyword">end</span>
+
+names |= users.map <span class="hljs-keyword">do</span> |<span class="hljs-params">user</span>|
+  user.name
+<span class="hljs-keyword">end</span>

--- a/test/markup/ruby/blocks.txt
+++ b/test/markup/ruby/blocks.txt
@@ -1,0 +1,7 @@
+[1, 2, 3].each do |num|
+  puts num
+end
+
+names |= users.map do |user|
+  user.name
+end


### PR DESCRIPTION
Fix block parameter handling

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

in ruby block parameter can be enclosed with |. But ruby also has builtin operator |=. This PR ensure that |= is not marked as be the beginning of the block parameter.
Before: 

<img width="1030" alt="Screenshot 2024-08-19 at 5 44 09 AM" src="https://github.com/user-attachments/assets/34a492c7-79f5-4875-aea6-99e3891fb2be">

After:

<img width="1030" alt="Screenshot 2024-08-19 at 5 44 43 AM" src="https://github.com/user-attachments/assets/d5591c86-ff0f-43bc-a71e-51957204d905">


### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
