### PR TITLE
fix(app): #4101 Fixes parser to parse new lines directly to output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Core Grammars:
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
 - fix(sql) - Fixed sql primary key and foreign key spacing issue   [Dxuian]
 - fix(cpp) added flat_set and flat_map as a part of cpp 23 version [Lavan]
+
   
 New Grammars:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [Osmocom]: https://github.com/osmocom
 [Álvaro Mondéjar]: https://github.com/mondeja
 [Lavan]: https://github.com/jvlavan
+[Mohit Nagaraj]: https://github.com/mohit-nagaraj
 
 
 ## Version 11.10.0
@@ -105,6 +107,7 @@ Core Grammars:
 - enh(css) add `inset`, `inset-*`, `border-start-*-radius` and `border-end-*-radius` attributes [Vasily Polovnyov][]
 - enh(css) add `text-decoration-skip-ink`, `text-decoration-thickness` and `text-underline-offset` attributes [Vasily Polovnyov][]
 - enh(java) add `when` to be recognized as a keyword in Java [Chiel van de Steeg][]
+- enh(parser) improve parser to parse new lines in code [Mohit Nagaraj][]
 
 New Grammars:
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -47,7 +47,7 @@ const MAX_KEYWORD_HITS = 7;
  * @param {any} hljs - object that is extended (legacy)
  * @returns {HLJSApi}
  */
-const HLJS = function(hljs) {
+const HLJS = function (hljs) {
   // Global internal variables used within the highlight.js library.
   /** @type {Record<string, Language>} */
   const languages = Object.create(null);
@@ -481,7 +481,19 @@ const HLJS = function(hljs) {
       const lexeme = match && match[0];
 
       // add non-matched text to the current mode buffer
-      modeBuffer += textBeforeMatch;
+      if (textBeforeMatch) {
+        // Preserve newline characters
+        const lines = textBeforeMatch.split('\n');
+        lines.forEach((line, index) => {
+          if (index > 0) {
+            processBuffer();
+            emitter.addText('\n');
+          }
+          if (line.length > 0) {
+            modeBuffer += line;
+          }
+        });
+      }
 
       if (lexeme == null) {
         processBuffer();
@@ -574,7 +586,7 @@ const HLJS = function(hljs) {
       if (!language.__emitTokens) {
         top.matcher.considerAll();
 
-        for (;;) {
+        for (; ;) {
           iterations++;
           if (resumeScanAtSamePosition) {
             // only regexes not matched previously will now be
@@ -967,7 +979,7 @@ const HLJS = function(hljs) {
    */
   function fire(event, args) {
     const cb = event;
-    plugins.forEach(function(plugin) {
+    plugins.forEach(function (plugin) {
       if (plugin[cb]) {
         plugin[cb](args);
       }
@@ -1007,8 +1019,8 @@ const HLJS = function(hljs) {
     removePlugin
   });
 
-  hljs.debugMode = function() { SAFE_MODE = false; };
-  hljs.safeMode = function() { SAFE_MODE = true; };
+  hljs.debugMode = function () { SAFE_MODE = false; };
+  hljs.safeMode = function () { SAFE_MODE = true; };
   hljs.versionString = packageJSON.version;
 
   hljs.regex = {

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -9,4 +9,5 @@ describe('hljs', function() {
   require('./should-not-destroyData');
   require('./compiler-extensions');
   require('./max_keyword_hits');
+  require('./process-buffer');
 });

--- a/test/parser/process-buffer.js
+++ b/test/parser/process-buffer.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const hljs = require('../../build');
+const { expect } = require('chai');
+
+describe('processBuffer and emitter', () => {
+  // Helper function to create a minimal language definition
+  const createLanguage = (name, keywords) => ({
+    name,
+    case_insensitive: true,
+    keywords: keywords
+  });
+
+  it('should correctly process and emit simple keywords', () => {
+    const testLang = createLanguage('test', 'if else while');
+    hljs.registerLanguage('test', () => testLang);
+
+    const result = hljs.highlight('if (x) { while (y) {} } else {}', { language: 'test' });
+
+    expect(result.value).to.equal(
+      '<span class="hljs-keyword">if</span> (x) { <span class="hljs-keyword">while</span> (y) {} } <span class="hljs-keyword">else</span> {}'
+    );
+  });
+
+  it('should handle sublanguages correctly', () => {
+    const outerLang = {
+      name: 'outer',
+      contains: [
+        {
+          begin: '```js',
+          end: '```',
+          subLanguage: 'javascript'
+        }
+      ]
+    };
+    hljs.registerLanguage('outer', () => outerLang);
+
+    const result = hljs.highlight('Before\n```js\nlet x = 5;\n```\nAfter', { language: 'outer' });
+
+    expect(result.value).to.include('<span class="hljs-keyword">let</span>');
+    expect(result.value).to.include('<span class="hljs-variable language_">x</span>');
+  });
+
+  it('should preserve newlines in the output', () => {
+    const simpleLang = createLanguage('simple', 'keyword');
+    hljs.registerLanguage('simple', () => simpleLang);
+
+    const result = hljs.highlight('line1\nkeyword\nline3', { language: 'simple' });
+
+    expect(result.value).to.equal(
+      'line1\n<span class="hljs-keyword">keyword</span>\nline3'
+    );
+  });
+
+  it('should handle empty input correctly', () => {
+    const emptyLang = createLanguage('empty', '');
+    hljs.registerLanguage('empty', () => emptyLang);
+
+    const result = hljs.highlight('', { language: 'empty' });
+
+    expect(result.value).to.equal('');
+  });
+
+  it('should process multiple keywords in the same line', () => {
+    const multiKeywordLang = createLanguage('multi', 'one two three');
+    hljs.registerLanguage('multi', () => multiKeywordLang);
+
+    const result = hljs.highlight('one two three four five', { language: 'multi' });
+
+    expect(result.value).to.equal(
+      '<span class="hljs-keyword">one</span> <span class="hljs-keyword">two</span> <span class="hljs-keyword">three</span> four five'
+    );
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes parser to parse new lines directly to output. <!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Closes #4101 

### Changes
<!--- Describe your changes -->
This modification to the addText method ensures that newline characters are properly handled and preserved in the token tree

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
