### PR TITLE
refactor(tools): replace @colors/colors with smaller and faster ansis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "11.11.2",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@colors/colors": "^1.6.0",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@types/mocha": "^10.0.2",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/parser": "^7.15.0",
+        "ansis": "^3.5.2",
         "clean-css": "^5.3.2",
         "cli-table": "^0.3.1",
         "commander": "^12.1.0",
@@ -55,15 +55,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1151,6 +1142,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.5.2.tgz",
+      "integrity": "sha512-5uGcUZRbORJeEppVdWfZOSybTMz+Ou+84HepgK081Yk5+pPMMzWf/XGxiAT6bfBqCghRB4MwBtYn0CHqINRVag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/anymatch": {
@@ -5819,12 +5820,6 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
-    "@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "dev": true
-    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -6466,6 +6461,12 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "ansis": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.5.2.tgz",
+      "integrity": "sha512-5uGcUZRbORJeEppVdWfZOSybTMz+Ou+84HepgK081Yk5+pPMMzWf/XGxiAT6bfBqCghRB4MwBtYn0CHqINRVag==",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "@colors/colors": "^1.6.0",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@types/mocha": "^10.0.2",
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",
+    "ansis": "^3.5.2",
     "clean-css": "^5.3.2",
     "cli-table": "^0.3.1",
     "commander": "^12.1.0",

--- a/tools/checkAutoDetect.js
+++ b/tools/checkAutoDetect.js
@@ -6,7 +6,7 @@ const hljs = require('../build/lib/index.js');
 const path = require('path');
 const utility = require('../test/utility.js');
 const Table = require('cli-table');
-const colors = require('@colors/colors/safe.js');
+const { red, grey, green, yellow } = require('ansis');
 
 const resultTable = new Table({
   head: ['expected', 'actual', 'score', '2nd best', 'score', 'info'],
@@ -29,19 +29,19 @@ function testAutoDetection(language, index, languages) {
       if (actual.language !== expected && actual.secondBest.language !== expected) {
         return resultTable.push([
           expected,
-          colors.red(actual.language),
-          actual.relevance ? actual.relevance : colors.grey('None'),
-          colors.red(actual.secondBest.language),
-          actual.secondBest.relevance ? actual.secondBest.relevance : colors.grey('None')
+          red(actual.language),
+          actual.relevance ? actual.relevance : grey('None'),
+          red(actual.secondBest.language),
+          actual.secondBest.relevance ? actual.secondBest.relevance : grey('None')
         ]);
       }
       if (actual.language !== expected) {
         return resultTable.push([
           expected,
-          colors.yellow(actual.language),
-          actual.relevance ? actual.relevance : colors.grey('None'),
-          colors.yellow(actual.secondBest.language),
-          actual.secondBest.relevance ? actual.secondBest.relevance : colors.grey('None')
+          yellow(actual.language),
+          actual.relevance ? actual.relevance : grey('None'),
+          yellow(actual.secondBest.language),
+          actual.secondBest.relevance ? actual.secondBest.relevance : grey('None')
         ]);
       }
       // equal relevance is flagged
@@ -49,9 +49,9 @@ function testAutoDetection(language, index, languages) {
         return resultTable.push([
           expected,
           actual.language,
-          actual.relevance ? colors.yellow(actual.relevance) : colors.grey('None'),
+          actual.relevance ? yellow(actual.relevance) : grey('None'),
           actual.secondBest.language,
-          actual.secondBest.relevance ? colors.yellow(actual.secondBest.relevance) : colors.grey('None'),
+          actual.secondBest.relevance ? yellow(actual.secondBest.relevance) : grey('None'),
           "Relevance match."
         ]);
       }
@@ -65,7 +65,7 @@ if (process.env.ONLY_LANGUAGES) {
   languages = hljs.listLanguages().filter(hljs.autoDetection);
 }
 
-console.log('Checking auto-highlighting for ' + colors.grey(languages.length) + ' languages...');
+console.log('Checking auto-highlighting for ' + grey(languages.length) + ' languages...');
 languages.forEach((lang, index) => {
   if (index % 60 === 0) { console.log(""); }
   testAutoDetection(lang);
@@ -74,10 +74,10 @@ languages.forEach((lang, index) => {
 console.log("\n");
 
 if (resultTable.length === 0) {
-  console.log(colors.green('SUCCESS') + ' - ' + colors.green(languages.length) + ' of ' + colors.gray(languages.length) + ' languages passed auto-highlight check!');
+  console.log(green('SUCCESS') + ' - ' + green(languages.length) + ' of ' + grey(languages.length) + ' languages passed auto-highlight check!');
 } else {
   console.log(
-    colors.red('ISSUES') + ' - ' + colors.red(resultTable.length) + ' of ' + colors.gray(languages.length) + ' languages have potential issues.'
+    red('ISSUES') + ' - ' + red(resultTable.length) + ' of ' + grey(languages.length) + ' languages have potential issues.'
     + '\n'
     + resultTable.toString());
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR replaces [@colors/colors](https://github.com/DABH/colors.js) used in CLI tools with smaller and faster [ansis](https://github.com/webdiscus/ansis).

### Benefits of `ansis`

- The unpacked size is smaller: `@colors/colors` -[ 41.5 kB](https://www.npmjs.com/package/@colors/colors), `ansis` - [7 kB](https://www.npmjs.com/package/ansis), see [Compare the size of packages](https://github.com/webdiscus/ansis#compare-size)
- 10x faster than `@colors/colors`, see [Benchmarks](https://github.com/webdiscus/ansis#benchmark)
- Supports [Truecolor](https://github.com/webdiscus/ansis?tab=readme-ov-file#truecolor) with [fallback](https://github.com/webdiscus/ansis#fallback): TrueColor → 256 colors → 16 colors → no colors
- Doesn't extend `String.prototype`
- Zero dependencies
- Test coverage 100%

#### Packages that already use `ansis`

[facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json), [nestjs/nest](https://github.com/nestjs/nest/blob/master/package.json), [sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json), [oclif/core](https://github.com/oclif/core/blob/prerelease/beta/package.json), [salesforcecli/cli](https://github.com/salesforcecli/cli/blob/main/package.json) and [thousands others](https://github.com/webdiscus/ansis/network/dependents)

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

The changes in CLI tools:

- replace `@colors/colors` with  `ansis`
- add color preview for selectors used in CSS
- fix ESLint errors in tools code

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`

### Test

This PR does not require unit/integration tests, but you can do the `manual test`.

Clone and install the forked repository:
```
git clone https://github.com/webdiscus/ansis-highlight.js.git
cd ansis-highlight.js
git checkout switch-to-ansis
npm i
npm run build
```

**1) Run CheckTheme tools in CLI**

For example, we want to check the `vs2015` style:
```
node ./tools/checkTheme.js ./src/styles/vs2015.css
```
In console output will be displayed color text and NEW added preview of colors used in CSS selectors:
![high fidelity highlighting (this is optional)](https://github.com/user-attachments/assets/8397a5f3-958f-47be-8803-3ff0a3b2cbd8)

**2) Run CheckAutoDetect tools in CLI**

```
node ./tools/checkAutoDetect.js
```

In console output will be displayed color text:

![Pasted Graphic](https://github.com/user-attachments/assets/0d52e943-8ded-4887-97a3-ed20156863e3)
