### PR TITLE
Ada 2022 allows `[`, `]` as brackets and `parallel` as a keyword.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,11 +7,13 @@ New Grammars:
 Core Grammars:
 
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
+- enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
 
 CONTRIBUTORS
 
 [Josh Marchand]: https://github.com/yHSJ
 [Max Liashuk]: https://github.com/probil
+[Max Reznik]: https://github.com/reznikmm
 
 ## Version 11.11.1
 

--- a/src/languages/ada.js
+++ b/src/languages/ada.js
@@ -7,7 +7,7 @@ Description: Ada is a general-purpose programming language that has great suppor
              the newest standard being Ada2012.
 */
 
-// We try to support full Ada2012
+// We try to support full Ada 2022
 //
 // We highlight all appearances of types, keywords, literals (string, char, number, bool)
 // and titles (user defined function/procedure/package)
@@ -37,7 +37,7 @@ export default function(hljs) {
   const ID_REGEX = '[A-Za-z](_?[A-Za-z0-9.])*';
 
   // bad chars, only allowed in literals
-  const BAD_CHARS = `[]\\{\\}%#'"`;
+  const BAD_CHARS = `\\{\\}%#'"`;
 
   // Ada doesn't have block comments, only line comments
   const COMMENTS = hljs.COMMENT('--', '$');
@@ -146,7 +146,8 @@ export default function(hljs) {
     "do",
     "mod",
     "requeue",
-    "xor"
+    "xor",
+    "parallel"
   ];
 
   return {

--- a/test/markup/ada/default.expect.txt
+++ b/test/markup/ada/default.expect.txt
@@ -7,7 +7,7 @@
       Error_Message : <span class="hljs-type">String</span> := Null_Ignore_Value (Error_Message_C);
    <span class="hljs-keyword">begin</span>
 
-      Named : <span class="hljs-keyword">for</span> Index <span class="hljs-keyword">in</span> Foo..Bar <span class="hljs-keyword">loop</span>
+      Named : <span class="hljs-type">parallel</span> <span class="hljs-keyword">for</span> Index <span class="hljs-keyword">in</span> Foo..Bar <span class="hljs-keyword">loop</span>
           Put (<span class="hljs-string">&quot;Hi[]{}&quot;</span>);
       <span class="hljs-keyword">end</span> <span class="hljs-keyword">loop</span> Named;
 

--- a/test/markup/ada/default.txt
+++ b/test/markup/ada/default.txt
@@ -7,7 +7,7 @@ package body Sqlite.Simple is
       Error_Message : String := Null_Ignore_Value (Error_Message_C);
    begin
 
-      Named : for Index in Foo..Bar loop
+      Named : parallel for Index in Foo..Bar loop
           Put ("Hi[]{}");
       end loop Named;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow `[`, `]` in Ada and highlight `parallel` as a keyword.

<!-- Please link to a related issue below. -->
Resolves #4224

### Changes
Allow `[`, `]` in Ada and highlight `parallel` as a keyword.

### Checklist
- [ ] Fix markup test for `parallel` keyword
- [ ] Updated the changelog at `CHANGES.md`
