### PR TITLE
enh(php) support C style and hash prefix single line comments in functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,14 @@ Core Grammars:
 
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
+- enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
 
 CONTRIBUTORS
 
 [Josh Marchand]: https://github.com/yHSJ
 [Max Liashuk]: https://github.com/probil
 [Max Reznik]: https://github.com/reznikmm
+[Antoine Musso]: https://github.com/hashar
 
 ## Version 11.11.1
 

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -414,6 +414,8 @@ export default function(hljs) {
       VARIABLE,
       LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
       hljs.C_BLOCK_COMMENT_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
       STRING,
       NUMBER,
       CONSTRUCTOR_CALL,
@@ -438,6 +440,8 @@ export default function(hljs) {
     NAMED_ARGUMENT,
     LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
     hljs.C_BLOCK_COMMENT_MODE,
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.HASH_COMMENT_MODE,
     STRING,
     NUMBER,
     CONSTRUCTOR_CALL,
@@ -566,6 +570,8 @@ export default function(hljs) {
               VARIABLE,
               LEFT_AND_RIGHT_SIDE_OF_DOUBLE_COLON,
               hljs.C_BLOCK_COMMENT_MODE,
+              hljs.C_LINE_COMMENT_MODE,
+              hljs.HASH_COMMENT_MODE,
               STRING,
               NUMBER
             ]

--- a/test/markup/php/attributes.expect.txt
+++ b/test/markup/php/attributes.expect.txt
@@ -44,12 +44,14 @@
              <span class="hljs-attr">fields</span>: [
                  <span class="hljs-string">&#x27;authorEmail&#x27;</span> =&gt; <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\Email</span>,
                  <span class="hljs-string">&#x27;shortDesc&#x27;</span> =&gt; [
-                     <span class="hljs-comment">/*something*/</span>
+                     <span class="hljs-comment">// C line comment</span>
                      <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\NotBlank</span>,
+                     <span class="hljs-comment">/* C block comment */</span>
                      <span class="hljs-keyword">new</span> <span class="hljs-title class_">Assert\Length</span>(
                          <span class="hljs-attr">max</span>: <span class="hljs-number">200</span>,
                          <span class="hljs-attr">maxMessage</span>: <span class="hljs-string">&#x27;Your short desc is too long&#x27;</span>
                      )
+                     <span class="hljs-comment"># Hash comment</span>
                  ],
              ],
              <span class="hljs-attr">allowMissingFields</span>: <span class="hljs-literal">true</span>,

--- a/test/markup/php/attributes.txt
+++ b/test/markup/php/attributes.txt
@@ -44,12 +44,14 @@ class Book
              fields: [
                  'authorEmail' => new Assert\Email,
                  'shortDesc' => [
-                     /*something*/
+                     // C line comment
                      new Assert\NotBlank,
+                     /* C block comment */
                      new Assert\Length(
                          max: 200,
                          maxMessage: 'Your short desc is too long'
                      )
+                     # Hash comment
                  ],
              ],
              allowMissingFields: true,

--- a/test/markup/php/functions.expect.txt
+++ b/test/markup/php/functions.expect.txt
@@ -49,3 +49,15 @@
     <span class="hljs-attr">label</span>: <span class="hljs-string">&#x27;foo&#x27;</span>,
     <span class="hljs-attr">time</span>:<span class="hljs-title function_ invoke__">time</span>() + <span class="hljs-keyword">array</span>(<span class="hljs-number">5</span>)[<span class="hljs-number">0</span>] + <span class="hljs-title class_">Foo</span>::<span class="hljs-variable constant_">HOUR</span>,
 );
+
+<span class="hljs-title function_ invoke__">header</span>(
+    <span class="hljs-comment">// Contained C line comment</span>
+    <span class="hljs-comment">/* Contained C block comment */</span>
+    <span class="hljs-comment"># Contained hash comment</span>
+);
+
+<span class="hljs-function"><span class="hljs-keyword">fn</span>(<span class="hljs-params">
+    <span class="hljs-variable">$x</span>, <span class="hljs-comment">// C line comment</span>
+    <span class="hljs-comment">/* C block comment */</span>
+    <span class="hljs-variable">$y</span>, <span class="hljs-comment"># Contained hash comment</span>
+</span>) =&gt;</span> <span class="hljs-variable">$x</span> / <span class="hljs-variable">$y</span>;

--- a/test/markup/php/functions.txt
+++ b/test/markup/php/functions.txt
@@ -49,3 +49,15 @@ setAlarm(
     label: 'foo',
     time:time() + array(5)[0] + Foo::HOUR,
 );
+
+header(
+    // Contained C line comment
+    /* Contained C block comment */
+    # Contained hash comment
+);
+
+fn(
+    $x, // C line comment
+    /* C block comment */
+    $y, # Contained hash comment
+) => $x / $y;


### PR DESCRIPTION
enh(php) add // and # comments in functions and attributes

functions, arrow functions parameters can contain nested comments such as:

    header( /* cache age */ 'Age: 60' );
    fn($x /* something */) => $x;

Those are C blocks comments. However PHP also support single line comments either C-style (`//`) or using hash (`#`):

    header(
        # Set caching header
        'Age: 60' // seconds
    );
    fn(
        # We like magic
        $x // something
    ) => $x;

PHP 8 attributes can also have such comments:

    #[\Deprecated(
    # A comment
    since: "2025-03-25"
    // C line comment
    #)]

Parameters of functions, arrow functions and PHP 8 attributes solely had `C_BLOCK_COMMENT_MODE`.

Add `C_LINE_COMMENT_MODE` and `HASH_COMMENT_MODE` to recognize the single line comments.

Fixes: #3655
Fixes: https://phabricator.wikimedia.org/T372404