### PR TITLE
Add Ryton Programming Language Support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version 11.12.0
+New Languages:
+- Added RytonLang support with MetaTable system, Zig integration, and special operators [RejziDich]
+
 ## Version 11.11.1
 
 - Fixes regression with Rust grammar.

--- a/h -f origin add-ryton-language
+++ b/h -f origin add-ryton-language
@@ -1,5 +1,0 @@
-[33m8c84550f[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32madd-ryton-language[m[33m, [m[1;31morigin/add-ryton-language[m[33m)[m Add Ryton tests and update CHANGES.md
-[33m87532c2b[m Add Ryton language support
-[33md301848c[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m Replace link to Odin package in SUPPORTED_LANGUAGES.md (#4201)
-[33m62f8a60a[m (fix) fix `illegal` handling at end of input code
-[33m08cb242e[m (release) 11.1.1

--- a/h -f origin add-ryton-language
+++ b/h -f origin add-ryton-language
@@ -1,0 +1,5 @@
+[33m8c84550f[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32madd-ryton-language[m[33m, [m[1;31morigin/add-ryton-language[m[33m)[m Add Ryton tests and update CHANGES.md
+[33m87532c2b[m Add Ryton language support
+[33md301848c[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m Replace link to Odin package in SUPPORTED_LANGUAGES.md (#4201)
+[33m62f8a60a[m (fix) fix `illegal` handling at end of input code
+[33m08cb242e[m (release) 11.1.1

--- a/src/languages/ryton.js
+++ b/src/languages/ryton.js
@@ -1,0 +1,76 @@
+hljs.registerLanguage('ryton', function(hljs) {
+  return {
+    name: 'Ryton',
+    aliases: ['ry', 'ryt'],
+    keywords: {
+      keyword: 'func pack table parallel infinit try elerr elif else module import trash_cleaner init data struct chain event guard match protect defer lazy void',
+      built_in: 'MetaTable Terminal print input this none pylib jvmlib',
+      literal: 'true false none',
+      type: 'int str float bool list dict tuple',
+      operator: ':: -> => |> <=> >> := ?='
+    },
+    contains: [
+      // Комментарии
+      hljs.HASH_COMMENT_MODE,
+      {
+        className: 'comment',
+        begin: '//', end: '$'
+      },
+      // Строки
+      hljs.QUOTE_STRING_MODE,
+      {
+        className: 'string',
+        begin: '"""', end: '"""',
+        contains: [{ begin: '\\$[NTRVFBBs0]' }]
+      },
+      // Декораторы
+      {
+        className: 'meta',
+        begin: '@\\w+'
+      },
+      // Zig блоки
+      {
+        className: 'meta',
+        begin: '#Zig\\(start\\)', end: '#Zig\\(end:.*?\\)',
+        contains: [{ begin: '[^]+' }]
+      },
+      // MetaTable
+      {
+        className: 'class',
+        beginKeywords: 'table', end: '{',
+        contains: [hljs.TITLE_MODE]
+      },
+      // Функции
+      {
+        className: 'function',
+        beginKeywords: 'func', end: '{',
+        contains: [
+          hljs.TITLE_MODE,
+          {
+            className: 'params',
+            begin: '\\(', end: '\\)',
+            contains: [
+              hljs.TITLE_MODE,
+              {
+                className: 'type',
+                begin: ':', end: '[ ,\\)]'
+              }
+            ]
+          }
+        ]
+      },
+      // Классы
+      {
+        className: 'class',
+        beginKeywords: 'pack', end: '{',
+        contains: [
+          hljs.TITLE_MODE,
+          {
+            className: 'inheritance',
+            begin: '::', end: '[ {]'
+          }
+        ]
+      }
+    ]
+  }
+});

--- a/test/markup/ryton/basic.expect.txt
+++ b/test/markup/ryton/basic.expect.txt
@@ -1,0 +1,27 @@
+<span class="hljs-keyword">module</span> <span class="hljs-keyword">import</span> { std.RuVix.App }
+
+<span class="hljs-class"><span class="hljs-keyword">pack</span> <span class="hljs-title">TextEditor</span></span> {
+    <span class="hljs-function"><span class="hljs-keyword">init</span></span> {
+        <span class="hljs-keyword">this</span>.app = App.<span class="hljs-built_in">init</span>(<span class="hljs-literal">none</span>)
+        <span class="hljs-keyword">this</span>.effects = Effects.<span class="hljs-built_in">init</span>(<span class="hljs-keyword">this</span>.app)
+    }
+
+    <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">create_ui</span></span> {
+        <span class="hljs-keyword">this</span>.editor = <span class="hljs-keyword">this</span>.app.create_widget(<span class="hljs-string">'TextInput'</span>,
+            size_hint=(<span class="hljs-number">0.95</span>, <span class="hljs-number">0.85</span>),
+            font_name=<span class="hljs-string">'JetBrainsMono'</span>
+        )
+    }
+
+    <span class="hljs-class"><span class="hljs-keyword">table</span> <span class="hljs-title">Config</span></span> {
+        <span class="hljs-string">'theme'</span>: <span class="hljs-string">"dark"</span>
+        <span class="hljs-string">'font_size'</span>: <span class="hljs-number">14</span>
+        <span class="hljs-string">'color'</span> <span class="hljs-operator">:=</span> load_colors()
+    }
+}
+
+<span class="hljs-meta">#ZigModule</span>(
+    <span class="hljs-keyword">fn</span> calculate(x: <span class="hljs-type">i32</span>) <span class="hljs-type">i32</span> {
+        <span class="hljs-keyword">return</span> x * <span class="hljs-number">2</span>;
+    }
+) <span class="hljs-operator">-></span> fast_math

--- a/test/markup/ryton/basic.txt
+++ b/test/markup/ryton/basic.txt
@@ -1,0 +1,34 @@
+module import {
+    std.RuVix.App 
+}
+
+pylib: requests
+
+trash_cleaner = true
+
+pack TextEditor {
+    init {
+        this.app = App.init(none)
+        this.effects = Effects.init(this.app)
+    }
+
+    func create_ui {
+        this.editor = this.app.create_widget('TextInput',
+            size_hint=(0.95, 0.85),
+            font_name='JetBrainsMono'
+        )
+    }
+
+    table Config {
+        'theme': "dark"
+        'font_size': 14
+        'color' := load_colors()
+    }
+}
+
+#ZigModule(
+    fn calculate(x: i32) i32 {
+        return x * 2;
+    }
+) -> fast_math
+


### PR DESCRIPTION
Add Ryton Programming Language Support

### Changes
- Added syntax highlighting for Ryton programming language
- Added src/languages/ryton.js with language definition
- Includes support for:
  - MetaTable syntax
  - Zig code blocks
  - Special operators (::, =>, |>, <=>, >>)
  - Built-in keywords and types
  - String interpolation
  - Comments and documentation blocks

### Checklist
- [x] Added markup tests in test/markup/ryton/
- [x] Updated CHANGES.md with: