### PR TITLE
Add scope to the python `self` keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Core Grammars:
 - fix(csharp) add raw string highlighting for C# 11. [Tara][]
 - fix(bash) fix # within token being detected as the start of a comment [Felix Uhl][]
 - fix(python) fix `or` conflicts with string highlighting [Mohamed Ali][]
+- enh(python) adds a scope to the `self` variable [Lee Falin][]
 - enh(delphi) allow digits to be omitted for hex and binary literals [Jonah Jeleniewski][]
 - enh(delphi) add support for digit separators [Jonah Jeleniewski][]
 - enh(delphi) add support for character strings with non-decimal numerics [Jonah Jeleniewski][]

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -373,6 +373,7 @@ export default function(hljs) {
       NUMBER,
       {
         // very common convention
+        scope: 'variable.language',
         begin: /\bself\b/
       },
       {

--- a/test/markup/python/class_self.expect.txt
+++ b/test/markup/python/class_self.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">SelfTest</span>:
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-variable language_">self</span>.text = <span class="hljs-literal">True</span>
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">method</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">pass</span>

--- a/test/markup/python/class_self.txt
+++ b/test/markup/python/class_self.txt
@@ -1,0 +1,6 @@
+class SelfTest:
+    def __init__(self):
+        self.text = True
+
+    def method(self):
+        pass


### PR DESCRIPTION
Added a scope to the python `self` keyword.

### Changes
Added a scope to the python `self` keyword.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
