### PR TITLE
enh(cpp) add C++26 keywords, #embed, and compiler-builtin types

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -108,7 +108,11 @@ export default function(hljs) {
     scope: 'meta',
     begin: /#\s*include\b/,
     end: /$/,
-    keywords: { keyword: 'include' },
+    keywords: {
+      keyword: [
+        'include'
+      ]
+    },
     contains: [
       {
         // the `\` at the end of a line signaling continuation
@@ -128,9 +132,25 @@ export default function(hljs) {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,
     end: /$/,
-    keywords: { keyword:
-        'if else elif endif define undef warning error line '
-        + 'pragma _Pragma ifdef ifndef include' },
+    keywords: {
+      keyword: [
+        'if',
+        'else',
+        'elif',
+        'embed',
+        'endif',
+        'define',
+        'undef',
+        'warning',
+        'error',
+        'line',
+        'pragma',
+        '_Pragma',
+        'ifdef',
+        'ifndef',
+        'include'
+      ]
+    },
     contains: [
       {
         begin: /\\\n/,
@@ -153,7 +173,6 @@ export default function(hljs) {
     relevance: 0
   };
 
-  const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
   // Bounded on purpose: an unbounded quantifier here consumes an arbitrarily
   // long run of words, and when no function title follows it the engine retries
   // the title at every token boundary of that run - quadratic in the size of
@@ -187,6 +206,7 @@ export default function(hljs) {
     'constexpr',
     'constinit',
     'continue',
+    'contract_assert',
     'decltype',
     'default',
     'delete',
@@ -217,8 +237,10 @@ export default function(hljs) {
     'or',
     'or_eq',
     'override',
+    'pre',
     'private',
     'protected',
+    'post',
     'public',
     'reflexpr',
     'register',
@@ -248,8 +270,14 @@ export default function(hljs) {
     'volatile',
     'while',
     'xor',
-    'xor_eq'
+    'xor_eq',
+    '_Atomic',
+    '_BitInt'
   ];
+
+  const FUNCTION_TITLE = regex.optional(NAMESPACE_RE)
+    + `\\b(?!(?:${RESERVED_KEYWORDS.map((k) => k.replace(/\|.*/, '')).join('|')})\\b)`
+    + hljs.IDENT_RE + '\\s*\\(';
 
   // https://en.cppreference.com/w/cpp/keyword
   const RESERVED_TYPES = [

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -108,11 +108,9 @@ export default function(hljs) {
     scope: 'meta',
     begin: /#\s*include\b/,
     end: /$/,
-    keywords: {
-      keyword: [
-        'include'
-      ]
-    },
+    keywords: [
+      'include'
+    ],
     contains: [
       {
         // the `\` at the end of a line signaling continuation
@@ -132,25 +130,23 @@ export default function(hljs) {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,
     end: /$/,
-    keywords: {
-      keyword: [
-        'if',
-        'else',
-        'elif',
-        'embed',
-        'endif',
-        'define',
-        'undef',
-        'warning',
-        'error',
-        'line',
-        'pragma',
-        '_Pragma',
-        'ifdef',
-        'ifndef',
-        'include'
-      ]
-    },
+    keywords: [
+      'if',
+      'else',
+      'elif',
+      'embed',
+      'endif',
+      'define',
+      'undef',
+      'warning',
+      'error',
+      'line',
+      'pragma',
+      '_Pragma',
+      'ifdef',
+      'ifndef',
+      'include'
+    ],
     contains: [
       {
         begin: /\\\n/,
@@ -275,8 +271,10 @@ export default function(hljs) {
     '_BitInt'
   ];
 
+  // WHY: strip `|N` relevance suffixes (e.g. const_cast|10) so `|10` is not
+  // compiled as an extra empty/numeric alternative in this lookahead.
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE)
-    + `\\b(?!(?:${RESERVED_KEYWORDS.map((k) => k.replace(/\|.*/, '')).join('|')})\\b)`
+    + `\\b(?!(?:${RESERVED_KEYWORDS.map((k) => k.replace(/\|\d+/, '')).join('|')})\\b)`
     + hljs.IDENT_RE + '\\s*\\(';
 
   // https://en.cppreference.com/w/cpp/keyword

--- a/test/markup/cpp/function-declarations.expect.txt
+++ b/test/markup/cpp/function-declarations.expect.txt
@@ -23,3 +23,7 @@
 <span class="hljs-function"><span class="hljs-keyword">explicit</span> <span class="hljs-title">A</span><span class="hljs-params">()</span>: a(<span class="hljs-number">10</span>) {</span>}
 
 <span class="hljs-function"><span class="hljs-keyword">extern</span> <span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-type">int</span>)</span>, <span class="hljs-title">g</span><span class="hljs-params">(<span class="hljs-type">char</span>)</span></span>;
+
+<span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">throwing</span><span class="hljs-params">(<span class="hljs-type">int</span> x)</span> <span class="hljs-keyword">noexcept</span><span class="hljs-params">(<span class="hljs-literal">false</span>)</span></span>;
+<span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">deleted</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
+<span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">contracts</span><span class="hljs-params">(<span class="hljs-type">int</span> x)</span> <span class="hljs-keyword">pre</span><span class="hljs-params">(x &gt; <span class="hljs-number">10</span>)</span> <span class="hljs-keyword">post</span><span class="hljs-params">(r : r != <span class="hljs-number">0</span>)</span></span>;

--- a/test/markup/cpp/function-declarations.txt
+++ b/test/markup/cpp/function-declarations.txt
@@ -23,3 +23,7 @@ void A(): a(10) {}
 explicit A(): a(10) {}
 
 extern void f(int), g(char);
+
+void throwing(int x) noexcept(false);
+void deleted() = delete("reason");
+void contracts(int x) pre(x > 10) post(r : r != 0);

--- a/test/markup/cpp/function-like-keywords.expect.txt
+++ b/test/markup/cpp/function-like-keywords.expect.txt
@@ -10,3 +10,7 @@
 <span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
 
 <span class="hljs-keyword">static_assert</span>(<span class="hljs-literal">true</span>);
+<span class="hljs-keyword">contract_assert</span>(<span class="hljs-literal">false</span>);
+
+<span class="hljs-keyword">_BitInt</span>(<span class="hljs-number">64</span>) x;
+<span class="hljs-keyword">_Atomic</span>(<span class="hljs-type">int</span>) y;

--- a/test/markup/cpp/function-like-keywords.txt
+++ b/test/markup/cpp/function-like-keywords.txt
@@ -10,3 +10,7 @@ for (;;) {}
 void f() = delete("reason");
 
 static_assert(true);
+contract_assert(false);
+
+_BitInt(64) x;
+_Atomic(int) y;

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -1,5 +1,6 @@
 <span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;iostream&gt;</span></span>
 <span class="hljs-meta">#<span class="hljs-keyword">define</span> foo 1&lt;&lt;16</span>
+<span class="hljs-meta">#<span class="hljs-keyword">embed</span> <span class="hljs-string">&quot;payload.bin&quot;</span></span>
 
 <span class="hljs-meta">#<span class="hljs-keyword">ifdef</span> DEBUG</span>
 <span class="hljs-function">TYPE1 <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-type">void</span>)</span>

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -1,5 +1,6 @@
 #include <iostream>
 #define foo 1<<16
+#embed "payload.bin"
 
 #ifdef DEBUG
 TYPE1 foo(void)

--- a/tools/onePerLineKeywords.js
+++ b/tools/onePerLineKeywords.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Expand space-separated `keywords: { keyword: 'a b' + 'c' }` strings
- * into one-keyword-per-line arrays. Usage:
+ * Expand `keywords: { keyword: ... }` into a bare one-per-line array
+ * when that is the only scope (default `keyword`). Usage:
  *   node tools/onePerLineKeywords.js src/languages/cpp.js
  */
 const fs = require("fs");
@@ -13,22 +13,23 @@ if (!file) {
 }
 
 const src = fs.readFileSync(file, "utf8");
-const re = /keywords:\s*\{\s*keyword:\s*((?:'[^']*'\s*\+\s*)*'[^']*')\s*\}/g;
+const re = /keywords:\s*\{\s*keyword:\s*(?:((?:'[^']*'\s*\+\s*)*'[^']*')|\[([^\]]*)\])\s*\}/g;
 
 let count = 0;
-const out = src.replace(re, (_m, strings) => {
+const out = src.replace(re, (_m, strings, listBody) => {
   count += 1;
-  const words = [...strings.matchAll(/'([^']*)'/g)]
+  const raw = strings || listBody;
+  const words = [...raw.matchAll(/'([^']*)'/g)]
     .map((x) => x[1])
     .join(" ")
     .trim()
     .split(/\s+/);
-  const items = words.map((w) => `        '${w}'`).join(",\n");
-  return `keywords: {\n      keyword: [\n${items}\n      ]\n    }`;
+  const items = words.map((w) => `      '${w}'`).join(",\n");
+  return `keywords: [\n${items}\n    ]`;
 });
 
 if (count === 0) {
-  console.error(`no concatenated keyword strings found in ${file}`);
+  console.error(`no single-scope keyword lists found in ${file}`);
   process.exit(1);
 }
 

--- a/tools/onePerLineKeywords.js
+++ b/tools/onePerLineKeywords.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Expand space-separated `keywords: { keyword: 'a b' + 'c' }` strings
+ * into one-keyword-per-line arrays. Usage:
+ *   node tools/onePerLineKeywords.js src/languages/cpp.js
+ */
+const fs = require("fs");
+
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: node tools/onePerLineKeywords.js <grammar.js>");
+  process.exit(1);
+}
+
+const src = fs.readFileSync(file, "utf8");
+const re = /keywords:\s*\{\s*keyword:\s*((?:'[^']*'\s*\+\s*)*'[^']*')\s*\}/g;
+
+let count = 0;
+const out = src.replace(re, (_m, strings) => {
+  count += 1;
+  const words = [...strings.matchAll(/'([^']*)'/g)]
+    .map((x) => x[1])
+    .join(" ")
+    .trim()
+    .split(/\s+/);
+  const items = words.map((w) => `        '${w}'`).join(",\n");
+  return `keywords: {\n      keyword: [\n${items}\n      ]\n    }`;
+});
+
+if (count === 0) {
+  console.error(`no concatenated keyword strings found in ${file}`);
+  process.exit(1);
+}
+
+fs.writeFileSync(file, out);
+console.error(`expanded ${count} keyword list(s) in ${file}`);


### PR DESCRIPTION
Related to https://github.com/highlightjs/highlight.js/issues/4214.

### Changes
- (C++26) treat `#embed` as a known preprocessor directive
- (C++26) add `contract_assert`, `pre`, and `post` keywords
- (Clang) add `_Atomic` and `_BitInt` keywords

As for the last change, Clang supports `_Atomic` and `_BitInt` keywords in C++ mode as well, with the same semantics as in C. I am also working on a proposal that introduces bit-precise integers to C++, and either through standardization or common practice, at least `_BitInt` is expected to become a common non-standard keyword.

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`

The test expectations depend on decisions made in https://github.com/highlightjs/highlight.js/pull/4217, so I haven't written tests yet.