### PR TITLE
fix(parser) prevent gobbling of illegal newlines

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -526,6 +526,7 @@ const HLJS = function(hljs) {
       // first handler (when ignoreIllegals is true)
       if (match.type === "illegal" && lexeme === "") {
         // advance so we aren't stuck in an infinite loop
+        modeBuffer += "\n";
         return 1;
       }
 


### PR DESCRIPTION
Fixes #4101.

### Changes

In case `illegal` detects a 0 width match the only case that can happen is a $ matching right before a newline, so we now not only add 1 (so the parser keeps going) but we also inject the `\n` back into the `modeBuffer`.

The only other case might be if someone is using look-ahead in a illegal, and we'll simply say that is not-necessary and also not supported.

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
