### PR TITLE
fix(ruby) symbols, string interpolation, class names with underscores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Version 11.11.2
+
+Core Grammars:
+
+- fix(ruby) symbols, string interpolation, class names with underscores
+
+
 ## Version 11.11.1
 
 - Fixes regression with Rust grammar.

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -115,7 +115,7 @@ export default function(hljs) {
     begin: /#\{/,
     end: /\}/,
     keywords: RUBY_KEYWORDS,
-    relevance: 10
+    relevance: 2
   };
   const STRING_INTERPOLABLE = {
     className: 'string',

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -11,7 +11,7 @@ export default function(hljs) {
   const regex = hljs.regex;
   const RUBY_METHOD_RE = '([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)';
   // TODO: move concepts like CAMEL_CASE into `modes.js`
-  const CLASS_NAME_RE = /\b([A-Z]+[a-z0-9_]+)+[A-Z]*/;
+  const CLASS_NAME_RE = /\b([A-Z]+[a-z0-9_]*)+[A-Z]*/;
   // very popular ruby built-ins that one might even assume
   // are actual keywords (despite that not being the case)
   const PSEUDO_KWS = [
@@ -362,7 +362,7 @@ export default function(hljs) {
     },
     {
       className: 'symbol',
-      begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:',
+      begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:(?!:)',
       relevance: 0
     },
     {

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -115,7 +115,7 @@ export default function(hljs) {
     className: 'subst',
     begin: /#\{/,
     end: /\}/,
-    keywords: RUBY_KEYWORDS,
+    keywords: RUBY_KEYWORDS
   };
   const STRING_INTERPOLABLE = {
     className: 'string',
@@ -134,35 +134,35 @@ export default function(hljs) {
       },
       {
         begin: /%[QWx]?\(/,
-        end: /\)/,
+        end: /\)/
       },
       {
         begin: /%[QWx]?\[/,
-        end: /\]/,
+        end: /\]/
       },
       {
         begin: /%[QWx]?\{/,
-        end: /\}/,
+        end: /\}/
       },
       {
         begin: /%[QWx]?</,
-        end: />/,
+        end: />/
       },
       {
         begin: /%[QWx]?\//,
-        end: /\//,
+        end: /\//
       },
       {
         begin: /%[QWx]?%/,
-        end: /%/,
+        end: /%/
       },
       {
         begin: /%[QWx]?-/,
-        end: /-/,
+        end: /-/
       },
       {
         begin: /%[QWx]?\|/,
-        end: /\|/,
+        end: /\|/
       },
       // heredocs
       {
@@ -194,35 +194,35 @@ export default function(hljs) {
       },
       {
         begin: /%[qw]?\(/,
-        end: /\)/,
+        end: /\)/
       },
       {
         begin: /%[qw]?\[/,
-        end: /\]/,
+        end: /\]/
       },
       {
         begin: /%[qw]?\{/,
-        end: /\}/,
+        end: /\}/
       },
       {
         begin: /%[qw]?</,
-        end: />/,
+        end: />/
       },
       {
         begin: /%[qw]?\//,
-        end: /\//,
+        end: /\//
       },
       {
         begin: /%[qw]?%/,
-        end: /%/,
+        end: /%/
       },
       {
         begin: /%[qw]?-/,
-        end: /-/,
+        end: /-/
       },
       {
         begin: /%[qw]?\|/,
-        end: /\|/,
+        end: /\|/
       },
       // in the following expressions, \B in the beginning suppresses recognition of ?-sequences
       // where ? is the last character of a preceding identifier, as in: `func?4`

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -375,7 +375,7 @@ export default function(hljs) {
     METHOD_DEFINITION,
     {
       // swallow namespace qualifiers before symbols
-      begin: hljs.IDENT_RE + '::'
+      begin: '::'
     },
     {
       className: 'symbol',
@@ -384,7 +384,7 @@ export default function(hljs) {
     },
     {
       className: 'symbol',
-      begin: '(?<!:):(?!\\s|:)',
+      begin: ':(?!\\s)',
       contains: [
         { begin: /'/, end: /'/ },
         {

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -311,7 +311,7 @@ export default function(hljs) {
 
   const UPPER_CASE_CONSTANT = {
     relevance: 0,
-    match: /\b[A-Z][A-Z_0-9]+\b/,
+    match: /\b[A-Z][A-Z_0-9]*\b/,
     className: "variable.constant"
   };
 

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -10,9 +10,8 @@ Category: common, scripting
 export default function(hljs) {
   const regex = hljs.regex;
   const RUBY_METHOD_RE = '([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)';
-  const CLASS_NAME_PATTERN = '([A-Z]+[a-z0-9_]+)+[A-Z]*'
   // TODO: move concepts like CAMEL_CASE into `modes.js`
-  const CLASS_NAME_RE = new RegExp(`\\b${CLASS_NAME_PATTERN}`);
+  const CLASS_NAME_RE = /\b([A-Z]+[a-z0-9_]+)+[A-Z]*/;
   // very popular ruby built-ins that one might even assume
   // are actual keywords (despite that not being the case)
   const PSEUDO_KWS = [
@@ -295,10 +294,9 @@ export default function(hljs) {
     ]
   };
 
-  const CLASS_INHERITANCE = {
-    relevance: 0,
-    match: new RegExp(`(?<=\\s*class\\s+(${CLASS_NAME_PATTERN}::)*${CLASS_NAME_PATTERN}\\s*<\\s*(${CLASS_NAME_PATTERN}::)*)${CLASS_NAME_PATTERN}`),
-    className: "title.class.inherited"
+  const CLASS_ANCESTOR = {
+    className: "title.class.inherited",
+    match: CLASS_NAME_RE
   };
 
   // CamelCase
@@ -308,12 +306,50 @@ export default function(hljs) {
     scope: "title.class"
   };
 
+  const CLASS_SEPARATOR = {
+    match: /::/
+  };
+
+  const CLASS_KEYWORD = {
+    match: /class/,
+    scope: "keyword"
+  };
+
+  const CLASS_INHERITANCE = {
+    begin: /\s*class\b/,
+    excludeBegin: true,
+    variants: [
+      {
+        contains: [
+          CLASS_KEYWORD,
+          {
+            begin: /\s/,
+            contains: [ CLASS_REFERENCE, CLASS_SEPARATOR ],
+          },
+          {
+            begin: /<\s*/,
+            contains:  [ CLASS_ANCESTOR, CLASS_SEPARATOR ]
+          }
+        ]
+      },
+      {
+        contains: [
+          CLASS_KEYWORD,
+          {
+            begin: /\s/,
+            contains: [ CLASS_REFERENCE, CLASS_SEPARATOR ]
+          },
+        ]
+      }
+    ]
+  };
+
   const RUBY_DEFAULT_CONTAINS = [
     STRING_INTERPOLABLE,
     STRING_NONINTERPOLABLE,
     UPPER_CASE_CONSTANT,
-    CLASS_INHERITANCE,
     CLASS_REFERENCE,
+    CLASS_INHERITANCE,
     METHOD_DEFINITION,
     {
       // swallow namespace qualifiers before symbols

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -10,8 +10,9 @@ Category: common, scripting
 export default function(hljs) {
   const regex = hljs.regex;
   const RUBY_METHOD_RE = '([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)';
+  const CLASS_NAME_PATTERN = '([A-Z]+[a-z0-9_]+)+[A-Z]*'
   // TODO: move concepts like CAMEL_CASE into `modes.js`
-  const CLASS_NAME_RE = /\b([A-Z]+[a-z0-9_]*)+[A-Z]*/;
+  const CLASS_NAME_RE = new RegExp(`\\b${CLASS_NAME_PATTERN}`);
   // very popular ruby built-ins that one might even assume
   // are actual keywords (despite that not being the case)
   const PSEUDO_KWS = [
@@ -274,41 +275,6 @@ export default function(hljs) {
     ]
   };
 
-  const INCLUDE_EXTEND = {
-    match: [
-      /(include|extend)\s+/,
-      CLASS_NAME_RE
-    ],
-    scope: {
-      2: "title.class"
-    },
-    keywords: RUBY_KEYWORDS
-  };
-
-  const CLASS_DEFINITION = {
-    variants: [
-      {
-        match: [
-          /class\s+/,
-          CLASS_NAME_RE,
-          /\s+<\s+/,
-          CLASS_NAME_RE
-        ]
-      },
-      {
-        match: [
-          /\b(class|module)\s+/,
-          CLASS_NAME_RE
-        ]
-      }
-    ],
-    scope: {
-      2: "title.class",
-      4: "title.class.inherited"
-    },
-    keywords: RUBY_KEYWORDS
-  };
-
   const UPPER_CASE_CONSTANT = {
     relevance: 0,
     match: /\b[A-Z][A-Z_0-9]*\b/,
@@ -329,15 +295,10 @@ export default function(hljs) {
     ]
   };
 
-  const OBJECT_CREATION = {
+  const CLASS_INHERITANCE = {
     relevance: 0,
-    match: [
-      CLASS_NAME_RE,
-      /\.new[. (]/
-    ],
-    scope: {
-      1: "title.class"
-    }
+    match: new RegExp(`(?<=\\s*class\\s+(${CLASS_NAME_PATTERN}::)*${CLASS_NAME_PATTERN}\\s*<\\s*(${CLASS_NAME_PATTERN}::)*)${CLASS_NAME_PATTERN}`),
+    className: "title.class.inherited"
   };
 
   // CamelCase
@@ -350,10 +311,8 @@ export default function(hljs) {
   const RUBY_DEFAULT_CONTAINS = [
     STRING_INTERPOLABLE,
     STRING_NONINTERPOLABLE,
-    CLASS_DEFINITION,
-    INCLUDE_EXTEND,
-    OBJECT_CREATION,
     UPPER_CASE_CONSTANT,
+    CLASS_INHERITANCE,
     CLASS_REFERENCE,
     METHOD_DEFINITION,
     {

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -115,7 +115,6 @@ export default function(hljs) {
     begin: /#\{/,
     end: /\}/,
     keywords: RUBY_KEYWORDS,
-    relevance: 2
   };
   const STRING_INTERPOLABLE = {
     className: 'string',
@@ -135,42 +134,34 @@ export default function(hljs) {
       {
         begin: /%[QWx]?\(/,
         end: /\)/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?\[/,
         end: /\]/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?\{/,
         end: /\}/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?</,
         end: />/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?\//,
         end: /\//,
-        relevance: 2
       },
       {
         begin: /%[QWx]?%/,
         end: /%/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?-/,
         end: /-/,
-        relevance: 2
       },
       {
         begin: /%[QWx]?\|/,
         end: /\|/,
-        relevance: 2
       },
       // heredocs
       {
@@ -203,42 +194,34 @@ export default function(hljs) {
       {
         begin: /%[qw]?\(/,
         end: /\)/,
-        relevance: 2
       },
       {
         begin: /%[qw]?\[/,
         end: /\]/,
-        relevance: 2
       },
       {
         begin: /%[qw]?\{/,
         end: /\}/,
-        relevance: 2
       },
       {
         begin: /%[qw]?</,
         end: />/,
-        relevance: 2
       },
       {
         begin: /%[qw]?\//,
         end: /\//,
-        relevance: 2
       },
       {
         begin: /%[qw]?%/,
         end: /%/,
-        relevance: 2
       },
       {
         begin: /%[qw]?-/,
         end: /-/,
-        relevance: 2
       },
       {
         begin: /%[qw]?\|/,
         end: /\|/,
-        relevance: 2
       },
       // in the following expressions, \B in the beginning suppresses recognition of ?-sequences
       // where ? is the last character of a preceding identifier, as in: `func?4`

--- a/test/markup/ruby/classes.expect.txt
+++ b/test/markup/ruby/classes.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-title class_">Class</span>
+<span class="hljs-title class_">ClassName</span>
+<span class="hljs-title class_">Class_Name</span>
+<span class="hljs-title class_">ClassNAME</span>
+<span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>::<span class="hljs-title class_">Namespace</span>
+<span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>.method
+::<span class="hljs-title class_">TopLevel</span>::<span class="hljs-title class_">Class</span>

--- a/test/markup/ruby/classes.expect.txt
+++ b/test/markup/ruby/classes.expect.txt
@@ -5,3 +5,9 @@
 <span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>::<span class="hljs-title class_">Namespace</span>
 <span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>.method
 ::<span class="hljs-title class_">TopLevel</span>::<span class="hljs-title class_">Class</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Class</span>::<span class="hljs-title class_">Name</span> &lt; <span class="hljs-title class_">With</span>::<span class="hljs-title class_">Inheritance</span>
+<span class="hljs-keyword">end</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">A</span>::<span class="hljs-title class_">B</span> &lt; <span class="hljs-title class_">C</span>::<span class="hljs-title class_">D</span>
+<span class="hljs-keyword">end</span>

--- a/test/markup/ruby/classes.expect.txt
+++ b/test/markup/ruby/classes.expect.txt
@@ -6,8 +6,11 @@
 <span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>.method
 ::<span class="hljs-title class_">TopLevel</span>::<span class="hljs-title class_">Class</span>
 
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::<span class="hljs-title class_">Baz</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span> &lt; ::<span class="hljs-title class_ inherited__">Qux</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>&lt;<span class="hljs-title class_ inherited__">Qux</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>::<span class="hljs-title class_ inherited__">Quux</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::<span class="hljs-title class_">Baz</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>::<span class="hljs-title class_ inherited__">Quux</span>
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::<span class="hljs-title class_">Baz</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>::<span class="hljs-title class_ inherited__">Quux</span>::<span class="hljs-title class_ inherited__">Corge</span>
-<span class="hljs-keyword">end</span>
-
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">Child</span> &lt; <span class="hljs-title class_ inherited__">Parent</span>
-<span class="hljs-keyword">end</span>

--- a/test/markup/ruby/classes.expect.txt
+++ b/test/markup/ruby/classes.expect.txt
@@ -6,8 +6,8 @@
 <span class="hljs-title class_">ClassName</span>::<span class="hljs-title class_">With</span>.method
 ::<span class="hljs-title class_">TopLevel</span>::<span class="hljs-title class_">Class</span>
 
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">Class</span>::<span class="hljs-title class_">Name</span> &lt; <span class="hljs-title class_">With</span>::<span class="hljs-title class_">Inheritance</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::<span class="hljs-title class_">Baz</span> &lt; <span class="hljs-title class_ inherited__">Qux</span>::<span class="hljs-title class_ inherited__">Quux</span>::<span class="hljs-title class_ inherited__">Corge</span>
 <span class="hljs-keyword">end</span>
 
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">A</span>::<span class="hljs-title class_">B</span> &lt; <span class="hljs-title class_">C</span>::<span class="hljs-title class_">D</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Child</span> &lt; <span class="hljs-title class_ inherited__">Parent</span>
 <span class="hljs-keyword">end</span>

--- a/test/markup/ruby/classes.txt
+++ b/test/markup/ruby/classes.txt
@@ -6,8 +6,8 @@ ClassName::With::Namespace
 ClassName::With.method
 ::TopLevel::Class
 
-class Class::Name < With::Inheritance
+class Foo::Bar::Baz < Qux::Quux::Corge
 end
 
-class A::B < C::D
+class Child < Parent
 end

--- a/test/markup/ruby/classes.txt
+++ b/test/markup/ruby/classes.txt
@@ -6,8 +6,11 @@ ClassName::With::Namespace
 ClassName::With.method
 ::TopLevel::Class
 
+class Foo::Bar::Baz
+class Foo < Qux
+class Foo < ::Qux
+class Foo<Qux
+class Foo::Bar < Qux
+class Foo < Qux::Quux
+class Foo::Bar::Baz < Qux::Quux
 class Foo::Bar::Baz < Qux::Quux::Corge
-end
-
-class Child < Parent
-end

--- a/test/markup/ruby/classes.txt
+++ b/test/markup/ruby/classes.txt
@@ -1,0 +1,7 @@
+Class
+ClassName
+Class_Name
+ClassNAME
+ClassName::With::Namespace
+ClassName::With.method
+::TopLevel::Class

--- a/test/markup/ruby/classes.txt
+++ b/test/markup/ruby/classes.txt
@@ -5,3 +5,9 @@ ClassNAME
 ClassName::With::Namespace
 ClassName::With.method
 ::TopLevel::Class
+
+class Class::Name < With::Inheritance
+end
+
+class A::B < C::D
+end

--- a/test/markup/ruby/strings.expect.txt
+++ b/test/markup/ruby/strings.expect.txt
@@ -28,3 +28,27 @@ c = <span class="hljs-string">?\u{0AF09}</span>
 c = <span class="hljs-string">?\u{AF9}</span>
 c = <span class="hljs-string">?\u{F9}</span>
 c = <span class="hljs-string">?\u{F}</span>
+
+<span class="hljs-comment"># Interpolable Strings</span>
+<span class="hljs-string">&quot;string&quot;</span>
+<span class="hljs-string">&quot;string <span class="hljs-subst">#{var}</span>&quot;</span>
+<span class="hljs-string">`string`</span>
+<span class="hljs-string">`string <span class="hljs-subst">#{var}</span>`</span>
+<span class="hljs-string">%W[foo bar]</span>
+<span class="hljs-string">%W[foo bar <span class="hljs-subst">#{var}</span>]</span>
+<span class="hljs-string">%Q[foo bar]</span>
+<span class="hljs-string">%Q[foo bar <span class="hljs-subst">#{var}</span>]</span>
+<span class="hljs-string">%x[foo]</span>
+<span class="hljs-string">%x[foo <span class="hljs-subst">#{var}</span>]</span>
+<span class="hljs-string">&lt;&lt;~DOC
+  Multiline heredoc
+  Text <span class="hljs-subst">#{var}</span>
+DOC</span>
+
+<span class="hljs-comment"># Non-interpolable Strings</span>
+<span class="hljs-string">&#x27;string&#x27;</span>
+<span class="hljs-string">&#x27;string #{var}&#x27;</span>
+<span class="hljs-string">%q[foo]</span>
+<span class="hljs-string">%q[foo #{var}]</span>
+<span class="hljs-string">%w[foo]</span>
+<span class="hljs-string">%w[foo #{var}]</span>

--- a/test/markup/ruby/strings.txt
+++ b/test/markup/ruby/strings.txt
@@ -28,3 +28,27 @@ c = ?\u{0AF09}
 c = ?\u{AF9}
 c = ?\u{F9}
 c = ?\u{F}
+
+# Interpolable Strings
+"string"
+"string #{var}"
+`string`
+`string #{var}`
+%W[foo bar]
+%W[foo bar #{var}]
+%Q[foo bar]
+%Q[foo bar #{var}]
+%x[foo]
+%x[foo #{var}]
+<<~DOC
+  Multiline heredoc
+  Text #{var}
+DOC
+
+# Non-interpolable Strings
+'string'
+'string #{var}'
+%q[foo]
+%q[foo #{var}]
+%w[foo]
+%w[foo #{var}]

--- a/test/markup/ruby/symbols.expect.txt
+++ b/test/markup/ruby/symbols.expect.txt
@@ -1,0 +1,22 @@
+<span class="hljs-symbol">:symbol</span>
+<span class="hljs-symbol">:Symbol</span>
+<span class="hljs-symbol">:_leading</span>
+<span class="hljs-symbol">:trailing_</span>
+<span class="hljs-symbol">:contains_underscore</span>
+<span class="hljs-symbol">:symbol_CAPS</span>
+<span class="hljs-symbol">:&quot;string symbol&quot;</span>
+<span class="hljs-symbol">:&quot;interpolated <span class="hljs-subst">#{test}</span>&quot;</span>
+<span class="hljs-symbol">:&#x27;string symbol&#x27;</span>
+<span class="hljs-symbol">:&#x27;not interpolated #{test}&#x27;</span>
+method <span class="hljs-symbol">:symbol</span>
+method(<span class="hljs-symbol">:symbol</span>)
+method(&amp;<span class="hljs-symbol">:symbol</span>)
+assign=<span class="hljs-symbol">:symbol</span>
+assign = <span class="hljs-symbol">:symbol</span>
+<span class="hljs-symbol">:symbol</span>, others
+<span class="hljs-symbol">:</span>1notasymbol
+<span class="hljs-symbol">:</span><span class="hljs-string">%q[notasymbol]</span>
+
+::notsymbol
+
+<span class="hljs-symbol">hash_symbol:</span> value

--- a/test/markup/ruby/symbols.txt
+++ b/test/markup/ruby/symbols.txt
@@ -1,0 +1,22 @@
+:symbol
+:Symbol
+:_leading
+:trailing_
+:contains_underscore
+:symbol_CAPS
+:"string symbol"
+:"interpolated #{test}"
+:'string symbol'
+:'not interpolated #{test}'
+method :symbol
+method(:symbol)
+method(&:symbol)
+assign=:symbol
+assign = :symbol
+:symbol, others
+:1notasymbol
+:%q[notasymbol]
+
+::notsymbol
+
+hash_symbol: value


### PR DESCRIPTION
Also fix #3676

Change from:

<img width="232" alt="image" src="https://github.com/user-attachments/assets/aca01992-394f-4096-9c05-6297803fe021" />
<img width="235" alt="image" src="https://github.com/user-attachments/assets/d2bd335f-02df-4aed-94c5-4bd9abf27b99" />
<img width="232" alt="image" src="https://github.com/user-attachments/assets/e35852b1-15f6-451b-8765-77e31666799a" />


To:

<img width="253" alt="image" src="https://github.com/user-attachments/assets/c6180c5b-8730-403e-b1e8-966bc5b3d633" />
<img width="246" alt="image" src="https://github.com/user-attachments/assets/2b7caa5a-a9ec-46f1-ad7b-eb9c036ed7fc" />
<img width="244" alt="image" src="https://github.com/user-attachments/assets/d33ac2e2-3e28-4878-8bf8-33fc726b4617" />



### Checklist
* [x]  Added markup tests
* [x]  Updated the changelog at `CHANGES.md`
