### PR TITLE
fix(cpp) exclude keywords from function calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Core Grammars:
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
+- fix(cpp) - Exclude keywords from highlighting as function calls [Eisenwave]
 
 New Grammars:
 
@@ -107,6 +108,7 @@ CONTRIBUTORS
 [Laurel King]: https://github.com/laurelthorburn
 [Kristian Ekenes]: https://github.com/ekenes
 [Danny Winrow]: https://github.com/dannywinrow
+[Eisenwave]: https://github.com/Eisenwave/
 
 
 ## Version 11.10.0

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -425,11 +425,7 @@ export default function(hljs) {
       _hint: FUNCTION_HINTS },
     begin: regex.concat(
       /\b/,
-      /(?!decltype)/,
-      /(?!if)/,
-      /(?!for)/,
-      /(?!switch)/,
-      /(?!while)/,
+      `(?!${RESERVED_KEYWORDS.join('|')})`,
       hljs.IDENT_RE,
       regex.lookahead(/(<[^<>]+>|)\s*\(/))
   };

--- a/test/markup/cpp/function-like-keywords.expect.txt
+++ b/test/markup/cpp/function-like-keywords.expect.txt
@@ -6,3 +6,7 @@
 <span class="hljs-keyword">while</span> (ch) {}
 
 <span class="hljs-keyword">for</span> (;;) {}
+
+<span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
+
+<span class="hljs-keyword">static_assert</span>(<span class="hljs-literal">true</span>);

--- a/test/markup/cpp/function-like-keywords.txt
+++ b/test/markup/cpp/function-like-keywords.txt
@@ -6,3 +6,7 @@ switch (ch) {}
 while (ch) {}
 
 for (;;) {}
+
+void f() = delete("reason");
+
+static_assert(true);

--- a/test/markup/cpp/template-complexity.expect.txt
+++ b/test/markup/cpp/template-complexity.expect.txt
@@ -10,7 +10,7 @@
 <span class="hljs-keyword">template</span>&lt;<span class="hljs-keyword">class</span> <span class="hljs-title class_">T</span>, <span class="hljs-keyword">class</span> = std::<span class="hljs-type">enable_if_t</span>&lt;!impl::is_streamable_v&lt;<span class="hljs-type">const</span> T &amp;&gt; &amp;&amp; std::is_convertible_v&lt;<span class="hljs-type">const</span> T &amp;, std::wstring_view&gt;&gt;&gt;
 std::wostream &amp;<span class="hljs-keyword">operator</span> &lt;&lt;(std::wostream &amp;stream, <span class="hljs-type">const</span> T &amp;thing)
 {
-    <span class="hljs-keyword">return</span> stream &lt;&lt; <span class="hljs-built_in">static_cast</span>&lt;std::wstring_view&gt;(thing);
+    <span class="hljs-keyword">return</span> stream &lt;&lt; <span class="hljs-keyword">static_cast</span>&lt;std::wstring_view&gt;(thing);
 }
 
 <span class="hljs-keyword">enum struct</span> <span class="hljs-title class_">DataHolder</span> { };


### PR DESCRIPTION
Related to https://github.com/highlightjs/highlight.js/issues/4214.

The highlighter for C++ behaves treats keywords followed by parentheses as function calls (with some exceptions), and this is harmful:

```cpp
// highlighted as a function call, but is grammatically a declaration
static_assert("");

// providing a reason for deletion should not be a function call!
void awoo() = delete("reason");

// highlighted as a function call, but that is slightly forgivable
// because it's called "function-style cast"
int(0);
// ... but then why is a function-style cast with braces not a function call?!
int { 0 };
// ... and why is this other cast not a function call?!
(int) x;
```
In general, it is wrong to highlight keywords followed by parentheses as function calls. This is always wrong, not just in specific cases like `for()` or `if()`.

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
Exclude all keywords followed by parentheses from being classified as `function.dispatch = built_in`.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
