### PR TITLE
potential fix for issue#4134

### DIFF
--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -15,14 +15,27 @@ export default function(hljs) {
 
   // for matching comments starting with ::
   const COMMENT_2 = hljs.COMMENT(
-    /^::/, /$/,
+    /^::.*$/, /$/,
     { relevance: 10 }
   );
   const LABEL = {
     className: 'symbol',
-    begin: '^:',
+    begin: '^:[A-Za-z._?][A-Za-z0-9_$#@~.?]*',
     relevance: 0
   };
+
+  const DISK_CHANGE = {
+    className: 'symbol',
+    begin: '^[A-Za-z]:\\?$',
+    relevance: 0
+  };
+
+  const OUTPUT_REDIRECT = {
+    className: 'symbol',
+    begin: '[1-2]?[>]>{1}\s*[^&\s]+',
+    relevance: 0
+  };
+
   const KEYWORDS = [
     "if",
     "else",
@@ -157,11 +170,23 @@ export default function(hljs) {
         className: 'function',
         begin: LABEL.begin,
         end: /\n/,
-        illegal: '[::].+', // to ignore lines starting with "::" [COMMENTS]
         contains: [
           hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }),
-          COMMENT
+          COMMENT,
+          COMMENT_2
         ]
+      },
+      {
+        className: 'function',
+        begin: DISK_CHANGE.begin,
+        end: /\n/,
+        contains: [ hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }) ]
+      },
+      {
+        className: 'function',
+        begin: OUTPUT_REDIRECT.begin,
+        end: /\n/,
+        contains: [ hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }) ]
       },
       {
         className: 'number',

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -12,9 +12,15 @@ export default function(hljs) {
     /^\s*@?rem\b/, /$/,
     { relevance: 10 }
   );
+
+  // for matching comments starting with ::
+  const COMMENT_2 = hljs.COMMENT(
+    /^::/, /$/,
+    { relevance: 10 }
+  );
   const LABEL = {
     className: 'symbol',
-    begin: '^\\s*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|\\s+label)',
+    begin: '^:',
     relevance: 0
   };
   const KEYWORDS = [
@@ -141,6 +147,8 @@ export default function(hljs) {
       built_in: BUILT_INS
     },
     contains: [
+      COMMENT,
+      COMMENT_2,
       {
         className: 'variable',
         begin: /%%[^ ]|%[^ ]+?%|![^ ]+?!/
@@ -149,7 +157,7 @@ export default function(hljs) {
         className: 'function',
         begin: LABEL.begin,
         end: /\n/,
-        illegal: LABEL.begin + /\s*$/,
+        illegal: '[::].+', // to ignore lines starting with "::" [COMMENTS]
         contains: [
           hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }),
           COMMENT
@@ -160,7 +168,6 @@ export default function(hljs) {
         begin: '\\b\\d+',
         relevance: 0
       },
-      COMMENT
     ]
   };
 }

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -14,7 +14,7 @@ export default function(hljs) {
   );
   const LABEL = {
     className: 'symbol',
-    begin: '^\\s*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|\\s+label)',
+    begin: '^:',
     relevance: 0
   };
   const KEYWORDS = [
@@ -149,7 +149,7 @@ export default function(hljs) {
         className: 'function',
         begin: LABEL.begin,
         end: /\n/,
-        illegal: LABEL.begin + /\s*$/,
+        illegal: '[::].+', // to ignore lines starting with "::" [COMMENTS]
         contains: [
           hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }),
           COMMENT

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -148,7 +148,8 @@ export default function(hljs) {
       {
         className: 'function',
         begin: LABEL.begin,
-        end: '\n',
+        end: /\n/,
+        illegal: LABEL.begin + /\s*$/,
         contains: [
           hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }),
           COMMENT

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -148,7 +148,7 @@ export default function(hljs) {
       {
         className: 'function',
         begin: LABEL.begin,
-        end: 'goto:eof',
+        end: '\n',
         contains: [
           hljs.inherit(hljs.TITLE_MODE, { begin: '([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*' }),
           COMMENT


### PR DESCRIPTION
### Potential fix for the problem
dos/bat/cmd Disk switch "D:" destroys highlight

Resolves #4134 

### Changes
in `src/languages/dos.js line:151` replaced `end:'goto:eof'` to `end:'\n'`

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
