### PR TITLE
Add `time` and `coproc` reserved keywords to Bash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Core Grammars:
 - enh(erlang) OTP25/27 maybe statement [nixxquality][]
 - enh(dart) Support digit-separators in number literals [Sam Rawlins][]
 - enh(csharp) add Contextual keywords `file`, `args`, `dynamic`, `record`, `required` and `scoped` [Alvin Joy][]
+- enh(bash) add reserved keywords `time` and `coproc` [Álvaro Mondéjar][]
 - fix(c) - Fixed hex numbers with decimals  [Dxuian]
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ CONTRIBUTORS
 [Aboobacker MK]: https://github.com/tachyons
 [Imken]: https://github.com/immccn123
 [Osmocom]: https://github.com/osmocom
+[Álvaro Mondéjar]: https://github.com/mondeja
 
 
 ## Version 11.10.0

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -123,6 +123,7 @@ export default function(hljs) {
     "else",
     "elif",
     "fi",
+    "time",
     "for",
     "while",
     "until",
@@ -131,6 +132,7 @@ export default function(hljs) {
     "done",
     "case",
     "esac",
+    "coproc",
     "function",
     "select"
   ];


### PR DESCRIPTION
### Changes

Adds the keywords `time` and `coproc` to Bash. See https://www.gnu.org/software/bash/manual/bash.html#Reserved-Words

- `coproc` [was added in bash-4.0-alpha](https://github.com/bminor/bash/blob/142bbdd89e4d5bb62aea4469d1d2c24cf470afd8/CHANGES#L5270)
- `time` seems that has been added previous to v2 but was not being documented as a reserved word.

In fact, many of the reserved words should only be taken as such when followed by certain others, but it seems excessive in this context.

### Checklist
- [x] Tests don't apply here because is a trivial change.
- [x] Updated the changelog at `CHANGES.md`