### PR TITLE
enh(lua) add 'pluto' as an alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
+- enh(lua) add 'pluto' as an alias [Sainan]
 - fix(c) - Fixed hex numbers with decimals  [Dxuian]
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 
@@ -46,6 +47,7 @@ CONTRIBUTORS
 [Dxuian]:https://github.com/Dxuian
 [Aboobacker MK]: https://github.com/tachyons
 [Imken]: https://github.com/immccn123
+[Sainan]: https://github.com/Sainan
 
 
 ## Version 11.10.0

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -130,7 +130,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | LiveCode Server         | livecodeserver         |         |
 | LiveScript              | livescript, ls         |         |
 | LookML                  | lookml                 | [highlightjs-lookml](https://github.com/spectacles-ci/highlightjs-lookml) |
-| Lua                     | lua                    |         |
+| Lua                     | lua, pluto             |         |
 | Luau                    | luau                   | [highlightjs-luau](https://github.com/highlightjs/highlightjs-luau) |
 | Macaulay2               | macaulay2              | [highlightjs-macaulay2](https://github.com/d-torrance/highlightjs-macaulay2) |
 | Makefile                | makefile, mk, mak, make |        |

--- a/src/languages/lua.js
+++ b/src/languages/lua.js
@@ -27,6 +27,7 @@ export default function(hljs) {
   ];
   return {
     name: 'Lua',
+    aliases: ['pluto'],
     keywords: {
       $pattern: hljs.UNDERSCORE_IDENT_RE,
       literal: "true false nil",


### PR DESCRIPTION
Rationale: My understanding is that the aliases are used for file extension matching. [Pluto](https://pluto-lang.org/) is a fork of Lua that uses the .pluto extension. There would be benefit for its users if .pluto files were recognised and highlighted as Lua by this package.

There are some differences in syntax, but I don't want to impose the burden of you having to maintain highlighting for it.