### PR TITLE
Add the `using` keyword per the "Explicit Resource Management" proposal

### DIFF
--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -40,7 +40,8 @@ const KEYWORDS = [
   "import",
   "from",
   "export",
-  "extends"
+  "extends",
+  "using"
 ];
 const LITERALS = [
   "true",

--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -41,6 +41,7 @@ const KEYWORDS = [
   "from",
   "export",
   "extends",
+  // It's reached stage 3, which is "recommended for implementation":
   "using"
 ];
 const LITERALS = [

--- a/test/markup/javascript/keywords.expect.txt
+++ b/test/markup/javascript/keywords.expect.txt
@@ -10,4 +10,5 @@
     <span class="hljs-keyword">if</span> (<span class="hljs-title function_">checkCondition</span>(classes[i]) === <span class="hljs-literal">undefined</span>)
       <span class="hljs-keyword">return</span> <span class="hljs-regexp">/\d+[\s/]/g</span>;
   }
+  <span class="hljs-keyword">using</span> val = <span class="hljs-title function_">condition</span>();
 }

--- a/test/markup/javascript/keywords.txt
+++ b/test/markup/javascript/keywords.txt
@@ -10,4 +10,5 @@ function $initHighlight(block, cls) {
     if (checkCondition(classes[i]) === undefined)
       return /\d+[\s/]/g;
   }
+  using val = condition();
 }


### PR DESCRIPTION
### Changes

This ECMAScript proposal adds a new keyword (`using`). It's reached stage 3, which is "recommended for implementation":
* Proposal: https://github.com/tc39/proposal-explicit-resource-management
* ECMAScript proposal process: https://tc39.es/process-document/

The change itself is very small, I've just added the `using` keyword to the list of keywords in `src/languages/lib/ecmascript.js`. I've also updated an existing keyword test adding a case to ensure `using` is rendered as `<span class="hljs-keyword">using</span>` in a declaration.

I didn't update the `CHANGES.md`, since I'm not sure if I should cut a new version for this? But let me know what to do and I can do it.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
