### PR TITLE
fixed escape chars in css highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Core Grammars:
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
 - fix(c) - Fixed hex numbers with decimals in c  [Dxuian]
+- fix(sql) - Fixed foreign key and primary key not being highlighted   [Dxuian]
 
 New Grammars:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
+- fix(c) - Fixed hex numbers with decimals in c  [Dxuian]
 
 New Grammars:
 
@@ -37,6 +38,7 @@ CONTRIBUTORS
 [nixxquality]: https://github.com/nixxquality
 [srawlins]: https://github.com/srawlins
 [Alvin Joy]: https://github.com/alvinsjoy
+[Dxuian]:https://github.com/Dxuian
 
 
 ## Version 11.10.0

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -57,11 +57,11 @@ export default function(hljs) {
   const NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(0b[01\']+)' },  
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },  
-      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?)' },  
-      { begin: '(-?)\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?' }  
-    ],
+      { match: /\b(0b[01']+)/ },  
+      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
+      { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
+  ],
     relevance: 0
   };
   

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -58,12 +58,12 @@ export default function(hljs) {
     className: 'number',
     variants: [
       { match: /\b(0b[01']+)/ },  
-      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
       { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
       { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
-  ],
+    ],
     relevance: 0
-  };
+  };  
   
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -57,14 +57,14 @@ export default function(hljs) {
   const NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(0b[01\']+)' },
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?|\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?)' }
+      { begin: '\\b(0b[01\']+)' },  
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },  
+      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?)' },  
+      { begin: '(-?)\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?' }  
     ],
     relevance: 0
   };
-
-
+  
   const PREPROCESSOR = {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -58,10 +58,10 @@ export default function(hljs) {
     className: 'number',
     variants: [
       { match: /\b(0b[01']+)/ },  
-      { match: /(-?)([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
+      { match: /(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/ },  
       { match: /(-?)(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/ },  
       { match: /(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/ }  
-    ],
+  ],
     relevance: 0
   };  
   

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -54,15 +54,16 @@ export default function(hljs) {
     ]
   };
 
-  const NUMBERS = {
-    className: 'number',
-    variants: [
-      { begin: '\\b(0b[01\']+)' },
-      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-      { begin: '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)' }
-    ],
-    relevance: 0
-  };
+const NUMBERS = {
+  className: 'number',
+  variants: [
+    { begin: '\\b(0b[01\']+)' },
+    { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
+    { begin: '(-?)\\b0[xX][a-fA-F0-9\']+(\\.[a-fA-F0-9\']+)?([pP][-+]?[\\d\']+)?' }
+  ],
+  relevance: 0
+};
+
 
   const PREPROCESSOR = {
     className: 'meta',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -54,15 +54,15 @@ export default function(hljs) {
     ]
   };
 
-const NUMBERS = {
-  className: 'number',
-  variants: [
-    { begin: '\\b(0b[01\']+)' },
-    { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
-    { begin: '(-?)\\b0[xX][a-fA-F0-9\']+(\\.[a-fA-F0-9\']+)?([pP][-+]?[\\d\']+)?' }
-  ],
-  relevance: 0
-};
+  const NUMBERS = {
+    className: 'number',
+    variants: [
+      { begin: '\\b(0b[01\']+)' },
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)' },
+      { begin: '(-?)(0[xX][a-fA-F0-9]+(?:\'[a-fA-F0-9]+)*(?:\\.[a-fA-F0-9]*(?:\'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?|\\b\\d+(?:\'\\d+)*(?:\\.\\d*(?:\'\\d*)*)?(?:[eE][-+]?\\d+)?)' }
+    ],
+    relevance: 0
+  };
 
 
   const PREPROCESSOR = {

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -14,7 +14,7 @@ export default function(hljs) {
   const VENDOR_PREFIX = { begin: /-(webkit|moz|ms|o)-(?=[a-z])/ };
   const AT_MODIFIERS = "and or not only";
   const AT_PROPERTY_RE = /@-?\w[\w]*(-\w+)*/; // @-webkit-keyframes
-  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
+  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*(\\\\:[a-zA-Z0-9_-]+)*';
   const STRINGS = [
     hljs.APOS_STRING_MODE,
     hljs.QUOTE_STRING_MODE
@@ -37,7 +37,7 @@ export default function(hljs) {
       modes.CSS_NUMBER_MODE,
       {
         className: 'selector-id',
-        begin: /#[A-Za-z0-9_-]+/,
+        begin: '#' + IDENT_RE,
         relevance: 0
       },
       {
@@ -49,8 +49,8 @@ export default function(hljs) {
       {
         className: 'selector-pseudo',
         variants: [
-          { begin: ':(' + css.PSEUDO_CLASSES.join('|') + ')' },
-          { begin: ':(:)?(' + css.PSEUDO_ELEMENTS.join('|') + ')' }
+          { begin: '(?<!\\\\):(' + css.PSEUDO_CLASSES.join('|') + ')'},
+          { begin: '(?<!\\\\):(:)?(' + css.PSEUDO_ELEMENTS.join('|') + ')'}
         ]
       },
       // we may actually need this (12/2020)

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -622,6 +622,35 @@ export default function(hljs) {
     keywords: { built_in: FUNCTIONS }
   };
 
+  //COMBOS generator
+  // const regexPatterns = COMBOS.map(phrase => {
+  //   const escapedPhrase = phrase.replace(/ /g, "\\s+"); // Replace spaces with \s+ to match any whitespace
+  //   return new RegExp(escapedPhrase, "gi"); // Create case-insensitive regex
+  // });
+
+  const COMBOSLIST = {
+    className: 'type',
+    variants: [
+      { match: /\bcreate\s+table\b/ },
+      { match: /\binsert\s+into\b/ },
+      { match: /\bprimary\s+key\b/ },
+      { match: /\bforeign\s+key\b/ },
+      { match: /\bnot\s+null\b/ },
+      { match: /\balter\s+table\b/ },
+      { match: /\badd\s+constraint\b/ },
+      { match: /\bgrouping\s+sets\b/ },
+      { match: /\bon\s+overflow\b/ },
+      { match: /\bcharacter\s+set\b/ },
+      { match: /\brespect\s+nulls\b/ },
+      { match: /\bignore\s+nulls\b/ },
+      { match: /\bnulls\s+first\b/ },
+      { match: /\bnulls\s+last\b/ },
+      { match: /\bdepth\s+first\b/ },
+      { match: /\bbreadth\s+first\b/ }
+    ],
+    relevance: 0
+  };
+  
   // keywords with less than 3 letters are reduced in relevancy
   function reduceRelevancy(list, {
     exceptions, when
@@ -638,14 +667,7 @@ export default function(hljs) {
       }
     });
   }
-  //COMBOS generator 
-  function generateComboKeywords(combos) {
-    const keywords = [];
-    combos.forEach(combo => {
-      keywords.push(...combo.split(' '));
-    });
-    return keywords;
-  }
+
   return {
     name: 'SQL',
     case_insensitive: true,
@@ -661,19 +683,10 @@ export default function(hljs) {
     },
     contains: [
       {
-        begin: regex.either(...generateComboKeywords(COMBOS)),
-        relevance: 0,
-        keywords: {
-          $pattern: /[\w\.]+/,
-          keyword: KEYWORDS.concat(generateComboKeywords(COMBOS)),
-          literal: LITERALS,
-          type: TYPES
-        },
-      },
-      {
         className: "type",
         begin: regex.either(...MULTI_WORD_TYPES)
       },
+      COMBOSLIST,
       FUNCTION_CALL,
       VARIABLE,
       STRING,

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -266,7 +266,6 @@ export default function(hljs) {
     "json_table",
     "json_table_primitive",
     "json_value",
-    "key",
     "lag",
     "language",
     "large",
@@ -639,7 +638,14 @@ export default function(hljs) {
       }
     });
   }
-
+  //COMBOS generator 
+  function generateComboKeywords(combos) {
+    const keywords = [];
+    combos.forEach(combo => {
+      keywords.push(...combo.split(' '));
+    });
+    return keywords;
+  }
   return {
     name: 'SQL',
     case_insensitive: true,
@@ -655,11 +661,11 @@ export default function(hljs) {
     },
     contains: [
       {
-        begin: regex.either(...COMBOS),
+        begin: regex.either(...generateComboKeywords(COMBOS)),
         relevance: 0,
         keywords: {
           $pattern: /[\w\.]+/,
-          keyword: KEYWORDS.concat(COMBOS),
+          keyword: KEYWORDS.concat(generateComboKeywords(COMBOS)),
           literal: LITERALS,
           type: TYPES
         },

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -266,6 +266,7 @@ export default function(hljs) {
     "json_table",
     "json_table_primitive",
     "json_value",
+    "key",
     "lag",
     "language",
     "large",

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -20,15 +20,15 @@ export default function(hljs) {
   const KEY = {
     className: 'attr',
     variants: [
-      // added brackets support 
-      { begin: /\w[\w :()\./-]*:(?=[ \t]|$)/ },
-      { // double quoted keys - with brackets
-        begin: /"\w[\w :()\./-]*":(?=[ \t]|$)/ },
-      { // single quoted keys - with brackets
-        begin: /'\w[\w :()\./-]*':(?=[ \t]|$)/ },
+      // added brackets support and special char support
+      { begin: /[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)/ },
+      { // double quoted keys - with brackets and special char support
+        begin: /"[\w*@][\w*@ :()\./-]*":(?=[ \t]|$)/ },
+      { // single quoted keys - with brackets and special char support
+        begin: /'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)/ },
     ]
   };
-
+  
   const TEMPLATE_VARIABLES = {
     className: 'template-variable',
     variants: [

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -33,8 +33,8 @@
 <span class="hljs-number">12</span>
 
 <span class="hljs-comment">// Literal suffixes.</span>
-<span class="hljs-number">0X2</span>L
-<span class="hljs-number">0x2</span>l
+<span class="hljs-number">0X2L</span>
+<span class="hljs-number">0x2l</span>
 <span class="hljs-number">03LL</span>
 <span class="hljs-number">03ll</span>
 <span class="hljs-number">4UL</span> <span class="hljs-number">4Ul</span> <span class="hljs-number">4uL</span> <span class="hljs-number">4ul</span>

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -1,0 +1,46 @@
+<span class="hljs-comment">/* Floating-point literals. */</span>
+<span class="hljs-comment">// Decimal.</span>
+<span class="hljs-number">1.</span>
++<span class="hljs-number">12.</span>
+<span class="hljs-number">1.2</span>
+<span class="hljs-number">1234e56</span>
+
+<span class="hljs-comment">// Hexadecimal.</span>
+<span class="hljs-number">0x1p2</span>
++<span class="hljs-number">0x1.p2</span>
+<span class="hljs-number">-0X1A.P2</span>
+<span class="hljs-number">0x1.Ap2</span>
+
+<span class="hljs-comment">// Literal suffixes.</span>
+<span class="hljs-number">1.F</span>
+
+<span class="hljs-comment">/* Integer literals. */</span>
+<span class="hljs-comment">// Binary.</span>
++<span class="hljs-number">0b1</span> <span class="hljs-comment">// Note: Not standard C, but valid in some compilers</span>
+<span class="hljs-number">0B</span>01 <span class="hljs-comment">// Note: Not standard C, but valid in some compilers</span>
+
+<span class="hljs-comment">// Hexadecimal.</span>
++<span class="hljs-number">0x1</span>
+<span class="hljs-number">0X1A</span>
+
+<span class="hljs-comment">// Octal.</span>
++<span class="hljs-number">01</span>
+<span class="hljs-number">012</span>
+
+<span class="hljs-comment">// Decimal.</span>
+<span class="hljs-number">0</span>
++<span class="hljs-number">1</span>
+<span class="hljs-number">12</span>
+
+<span class="hljs-comment">// Literal suffixes.</span>
+<span class="hljs-number">0X2</span>L
+<span class="hljs-number">0x2</span>l
+<span class="hljs-number">03LL</span>
+<span class="hljs-number">03ll</span>
+<span class="hljs-number">4UL</span> <span class="hljs-number">4Ul</span> <span class="hljs-number">4uL</span> <span class="hljs-number">4ul</span>
+<span class="hljs-number">5LU</span> <span class="hljs-number">5Lu</span> <span class="hljs-number">5lU</span> <span class="hljs-number">5lu</span>
+<span class="hljs-number">6ULL</span> <span class="hljs-number">6Ull</span> <span class="hljs-number">6uLL</span> <span class="hljs-number">6ull</span>
+<span class="hljs-number">7LLU</span> <span class="hljs-number">7LLu</span> <span class="hljs-number">7llU</span> <span class="hljs-number">7llu</span>
+
+<span class="hljs-comment">// Character array.</span>
+<span class="hljs-type">char</span> word[] = { <span class="hljs-string">&#x27;3&#x27;</span>, <span class="hljs-string">&#x27;\0&#x27;</span> };

--- a/test/markup/c/number-literals.txt
+++ b/test/markup/c/number-literals.txt
@@ -1,0 +1,46 @@
+/* Floating-point literals. */
+// Decimal.
+1.
++12.
+1.2
+1234e56
+
+// Hexadecimal.
+0x1p2
++0x1.p2
+-0X1A.P2
+0x1.Ap2
+
+// Literal suffixes.
+1.F
+
+/* Integer literals. */
+// Binary.
++0b1 // Note: Not standard C, but valid in some compilers
+0B01 // Note: Not standard C, but valid in some compilers
+
+// Hexadecimal.
++0x1
+0X1A
+
+// Octal.
++01
+012
+
+// Decimal.
+0
++1
+12
+
+// Literal suffixes.
+0X2L
+0x2l
+03LL
+03ll
+4UL 4Ul 4uL 4ul
+5LU 5Lu 5lU 5lu
+6ULL 6Ull 6uLL 6ull
+7LLU 7LLu 7llU 7llu
+
+// Character array.
+char word[] = { '3', '\0' };


### PR DESCRIPTION

Resolves #3965

before
![image](https://github.com/user-attachments/assets/5421246d-bef2-4358-b6ad-d29e5d3beb66)

after
![image](https://github.com/user-attachments/assets/c33be8d8-5e01-4e39-bfb8-abd0bfc1b765)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
