### PR TITLE
fix(build) Replace deleteSync, which was removed in v6 of del lib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 - Nothing yet.
 
+Build:
+
+- fix(build) Replace deleteSync, which was removed in v6 of del lib. [Wojciech Kania][]
 
 Core Grammars:
 
@@ -55,6 +58,7 @@ CONTRIBUTORS
 [Osmocom]: https://github.com/osmocom
 [Álvaro Mondéjar]: https://github.com/mondeja
 [Lavan]: https://github.com/jvlavan
+[Wojciech Kania]: https://github.com/wkania
 
 
 ## Version 11.10.0

--- a/tools/lib/makestuff.js
+++ b/tools/lib/makestuff.js
@@ -6,7 +6,7 @@ const config = require("../build_config.js");
 
 async function clean(directory) {
   const del = await import('del');
-  del.deleteSync([directory]);
+  await del.default([directory]);
   fs.mkdirSync(directory, { recursive: true });
 }
 


### PR DESCRIPTION
I'm back and it looks like the following command `build_and_test` does not work at least since [PR](https://github.com/highlightjs/highlight.js/commit/aa093815ce9c092e14aeefbf13c4a40631317665)

The runner use older version of this lib. This require some sync:
```
 Starting build.
Finished build.
/home/runner/work/highlight.js/highlight.js/pr/tools/lib/makestuff.js:9
  await del.default([directory]);
                   ^

TypeError: del.default is not a function
    at clean (/home/runner/work/highlight.js/highlight.js/pr/tools/lib/makestuff.js:9:20)
    at async doTarget (/home/runner/work/highlight.js/highlight.js/pr/tools/build.js:89:3)
```

```
docker compose exec web npm run build_and_test

> highlight.js@11.10.0 build_and_test
> npm run build && npm run test


> highlight.js@11.10.0 build
> node ./tools/build.js -t node

Starting build.
Finished build.
/usr/src/service/tools/lib/makestuff.js:9
  del.deleteSync([directory]);
      ^

TypeError: del.deleteSync is not a function
    at clean (/usr/src/service/tools/lib/makestuff.js:9:7)
    at async doTarget (/usr/src/service/tools/build.js:89:3)
```


### Checklist
- ☑️  Fixed `docker compose exec web npm run build_and_test` 
- ☑️  Updated the changelog at `CHANGES.md`
