### PR TITLE
fix(rust) allow function invocations with names that start with a keyword

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -21,7 +21,7 @@ export default function(hljs) {
     relevance: 0,
     begin: regex.concat(
       /\b/,
-      /(?!let|for|while|if|else|match\b)/,
+      /(?!(?:let|for|while|if|else|match)\b)/,
       IDENT_RE,
       regex.lookahead(/\s*\(/))
   };

--- a/test/markup/rust/invoked-keywords.expect.txt
+++ b/test/markup/rust/invoked-keywords.expect.txt
@@ -7,3 +7,4 @@
 <span class="hljs-keyword">for</span> <span class="hljs-variable">a</span> <span class="hljs-keyword">in</span> <span class="hljs-number">0</span>..<span class="hljs-number">10</span> {}
 <span class="hljs-keyword">match</span> <span class="hljs-type">str</span> {}
 <span class="hljs-keyword">match</span> (<span class="hljs-type">str</span>) {}
+<span class="hljs-title function_ invoke__">foreach</span>(x)

--- a/test/markup/rust/invoked-keywords.txt
+++ b/test/markup/rust/invoked-keywords.txt
@@ -7,3 +7,4 @@ for (a, b) in (0..10).enumerate() {}
 for a in 0..10 {}
 match str {}
 match (str) {}
+foreach(x)


### PR DESCRIPTION
### Changes

Example: `foreach()` was not highlighted because it starts with `for`.

### Checklist
- [x] Added markup tests
- [ ] Updated the changelog at `CHANGES.md`
