### PR TITLE
fix(docs) Add missing information to CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,31 @@
+## Unreleased Version
+
+New Grammars:
+
+- Replace link to Odin package in SUPPORTED_LANGUAGES.md [Marian Pekár][]
+
+Developer Tools:
+
+- Since 11.10.0, the auto-detect test suite has been commented out [Josh Goebel][]
+
+Improvements:
+
+- (fix) fix illegal handling at end of input code [Josh Goebel][]
+
+CONTRIBUTORS
+
+[Josh Goebel]: https://github.com/joshgoebel
+[Marian Pekár]: https://github.com/marianpekar
+
 ## Version 11.11.1
 
-- Fixes regression with Rust grammar.
+Core Grammars:
 
+- Fixes regression with Rust grammar. [Josh Goebel][]
+
+CONTRIBUTORS
+
+[Josh Goebel]: https://github.com/joshgoebel
 
 ## Version 11.11.0
 


### PR DESCRIPTION
As discussed with Josh Goebel on the discord server, PR #3906 which was already in effect since 11.10.0 had a change in developer tooling [in which auto-detect tests are now being de-emphasized](https://github.com/highlightjs/highlight.js/pull/3906/commits/57cf5a332e17611da54d8562c7398cca96722814) go undocumented in `CHANGES.md`.

Instead of retroactively placing the change under 11.10.0 where it would likely be missed, I was informed that for greater visibility of this change it should be placed on the latest release.

Additionally, the format of 11.11.1 (the current release) in `CHANGES.md` has been updated to match previous versions.

This also credits the merged changes made in #4201 and 62f8a60 which were not yet documented in `CHANGES.md` under `Unreleased Version`. Please let me know if something else would be preferable.

### Changes

- Retroactively credit changes in 11.11.1
- List changes since 11.11.1 release under Unreleased Version
    - List the change made in #4201
    - List the changes made in 62f8a60

### Checklist
- [x] Markup tests do not apply here as it is strictly a documentation change
- [x] Updated the changelog at `CHANGES.md`
