### PR TITLE
Replace link to Odin package in SUPPORTED_LANGUAGES.md

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -163,7 +163,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Object Constraint Language | ocl                 | [highlightjs-ocl](https://github.com/nhomble/highlightjs-ocl)        |
 | OCaml                   | ocaml, ml              |         |
 | Objective C             | objectivec, mm, objc, obj-c, obj-c++, objective-c++ |    |
-| Odin                    | odin                   |         [highlightjs-odin](https://github.com/NinjasCL/highlightjs-odin) |
+| Odin                    | odin                   |         [highlightjs-odinlang](https://github.com/marianpekar/highlightjs-odinlang) |
 | OpenGL Shading Language | glsl                   |         |
 | OpenSCAD                | openscad, scad         |         |
 | Oracle Rules Language   | ruleslanguage          |         |


### PR DESCRIPTION
The package for [Odin](https://odin-lang.org/) is incomplete and abandoned (the original author has archived the GitHub repository).

Here’s how my new package, which I propose as a replacement, compares to the original:

| **New Package 👍**       | **Currently Linked Package 👎**               |
|---------------------------|-----------------------------------------------|
| Complete grammar          | Lacks types and many keywords          |
| Full test coverage (includes sample and all keywords, types, built-ins, and literals) | No tests at all                      |
| Supports both `require` and `import` | Supports only `require`             |
| Active git repo | Archived git repo |  

I am also highly motivated to maintain the package because I run a blog at [https://www.marianpekar.com](https://www.marianpekar.com), where I use highlight.js. I’ve already started working on a series of blog posts covering various Odin topics (i.e. implementation of software renderer written in Odin I [already wrote code for](https://github.com/marianpekar/software-renderer-odin)), making me an active user of my own package.


