### PR TITLE
fix(dart) - improve highlighting for classes and functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Core Grammars:
 - fix(nix) don't mix escapes for `"` and `''` strings [h7x4][]
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
+- fix(dart) - Improved highlighting for class and functions [guuido]
   
 New Grammars:
 

--- a/src/languages/dart.js
+++ b/src/languages/dart.js
@@ -7,8 +7,13 @@ Website: https://dart.dev
 Category: scripting
 */
 
+import { keywords } from "./lib/kws_swift";
+
 /** @type LanguageFn */
 export default function(hljs) {
+
+  const regex = hljs.regex;
+
   const SUBST = {
     className: 'subst',
     variants: [ { begin: '\\$[A-Za-z0-9_]+' } ]
@@ -221,6 +226,42 @@ export default function(hljs) {
     $pattern: /[A-Za-z][A-Za-z0-9_]*\??/
   };
 
+  const CAPITALIZED_BUILT_IN_TYPES = BUILT_IN_TYPES.filter(type => /^[A-Z]/.test(type));
+
+  const BUILT_IN_TYPES_REGEX = `\\b(${CAPITALIZED_BUILT_IN_TYPES.join('|')})\\b`;
+
+  const CLASS_NAME_RE = regex.either(
+    /\b([A-Z]+[a-z0-9]+)+/,
+    // ends in caps
+    /\b([A-Z]+[a-z0-9]+)+[A-Z]+/,
+  );
+
+  const CLASS_REFERENCE = {
+    relevance: 0,
+    variants: [
+      {
+        // prevent built-in types with capital letter from being selected as title.class
+        match: BUILT_IN_TYPES_REGEX,
+        skip: true
+      },
+      {
+        match: CLASS_NAME_RE,
+        scope: "title.class"
+      } 
+    ]
+  };
+
+  const FUNCTION_REFERENCE = {
+    relevance: 0,
+    match: [
+      /[a-z][A-Za-z0-9]*/,
+       /\(/
+    ],
+    className: {
+      1: "title.function"
+    },
+  };
+
   return {
     name: 'Dart',
     keywords: KEYWORDS,
@@ -257,6 +298,8 @@ export default function(hljs) {
           hljs.UNDERSCORE_TITLE_MODE
         ]
       },
+      CLASS_REFERENCE,
+      FUNCTION_REFERENCE,
       NUMBER,
       {
         className: 'meta',

--- a/test/markup/dart/class.expect.txt
+++ b/test/markup/dart/class.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Person</span> </span>{
+  <span class="hljs-built_in">String</span> name;
+  <span class="hljs-built_in">int</span> age;
+
+  <span class="hljs-title class_">Person</span>(<span class="hljs-keyword">this</span>.name, <span class="hljs-keyword">this</span>.age);
+
+  <span class="hljs-keyword">void</span> <span class="hljs-title function_">introduce</span>() {
+    <span class="hljs-title function_">print</span>(<span class="hljs-string">&#x27;My name is <span class="hljs-subst">$name</span> and I am <span class="hljs-subst">$age</span> years old.&#x27;</span>);
+  }
+}

--- a/test/markup/dart/class.txt
+++ b/test/markup/dart/class.txt
@@ -1,0 +1,10 @@
+class Person {
+  String name;
+  int age;
+
+  Person(this.name, this.age);
+
+  void introduce() {
+    print('My name is $name and I am $age years old.');
+  }
+}

--- a/test/markup/dart/function.expect.txt
+++ b/test/markup/dart/function.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-keyword">void</span> <span class="hljs-title function_">greet</span>(<span class="hljs-built_in">String</span> name) {
+  <span class="hljs-title function_">print</span>(<span class="hljs-string">&#x27;Hello, <span class="hljs-subst">$name</span>!&#x27;</span>);
+}
+
+<span class="hljs-keyword">void</span> <span class="hljs-title function_">dummy</span>(<span class="hljs-title class_">Foo</span> obj) {
+  <span class="hljs-keyword">return</span> obj;
+}
+
+<span class="hljs-built_in">int</span> <span class="hljs-title function_">add</span>(<span class="hljs-built_in">int</span> a, <span class="hljs-built_in">int</span> b) {
+  <span class="hljs-keyword">return</span> a + b;
+}

--- a/test/markup/dart/function.txt
+++ b/test/markup/dart/function.txt
@@ -1,0 +1,11 @@
+void greet(String name) {
+  print('Hello, $name!');
+}
+
+void dummy(Foo obj) {
+  return obj;
+}
+
+int add(int a, int b) {
+  return a + b;
+}


### PR DESCRIPTION
Resolves #4091

### Changes

Before class and function names were not decorated and this could impact readability

![image](https://github.com/user-attachments/assets/280f7ae4-d71a-404c-94e2-cb2ba39ab6c3)

After the fix these elements are correctly highlighted

![image](https://github.com/user-attachments/assets/d96e1762-0a99-464d-bc89-e54012abdced)

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
