### PR TITLE
fix(css) line break disappearing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Core Grammars:
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 - fix(sql) - Fixed sql primary key and foreign key spacing issue   [Dxuian]
 - fix(cpp) added flat_set and flat_map as a part of cpp 23 version [Lavan]
+- fix(css) - Fixed the line breaks disappearing [Somya]
   
 New Grammars:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [Osmocom]: https://github.com/osmocom
 [Álvaro Mondéjar]: https://github.com/mondeja
 [Lavan]: https://github.com/jvlavan
+[Somya]: https://github.com/somya-05
 
 
 ## Version 11.10.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Core Grammars:
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 - fix(sql) - Fixed sql primary key and foreign key spacing issue   [Dxuian]
 - fix(cpp) added flat_set and flat_map as a part of cpp 23 version [Lavan]
-- fix(css) - Fixed the line breaks disappearing [Somya]
+- fix(basic) - Fixed closing quotation marks not required for a PRINT statement [Somya]
   
 New Grammars:
 

--- a/src/languages/basic.js
+++ b/src/languages/basic.js
@@ -198,7 +198,14 @@ export default function(hljs) {
       keyword: KEYWORDS
     },
     contains: [
-      hljs.QUOTE_STRING_MODE,
+      {
+        // Match strings that start with " and end with " or a line break
+        className: 'string',
+        begin: '"',
+        end: '"|$',
+        illegal: '\\n',
+        contains: [ hljs.BACKSLASH_ESCAPE ]
+      },
       hljs.COMMENT('REM', '$', { relevance: 10 }),
       hljs.COMMENT('\'', '$', { relevance: 0 }),
       {

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -17,7 +17,7 @@ export const MODES = (hljs) => {
       scope: 'selector-attr',
       begin: /\[/,
       end: /\]/,
-      illegal: /[$]/,
+      illegal: '$',
       contains: [
         hljs.APOS_STRING_MODE,
         hljs.QUOTE_STRING_MODE

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -17,7 +17,7 @@ export const MODES = (hljs) => {
       scope: 'selector-attr',
       begin: /\[/,
       end: /\]/,
-      illegal: '$',
+      illegal: /[$]/,
       contains: [
         hljs.APOS_STRING_MODE,
         hljs.QUOTE_STRING_MODE


### PR DESCRIPTION
Fixed the line break disappearing in case of CSS.

Resolves #4101

### Changes

Before:
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/886a20bc-bf58-48e9-ac1c-869e16ff952e">

After:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/6e7e6a58-b747-4443-ac0d-e3c0000138fa">




### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
