### PR TITLE
fix(swift) - add proper syntax highlighting for class func/var declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Core Grammars:
 - fix(cpp) added flat_set and flat_map as a part of cpp 23 version [Lavan]
 - fix(yaml) - Fixed special chars in yaml   [Dxuian]
 - fix(basic) - Fixed closing quotation marks not required for a PRINT statement [Somya]
+- fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
   
 New Grammars:
 
@@ -58,6 +59,7 @@ CONTRIBUTORS
 [Álvaro Mondéjar]: https://github.com/mondeja
 [Lavan]: https://github.com/jvlavan
 [Somya]: https://github.com/somya-05
+[guuido]: https://github.com/guuido
 
 
 ## Version 11.10.0

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -460,6 +460,31 @@ export default function(hljs) {
     end: /}/
   };
 
+  const CLASS_FUNC_DECLARATION = {
+    begin: [
+      /(class)\s+/,          
+      /(func)\b/,
+      /\s+/,
+      /\b[A-Za-z_][A-Za-z0-9_]*\b/ 
+    ],
+    beginScope: {
+      1: "keyword",
+      2: "keyword",
+      4: "title.function"
+    }
+  };
+
+  const CLASS_VAR_DECLARATION = {
+    begin: [
+      /(class)\s+/,          
+      /(var)\b/, 
+    ],
+    beginScope: {
+      1: "keyword",
+      2: "keyword"
+    }
+  };
+
   const TYPE_DECLARATION = {
     begin: [
       /(struct|protocol|class|extension|enum|actor)/,
@@ -524,6 +549,8 @@ export default function(hljs) {
       ...COMMENTS,
       FUNCTION_OR_MACRO,
       INIT_SUBSCRIPT,
+      CLASS_FUNC_DECLARATION,
+      CLASS_VAR_DECLARATION,
       TYPE_DECLARATION,
       OPERATOR_DECLARATION,
       PRECEDENCEGROUP,

--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -461,27 +461,29 @@ export default function(hljs) {
   };
 
   const CLASS_FUNC_DECLARATION = {
-    begin: [
-      /(class)\s+/,          
-      /(func)\b/,
+    match: [
+      /class\b/,          
+      /\s+/,
+      /func\b/,
       /\s+/,
       /\b[A-Za-z_][A-Za-z0-9_]*\b/ 
     ],
-    beginScope: {
+    scope: {
       1: "keyword",
-      2: "keyword",
-      4: "title.function"
+      3: "keyword",
+      5: "title.function"
     }
   };
 
   const CLASS_VAR_DECLARATION = {
-    begin: [
-      /(class)\s+/,          
-      /(var)\b/, 
+    match: [
+      /class\b/,
+      /\s+/,          
+      /var\b/, 
     ],
-    beginScope: {
+    scope: {
       1: "keyword",
-      2: "keyword"
+      3: "keyword"
     }
   };
 

--- a/test/markup/swift/class-func-var.expect.txt
+++ b/test/markup/swift/class-func-var.expect.txt
@@ -1,15 +1,15 @@
-<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f1</span>() -&gt; <span class="hljs-type">Void</span> { }
+<span class="hljs-keyword">class</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">f1</span>() -&gt; <span class="hljs-type">Void</span> { }
 
-<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f2</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span>: <span class="hljs-type">Comparable</span><span class="hljs-operator">&gt;</span>() -&gt; <span class="hljs-type">T</span> { }
+<span class="hljs-keyword">class</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">f2</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span>: <span class="hljs-type">Comparable</span><span class="hljs-operator">&gt;</span>() -&gt; <span class="hljs-type">T</span> { }
 
-<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f3</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span><span class="hljs-operator">&gt;</span>(
+<span class="hljs-keyword">class</span> <span class="hljs-keyword">func</span> <span class="hljs-title function_">f3</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span><span class="hljs-operator">&gt;</span>(
   <span class="hljs-keyword">_</span> p1: <span class="hljs-type">Int</span>,
   p2: <span class="hljs-type">String</span>
 ) <span class="hljs-keyword">async</span> <span class="hljs-keyword">throws</span> -&gt; [<span class="hljs-type">T</span>] { }
 
-<span class="hljs-keyword">class </span><span class="hljs-keyword">var</span> v1: <span class="hljs-type">Int</span> { <span class="hljs-keyword">get</span> <span class="hljs-keyword">set</span> }
+<span class="hljs-keyword">class</span> <span class="hljs-keyword">var</span> v1: <span class="hljs-type">Int</span> { <span class="hljs-keyword">get</span> <span class="hljs-keyword">set</span> }
 
-<span class="hljs-keyword">class </span><span class="hljs-keyword">var</span> v2: <span class="hljs-type">String</span> {
+<span class="hljs-keyword">class</span> <span class="hljs-keyword">var</span> v2: <span class="hljs-type">String</span> {
   <span class="hljs-keyword">get</span> { <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;test&quot;</span> }
   <span class="hljs-keyword">set</span> { }
 }

--- a/test/markup/swift/class-func-var.expect.txt
+++ b/test/markup/swift/class-func-var.expect.txt
@@ -1,0 +1,15 @@
+<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f1</span>() -&gt; <span class="hljs-type">Void</span> { }
+
+<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f2</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span>: <span class="hljs-type">Comparable</span><span class="hljs-operator">&gt;</span>() -&gt; <span class="hljs-type">T</span> { }
+
+<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">f3</span><span class="hljs-operator">&lt;</span><span class="hljs-type">T</span><span class="hljs-operator">&gt;</span>(
+  <span class="hljs-keyword">_</span> p1: <span class="hljs-type">Int</span>,
+  p2: <span class="hljs-type">String</span>
+) <span class="hljs-keyword">async</span> <span class="hljs-keyword">throws</span> -&gt; [<span class="hljs-type">T</span>] { }
+
+<span class="hljs-keyword">class </span><span class="hljs-keyword">var</span> v1: <span class="hljs-type">Int</span> { <span class="hljs-keyword">get</span> <span class="hljs-keyword">set</span> }
+
+<span class="hljs-keyword">class </span><span class="hljs-keyword">var</span> v2: <span class="hljs-type">String</span> {
+  <span class="hljs-keyword">get</span> { <span class="hljs-keyword">return</span> <span class="hljs-string">&quot;test&quot;</span> }
+  <span class="hljs-keyword">set</span> { }
+}

--- a/test/markup/swift/class-func-var.txt
+++ b/test/markup/swift/class-func-var.txt
@@ -1,0 +1,15 @@
+class func f1() -> Void { }
+
+class func f2<T: Comparable>() -> T { }
+
+class func f3<T>(
+  _ p1: Int,
+  p2: String
+) async throws -> [T] { }
+
+class var v1: Int { get set }
+
+class var v2: String {
+  get { return "test" }
+  set { }
+}


### PR DESCRIPTION
Fixes the syntax highlighting for class functions and variables

Resolves #4121

### Changes
Before the declaration of `class func` and `class var` was not handled correctly, for example
```swift
class func foo() async throws -> [Bar]
class var someProperty: Int { get }
```
was interpreted as
```html
<span class="hljs-keyword">class</span> <span class="hljs-title class_">func</span> foo() <span class="hljs-keyword">async</span> <span class="hljs-keyword">throws</span> -&gt; [<span class="hljs-type">Bar</span>]
<span class="hljs-keyword">class</span> <span class="hljs-title class_">var</span> someProperty: <span class="hljs-type">Int</span> { <span class="hljs-keyword">get</span> }
```
After the fix the result is the following:
```html
<span class="hljs-keyword">class </span><span class="hljs-keyword">func</span> <span class="hljs-title function_">foo</span>() <span class="hljs-keyword">async</span> <span class="hljs-keyword">throws</span> -&gt; [<span class="hljs-type">Bar</span>]
<span class="hljs-keyword">class </span><span class="hljs-keyword">var</span> someProperty: <span class="hljs-type">Int</span> { <span class="hljs-keyword">get</span> }
```

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
