### PR TITLE
added special char support to YAML keys 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
+- fix(c) - Fixed hex numbers with decimals in c  [Dxuian]
 
 New Grammars:
 
@@ -37,6 +38,7 @@ CONTRIBUTORS
 [nixxquality]: https://github.com/nixxquality
 [srawlins]: https://github.com/srawlins
 [Alvin Joy]: https://github.com/alvinsjoy
+[Dxuian]:https://github.com/Dxuian
 
 
 ## Version 11.10.0

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -57,11 +57,11 @@ export default function(hljs) {
   const NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(0b[01\']+)' },  
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },  
-      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?)' },  
-      { begin: '(-?)\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?' }  
-    ],
+      { match: /\b(0b[01']+)/ },  
+      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
+      { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
+  ],
     relevance: 0
   };
   

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -58,12 +58,12 @@ export default function(hljs) {
     className: 'number',
     variants: [
       { match: /\b(0b[01']+)/ },  
-      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
       { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
       { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
-  ],
+    ],
     relevance: 0
-  };
+  };  
   
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -57,14 +57,14 @@ export default function(hljs) {
   const NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(0b[01\']+)' },
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?|\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?)' }
+      { begin: '\\b(0b[01\']+)' },  
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },  
+      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?)' },  
+      { begin: '(-?)\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?' }  
     ],
     relevance: 0
   };
-
-
+  
   const PREPROCESSOR = {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -58,10 +58,10 @@ export default function(hljs) {
     className: 'number',
     variants: [
       { match: /\b(0b[01']+)/ },  
-      { match: /(-?)([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
       { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
       { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
-    ],
+  ],
     relevance: 0
   };  
   

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -54,15 +54,16 @@ export default function(hljs) {
     ]
   };
 
-  const NUMBERS = {
-    className: 'number',
-    variants: [
-      { begin: '\\b(0b[01\']+)' },
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-      { begin: '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)' }
-    ],
-    relevance: 0
-  };
+const NUMBERS = {
+  className: 'number',
+  variants: [
+    { begin: '\\b(0b[01\']+)' },
+    { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
+    { begin: '(-?)\\b0[xX][a-fA-F0-9\']+(\\.[a-fA-F0-9\']+)?([pP][-+]?[\\d\']+)?' }
+  ],
+  relevance: 0
+};
+
 
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -54,15 +54,15 @@ export default function(hljs) {
     ]
   };
 
-const NUMBERS = {
-  className: 'number',
-  variants: [
-    { begin: '\\b(0b[01\']+)' },
-    { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-    { begin: '(-?)\\b0[xX][a-fA-F0-9\']+(\\.[a-fA-F0-9\']+)?([pP][-+]?[\\d\']+)?' }
-  ],
-  relevance: 0
-};
+  const NUMBERS = {
+    className: 'number',
+    variants: [
+      { begin: '\\b(0b[01\']+)' },
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
+      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?|\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?)' }
+    ],
+    relevance: 0
+  };
 
 
   const PREPROCESSOR = {

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -20,15 +20,15 @@ export default function(hljs) {
   const KEY = {
     className: 'attr',
     variants: [
-      // added brackets support 
-      { begin: /\w[\w :()\./-]*:(?=[ \t]|$)/ },
-      { // double quoted keys - with brackets
-        begin: /"\w[\w :()\./-]*":(?=[ \t]|$)/ },
-      { // single quoted keys - with brackets
-        begin: /'\w[\w :()\./-]*':(?=[ \t]|$)/ },
+      // added brackets support and special char support
+      { begin: /[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)/ },
+      { // double quoted keys - with brackets and special char support
+        begin: /"[\w*@][\w*@ :()\./-]*":(?=[ \t]|$)/ },
+      { // single quoted keys - with brackets and special char support
+        begin: /'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)/ },
     ]
   };
-
+  
   const TEMPLATE_VARIABLES = {
     className: 'template-variable',
     variants: [

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -33,8 +33,8 @@
 <span class="hljs-number">12</span>
 
 <span class="hljs-comment">// Literal suffixes.</span>
-<span class="hljs-number">0X2</span>L
-<span class="hljs-number">0x2</span>l
+<span class="hljs-number">0X2L</span>
+<span class="hljs-number">0x2l</span>
 <span class="hljs-number">03LL</span>
 <span class="hljs-number">03ll</span>
 <span class="hljs-number">4UL</span> <span class="hljs-number">4Ul</span> <span class="hljs-number">4uL</span> <span class="hljs-number">4ul</span>

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -1,0 +1,46 @@
+<span class="hljs-comment">/* Floating-point literals. */</span>
+<span class="hljs-comment">// Decimal.</span>
+<span class="hljs-number">1.</span>
++<span class="hljs-number">12.</span>
+<span class="hljs-number">1.2</span>
+<span class="hljs-number">1234e56</span>
+
+<span class="hljs-comment">// Hexadecimal.</span>
+<span class="hljs-number">0x1p2</span>
++<span class="hljs-number">0x1.p2</span>
+<span class="hljs-number">-0X1A.P2</span>
+<span class="hljs-number">0x1.Ap2</span>
+
+<span class="hljs-comment">// Literal suffixes.</span>
+<span class="hljs-number">1.F</span>
+
+<span class="hljs-comment">/* Integer literals. */</span>
+<span class="hljs-comment">// Binary.</span>
++<span class="hljs-number">0b1</span> <span class="hljs-comment">// Note: Not standard C, but valid in some compilers</span>
+<span class="hljs-number">0B</span>01 <span class="hljs-comment">// Note: Not standard C, but valid in some compilers</span>
+
+<span class="hljs-comment">// Hexadecimal.</span>
++<span class="hljs-number">0x1</span>
+<span class="hljs-number">0X1A</span>
+
+<span class="hljs-comment">// Octal.</span>
++<span class="hljs-number">01</span>
+<span class="hljs-number">012</span>
+
+<span class="hljs-comment">// Decimal.</span>
+<span class="hljs-number">0</span>
++<span class="hljs-number">1</span>
+<span class="hljs-number">12</span>
+
+<span class="hljs-comment">// Literal suffixes.</span>
+<span class="hljs-number">0X2</span>L
+<span class="hljs-number">0x2</span>l
+<span class="hljs-number">03LL</span>
+<span class="hljs-number">03ll</span>
+<span class="hljs-number">4UL</span> <span class="hljs-number">4Ul</span> <span class="hljs-number">4uL</span> <span class="hljs-number">4ul</span>
+<span class="hljs-number">5LU</span> <span class="hljs-number">5Lu</span> <span class="hljs-number">5lU</span> <span class="hljs-number">5lu</span>
+<span class="hljs-number">6ULL</span> <span class="hljs-number">6Ull</span> <span class="hljs-number">6uLL</span> <span class="hljs-number">6ull</span>
+<span class="hljs-number">7LLU</span> <span class="hljs-number">7LLu</span> <span class="hljs-number">7llU</span> <span class="hljs-number">7llu</span>
+
+<span class="hljs-comment">// Character array.</span>
+<span class="hljs-type">char</span> word[] = { <span class="hljs-string">&#x27;3&#x27;</span>, <span class="hljs-string">&#x27;\0&#x27;</span> };

--- a/test/markup/c/number-literals.txt
+++ b/test/markup/c/number-literals.txt
@@ -1,0 +1,46 @@
+/* Floating-point literals. */
+// Decimal.
+1.
++12.
+1.2
+1234e56
+
+// Hexadecimal.
+0x1p2
++0x1.p2
+-0X1A.P2
+0x1.Ap2
+
+// Literal suffixes.
+1.F
+
+/* Integer literals. */
+// Binary.
++0b1 // Note: Not standard C, but valid in some compilers
+0B01 // Note: Not standard C, but valid in some compilers
+
+// Hexadecimal.
++0x1
+0X1A
+
+// Octal.
++01
+012
+
+// Decimal.
+0
++1
+12
+
+// Literal suffixes.
+0X2L
+0x2l
+03LL
+03ll
+4UL 4Ul 4uL 4ul
+5LU 5Lu 5lU 5lu
+6ULL 6Ull 6uLL 6ull
+7LLU 7LLu 7llU 7llu
+
+// Character array.
+char word[] = { '3', '\0' };


### PR DESCRIPTION

Resolves #4044
### Changes
added special char support to YAML keys via updating regex
before
![image](https://github.com/user-attachments/assets/1e091236-d8e4-4bfe-9428-5b17bd90ac1f)
after 
![image](https://github.com/user-attachments/assets/bc6daf75-5baf-4900-af02-686c4a7bb4bd)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
