### PR TITLE
fix for special chars in yaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Core Grammars:
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 - fix(sql) - Fixed sql primary key and foreign key spacing issue   [Dxuian]
 - fix(cpp) added flat_set and flat_map as a part of cpp 23 version [Lavan]
+- fix(yaml) - Fixed special chars in yaml   [Dxuian]
   
 New Grammars:
 

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -20,15 +20,15 @@ export default function(hljs) {
   const KEY = {
     className: 'attr',
     variants: [
-      // added brackets support 
-      { begin: /\w[\w :()\./-]*:(?=[ \t]|$)/ },
-      { // double quoted keys - with brackets
-        begin: /"\w[\w :()\./-]*":(?=[ \t]|$)/ },
-      { // single quoted keys - with brackets
-        begin: /'\w[\w :()\./-]*':(?=[ \t]|$)/ },
+      // added brackets support and special char support
+      { begin: /[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)/ },
+      { // double quoted keys - with brackets and special char support
+        begin: /"[\w*@][\w*@ :()\./-]*":(?=[ \t]|$)/ },
+      { // single quoted keys - with brackets and special char support
+        begin: /'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)/ },
     ]
   };
-
+  
   const TEMPLATE_VARIABLES = {
     className: 'template-variable',
     variants: [

--- a/test/markup/yaml/special_chars.expect.txt
+++ b/test/markup/yaml/special_chars.expect.txt
@@ -1,0 +1,18 @@
+<span class="hljs-comment"># quoted keys</span>
+<span class="hljs-attr">&quot;*&quot;:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;**/.env&quot;</span>
+
+<span class="hljs-comment"># unquoted keys</span>
+<span class="hljs-attr">*:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;**/.env&quot;</span>
+
+<span class="hljs-comment"># special chars in keys:</span>
+<span class="hljs-attr">git@github.com:*/copilot:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;/__tests__/**&quot;</span>
+
+<span class="hljs-comment"># leading special chars in a key</span>
+<span class="hljs-attr">*/copilot:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;/__tests__/**&quot;</span>
+   
+<span class="hljs-attr">@gitlab.com:gitlab-org/gitlab-runner.git:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;/__tests__/**&quot;</span>

--- a/test/markup/yaml/special_chars.txt
+++ b/test/markup/yaml/special_chars.txt
@@ -1,0 +1,19 @@
+# quoted keys
+"*":
+  - "**/.env"
+
+# unquoted keys
+*:
+  - "**/.env"
+
+# special chars in keys:
+git@github.com:*/copilot:
+  - "/__tests__/**"
+
+# leading special chars in a key
+*/copilot:
+  - "/__tests__/**"
+   
+@gitlab.com:gitlab-org/gitlab-runner.git:
+  - "/__tests__/**"
+   


### PR DESCRIPTION
Resolves #4044
### Changes
<!--- Describe your changes -->
added special char support to YAML keys via updating regex
before
![image](https://github.com/user-attachments/assets/1e091236-d8e4-4bfe-9428-5b17bd90ac1f)
after 
![image](https://github.com/user-attachments/assets/bc6daf75-5baf-4900-af02-686c4a7bb4bd)
### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
