### PR TITLE
fix(ruby) don't highlight interpolation in single quoted strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,8 @@ Core Grammars:
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
-  
+- fix(ruby) - Fix non-interpolabale Ruby strings [Boris Verkhovskiy][]
+
 New Grammars:
 
 - added 3rd party TTCN-3 grammar to SUPPORTED_LANGUAGES [Osmocom][]
@@ -85,7 +86,7 @@ CONTRIBUTORS
 [guuido]: https://github.com/guuido
 [clsource]: https://github.com/clsource
 [Jake Leahy]: https://github.com/ire4ever1190
-
+[Boris Verkhovskiy]: https://github.com/verhovsky
 
 ## Version 11.10.0
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1014,6 +1014,7 @@ const HLJS = function(hljs) {
   hljs.regex = {
     concat: regex.concat,
     lookahead: regex.lookahead,
+    escape: regex.escape,
     either: regex.either,
     optional: regex.optional,
     anyNumberOfTimes: regex.anyNumberOfTimes

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -15,8 +15,7 @@ export default function(hljs) {
     /\b([A-Z]+[a-z0-9]+)+/,
     // ends in caps
     /\b([A-Z]+[a-z0-9]+)+[A-Z]+/,
-  )
-  ;
+  );
   const CLASS_NAME_WITH_NAMESPACE_RE = regex.concat(CLASS_NAME_RE, /(::\w+)*/)
   // very popular ruby built-ins that one might even assume
   // are actual keywords (despite that not being the case)
@@ -124,54 +123,119 @@ export default function(hljs) {
   };
   const STRING = {
     className: 'string',
-    contains: [
-      hljs.BACKSLASH_ESCAPE,
-      SUBST
-    ],
+    contains: [ hljs.BACKSLASH_ESCAPE ],
     variants: [
       {
         begin: /'/,
         end: /'/
       },
       {
-        begin: /"/,
-        end: /"/
-      },
-      {
-        begin: /`/,
-        end: /`/
-      },
-      {
-        begin: /%[qQwWx]?\(/,
+        begin: /%q\(/,
         end: /\)/
       },
       {
-        begin: /%[qQwWx]?\[/,
+        begin: /%q\[/,
         end: /\]/
       },
       {
-        begin: /%[qQwWx]?\{/,
+        begin: /%q\{/,
         end: /\}/
       },
       {
-        begin: /%[qQwWx]?</,
+        begin: /%q</,
         end: />/
       },
       {
-        begin: /%[qQwWx]?\//,
+        begin: /%q\//,
         end: /\//
       },
       {
-        begin: /%[qQwWx]?%/,
+        begin: /%q%/,
         end: /%/
       },
       {
-        begin: /%[qQwWx]?-/,
+        begin: /%q-/,
         end: /-/
       },
       {
+        begin: /"/,
+        end: /"/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /`/,
+        end: /`/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?\(/,
+        end: /\)/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?\[/,
+        end: /\]/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?\{/,
+        end: /\}/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?</,
+        end: />/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?\//,
+        end: /\//,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?%/,
+        end: /%/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
+        begin: /%[qQwWx]?-/,
+        end: /-/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
+      },
+      {
         begin: /%[qQwWx]?\|/,
-        end: /\|/
+        end: /\|/,
+        contains: [
+          hljs.BACKSLASH_ESCAPE,
+          SUBST
+        ]
       },
       // in the following expressions, \B in the beginning suppresses recognition of ?-sequences
       // where ? is the last character of a preceding identifier, as in: `func?4`

--- a/test/markup/erb/default.expect.txt
+++ b/test/markup/erb/default.expect.txt
@@ -6,6 +6,6 @@
 
 &lt;%-</span><span class="language-ruby"> available_things = things.select(&amp;<span class="hljs-symbol">:available?</span>) </span><span class="language-xml">-%&gt;
 &lt;%%</span><span class="language-ruby">- x = <span class="hljs-number">1</span> + <span class="hljs-number">2</span> -</span><span class="language-xml">%%&gt;
-&lt;%%</span><span class="language-ruby"> value = <span class="hljs-string">&#x27;real string <span class="hljs-subst">#{<span class="hljs-variable">@value</span>}</span>&#x27;</span> </span><span class="language-xml">%%&gt;
+&lt;%%</span><span class="language-ruby"> value = <span class="hljs-string">&quot;real string <span class="hljs-subst">#{<span class="hljs-variable">@value</span>}</span>&quot;</span> </span><span class="language-xml">%%&gt;
 &lt;%%</span><span class="language-ruby">= available_things.inspect </span><span class="language-xml">%%&gt;
 </span>

--- a/test/markup/erb/default.txt
+++ b/test/markup/erb/default.txt
@@ -6,5 +6,5 @@
 
 <%- available_things = things.select(&:available?) -%>
 <%%- x = 1 + 2 -%%>
-<%% value = 'real string #{@value}' %%>
+<%% value = "real string #{@value}" %%>
 <%%= available_things.inspect %%>

--- a/test/markup/ruby/strings.expect.txt
+++ b/test/markup/ruby/strings.expect.txt
@@ -28,3 +28,9 @@ c = <span class="hljs-string">?\u{0AF09}</span>
 c = <span class="hljs-string">?\u{AF9}</span>
 c = <span class="hljs-string">?\u{F9}</span>
 c = <span class="hljs-string">?\u{F}</span>
+
+<span class="hljs-comment"># Interpolation</span>
+c = <span class="hljs-string">&#x27;a#{1}b&#x27;</span>  <span class="hljs-comment">#=&gt; &quot;a\#{1}b&quot;</span>
+c = <span class="hljs-string">&quot;a<span class="hljs-subst">#{<span class="hljs-number">1</span>}</span>b&quot;</span>  <span class="hljs-comment">#=&gt; &quot;a1b&quot;</span>
+c = <span class="hljs-string">%q(a#{1}b)</span> <span class="hljs-comment">#=&gt; &quot;a\#{1}b&quot;</span>
+c = <span class="hljs-string">%Q{a<span class="hljs-subst">#{<span class="hljs-number">1</span>}</span>b}</span> <span class="hljs-comment">#=&gt; &quot;a1b&quot;</span>

--- a/test/markup/ruby/strings.expect.txt
+++ b/test/markup/ruby/strings.expect.txt
@@ -22,6 +22,12 @@ c = <span class="hljs-string">?\c\M-x</span>     <span class="hljs-comment"># me
 c = <span class="hljs-string">?\c?</span>        <span class="hljs-comment"># delete, ASCII 7Fh (DEL)</span>
 c = <span class="hljs-string">?\C-?</span>       <span class="hljs-comment"># delete, ASCII 7Fh (DEL)</span>
 
+<span class="hljs-comment"># symbols</span>
+c = <span class="hljs-symbol">:booger</span>        <span class="hljs-comment">#=&gt; :booger</span>
+c = <span class="hljs-symbol">:&quot;booger&quot;</span>      <span class="hljs-comment">#=&gt; :booger</span>
+c = <span class="hljs-symbol">:&#x27;booger&#x27;</span>      <span class="hljs-comment">#=&gt; :booger</span>
+c = <span class="hljs-symbol">:&quot;b<span class="hljs-subst">#{yum}</span>ger&quot;</span>  <span class="hljs-comment">#=&gt; :burger</span>
+
 <span class="hljs-comment"># Unicode character(s) of type \u{nnnn ....}, where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])</span>
 c = <span class="hljs-string">?\u{00AF09}</span>
 c = <span class="hljs-string">?\u{0AF09}</span>

--- a/test/markup/ruby/strings.txt
+++ b/test/markup/ruby/strings.txt
@@ -28,3 +28,9 @@ c = ?\u{0AF09}
 c = ?\u{AF9}
 c = ?\u{F9}
 c = ?\u{F}
+
+# Interpolation
+c = 'a#{1}b'  #=> "a\#{1}b"
+c = "a#{1}b"  #=> "a1b"
+c = %q(a#{1}b) #=> "a\#{1}b"
+c = %Q{a#{1}b} #=> "a1b"

--- a/test/markup/ruby/strings.txt
+++ b/test/markup/ruby/strings.txt
@@ -22,6 +22,12 @@ c = ?\c\M-x     # meta control character, where x is an ASCII printable characte
 c = ?\c?        # delete, ASCII 7Fh (DEL)
 c = ?\C-?       # delete, ASCII 7Fh (DEL)
 
+# symbols
+c = :booger        #=> :booger
+c = :"booger"      #=> :booger
+c = :'booger'      #=> :booger
+c = :"b#{yum}ger"  #=> :burger
+
 # Unicode character(s) of type \u{nnnn ....}, where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])
 c = ?\u{00AF09}
 c = ?\u{0AF09}


### PR DESCRIPTION
Fixes #3676

### Changes

Not all Ruby strings can contain (`contains:`) string substitutions (`SUBST`).