### PR TITLE
fix(ruby): stricter block params, allowing bitwise OR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ CAVEATS / POTENTIALLY BREAKING CHANGES
 
 Core Grammars:
 
+- fix(ruby) correct bitwise OR(|) highlighting 
 - fix(rust) - adds emoji support in single quote strings [joshgoebel][]
 - fix(apache) - support line continuation via `\` [Josh Goebel][]
 - fix(makefile) - allow strings inside `$()` expressions [aneesh98][]

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -243,6 +243,16 @@ export default function(hljs) {
     ]
   };
 
+
+  const BLOCK_PARAMS = {
+      className: 'params',
+      begin: /(do|\{)\s\|(?!=)/,
+      end: /\|/,
+      excludeBegin: true,
+      excludeEnd: true,
+      keywords: RUBY_KEYWORDS,
+  };
+
   const INCLUDE_EXTEND = {
     match: [
       /(include|extend)\s+/,
@@ -326,7 +336,9 @@ export default function(hljs) {
     METHOD_DEFINITION,
     {
       // swallow namespace qualifiers before symbols
-      begin: hljs.IDENT_RE + '::' },
+      begin: hljs.IDENT_RE + '::'
+    },
+    BLOCK_PARAMS,
     {
       className: 'symbol',
       begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:',
@@ -347,15 +359,6 @@ export default function(hljs) {
       // @ident@ or $ident$ that might indicate this is not ruby at all
       className: "variable",
       begin: '(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])' + `(?![A-Za-z])(?![@$?'])`
-    },
-    {
-      className: 'params',
-      begin: /\|(?!=)/,
-      end: /\|/,
-      excludeBegin: true,
-      excludeEnd: true,
-      relevance: 0, // this could be a lot of things (in other languages) other than params
-      keywords: RUBY_KEYWORDS
     },
     { // regexp container
       begin: '(' + hljs.RE_STARTERS_RE + '|unless)\\s*',
@@ -398,7 +401,6 @@ export default function(hljs) {
 
   SUBST.contains = RUBY_DEFAULT_CONTAINS;
   PARAMS.contains = RUBY_DEFAULT_CONTAINS;
-
   // >>
   // ?>
   const SIMPLE_PROMPT = "[>?]>";

--- a/test/markup/ruby/blocks.expect.txt
+++ b/test/markup/ruby/blocks.expect.txt
@@ -5,3 +5,6 @@
 names |= users.map <span class="hljs-keyword">do</span> |<span class="hljs-params">user</span>|
   user.name
 <span class="hljs-keyword">end</span>
+
+bitwise_or = <span class="hljs-number">1</span> | <span class="hljs-number">2</span>
+not_registered_as_param

--- a/test/markup/ruby/blocks.txt
+++ b/test/markup/ruby/blocks.txt
@@ -5,3 +5,6 @@ end
 names |= users.map do |user|
   user.name
 end
+
+bitwise_or = 1 | 2
+not_registered_as_param


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Block parenthesis, which are two pipe symbols are applicable after a `do |param|` or inside of an inline block `{ |param| ... }`.

<!-- Please link to a related issue below. -->
Resolves #4187

### Changes
<!--- Describe your changes -->
This change ensures the pipes `|param|` are preceded by an open bracket `{` or a `do`.
By being specific when these parenthesis occur, bitwise OR operations `|` don't read what follows as params indefinitely.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
