### PR TITLE
fix(yaml) - correct escaping behavior in single-quoted YAML strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Core Grammars:
 - fix(nix) handle backslash string escapes [h7x4][]
 - fix(nix) don't mix escapes for `"` and `''` strings [h7x4][]
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
+- fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
   
 New Grammars:
 

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -42,14 +42,28 @@ export default function(hljs) {
       }
     ]
   };
-  const STRING = {
+
+  const SINGLE_QUOTE_STRING = {
     className: 'string',
     relevance: 0,
     variants: [
       {
         begin: /'/,
         end: /'/
-      },
+      }
+    ],
+    contains: [
+      {
+        begin: /''/,
+        relevance: 0
+      }
+    ]
+  };
+
+  const STRING = {
+    className: 'string',
+    relevance: 0,
+    variants: [
       {
         begin: /"/,
         end: /"/
@@ -67,7 +81,13 @@ export default function(hljs) {
   const CONTAINER_STRING = hljs.inherit(STRING, { variants: [
     {
       begin: /'/,
-      end: /'/
+      end: /'/,
+      contains: [
+        {
+          begin: /''/,
+          relevance: 0
+        }
+      ]
     },
     {
       begin: /"/,
@@ -176,6 +196,7 @@ export default function(hljs) {
     },
     OBJECT,
     ARRAY,
+    SINGLE_QUOTE_STRING,
     STRING
   ];
 

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -46,15 +46,12 @@ export default function(hljs) {
   const SINGLE_QUOTE_STRING = {
     className: 'string',
     relevance: 0,
-    variants: [
-      {
-        begin: /'/,
-        end: /'/
-      }
-    ],
+    begin: /'/,
+    end: /'/,
     contains: [
       {
-        begin: /''/,
+        match: /''/,
+        scope: 'char.escape',
         relevance: 0
       }
     ]

--- a/test/markup/yaml/string.expect.txt
+++ b/test/markup/yaml/string.expect.txt
@@ -11,3 +11,5 @@
 <span class="hljs-attr">key:</span> <span class="hljs-string">&quot;\&quot;
 key: value&quot;</span>
 <span class="hljs-attr">key:</span> <span class="hljs-string">value</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">&#x27;<span class="hljs-char escape_">&#x27;&#x27;</span>&#x27;</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">&#x27;some<span class="hljs-char escape_">&#x27;&#x27;</span>value&#x27;</span>

--- a/test/markup/yaml/string.expect.txt
+++ b/test/markup/yaml/string.expect.txt
@@ -5,3 +5,9 @@
   multi-string
   value
 </span><span class="hljs-attr">key:</span> <span class="hljs-literal">true</span>
+
+<span class="hljs-attr">key:</span> <span class="hljs-string">&#x27;\&#x27;</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">&quot;\\&quot;</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">&quot;\&quot;
+key: value&quot;</span>
+<span class="hljs-attr">key:</span> <span class="hljs-string">value</span>

--- a/test/markup/yaml/string.txt
+++ b/test/markup/yaml/string.txt
@@ -11,4 +11,5 @@ key: "\\"
 key: "\"
 key: value"
 key: value
-
+key: ''''
+key: 'some''value'

--- a/test/markup/yaml/string.txt
+++ b/test/markup/yaml/string.txt
@@ -5,3 +5,10 @@ key: |
   multi-string
   value
 key: true
+
+key: '\'
+key: "\\"
+key: "\"
+key: value"
+key: value
+


### PR DESCRIPTION
Fixes wrong escaping behavior in single-quoted strings

Resolves #4068 

### Changes
Before, backslashes in single-quoted strings were incorrectly treated as escape characters:

![image](https://github.com/user-attachments/assets/9f1f2696-e6b5-4b1a-99ad-5f0c1d52d142)

Now single-quoted strings follow YAML specification where only single quotes can be escaped (by doubling them):

![image](https://github.com/user-attachments/assets/c4ddb62f-0359-421c-8160-45100a32a473)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
