### PR TITLE
fix(rust) ensure brackets are balanced within attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,42 +1,218 @@
-## Version 11.11.2
+## Version 11.12.0
+
+Parser Engine:
+
+- fix(parser) count named capture groups when rewriting backreferences [spokodev][]
+
+New Grammars:
+
+- add FreeDesktop config file (`.desktop` / systemd) grammar [gg582][]
+- added 3rd party Cedar grammar to SUPPORTED_LANGUAGES [Dhruv Maniya][]
+- added 3rd party DAX and M (Power Query) grammars to SUPPORTED_LANGUAGES [jiaopengzi][]
+- added 3rd party Djot grammar to SUPPORTED_LANGUAGES [Mark Scherer][]
+- added 3rd party Igor Pro grammar to SUPPORTED_LANGUAGES [Ryne Andal][]
+- added 3rd party Jaiva grammar to SUPPORTED_LANGUAGES [Lehlogonolo Poole][]
+- added 3rd party Liquidsoap grammar to SUPPORTED_LANGUAGES [Romain Beauxis][]
+- added 3rd party MoonBit grammar to SUPPORTED_LANGUAGES [Kaida-Amethyst][]
+- added 3rd party Pkl grammar to SUPPORTED_LANGUAGES [Dan Chao][]
+- added 3rd party RAScript grammar to SUPPORTED_LANGUAGES [Joshua Raphael][]
+- added 3rd party Veryl grammar to SUPPORTED_LANGUAGES [Naoya Hatta][]
+- added 3rd party Why3 grammar to SUPPORTED_LANGUAGES [JGalego][]
+- added 3rd party Xojo grammar to SUPPORTED_LANGUAGES [patricksalo][]
+- referenced existing 3rd party ES|QL grammar in SUPPORTED_LANGUAGES [Styx0x6][]
+
+Core Grammars:
+
+- fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [Mark Xian][]
+- fix(c) do not highlight C++ std types as built-ins, issue #4103 [Arron Zou][]
+- fix(c, cpp) bound the run of type tokens in front of a function name (ReDoS), issue #4362 [Jayesh Bhade][]
+- fix(c, cpp) scope angle-bracket header string to `#include`, issue #3505 [Pablo][]
+- fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, issue #3585 [David Pavlovschii][]
+- enh(cmake) add `block` and `endblock` keywords [Anonymous Maarten][]
+- fix(cmake) only highlight standalone numbers, not digits that begin an identifier (e.g. `3rdparty`), issue #4170 [Mark Xian][]
+- fix(cpp) require a word boundary before numeric literals so digits inside identifiers aren't highlighted as numbers, issue #4231 [Mark Xian][]
+- fix(crystal) stop treating integer division `//` as a regex literal [Zain Asif][]
+- enh(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
+- enh(css) add corner-shape properties [Hama Tanveer][]
+- enh(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
+- enh(dart) add highlighting for class and function names [guuido][]
+- enh(dns) highlight registered CAA property tags, issue #4475 [Joey Huang][]
+- enh(dns) improve grammar: character strings, TXT, classes, escapes, addresses [Checconio][]
+- enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
+- enh(gherkin) update keyword list [Hirse][]
+- enh(gherkin) variables can't contain whitespace [Hirse][]
+- enh(gherkin) docstrings can use backticks [Hirse][]
+- enh(go) recognize binary integer literals [spokodev][]
+- enh(groovy) support underscores in numeric literals [greymoth][]
+- fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
+- enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
+- enh(javascript) add `self` to built-in variables [Dsaquel][]
+- enh(kotlin) add `ktm` and `ktx` aliases [DarkMatter-999][]
+- fix(leaf) fix bug in Leaf keyword highlighting [Francesco Paolo Severino][]
+- fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
+- enh(llvm) support block C-style comments [utam-1][]
+- enh(lua) add Lua 5.5 `global` keyword [Nibiri][]
+- fix(markdown) don't treat a `***` or `___` thematic break as the start of bold text, issue #3719 [Mayank Gupta][]
+- enh(nsis) enhance NSIS rules [Jan T. Sott][]
+- enh(python) add missing builtins: `aiter` and `anext` (3.10), `frozendict` and `sentinel` (3.15) [Hugo van Kemenade][]
+- enh(python) correctly highlight `lazy import` syntax from PEP 810 [Peter Bierma][]
+- enh(python) support t-strings [Nicolas Le Cam][]
+- fix(ruby) don't treat the scope resolution operator `::` as a symbol, issue #4294 [Hashim Khan][]
+- enh(rust) add `safe` keyword [Frances Wingerter][]
+- enh(rust) include the `raw` borrow operator in keywords [Shiva Kiran Koninty][]
+- enh(rust) parse f16 and f128 literals [usamoi][]
+- fix(rust) allow function invocations whose names start with a keyword [Xia Li-yao][]
+- fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
+- enh(shell) match period (.) as part of shell prompt [Ian Wienand][]
+- enh(sqf) update to Arma 3 v2.22 [LouMontana][]
+- fix(xml) remove recursive sublanguage references to prevent ReDoS [petejm][]
+
+Documentation:
+
+- docs(php) explain the difference between `php` and `php-template` [Zain Asif][]
+- document LLVM IR in SUPPORTED_LANGUAGES [Jan Schultke][]
+- document the existing `pwsh` alias for PowerShell [helpimnotdrowning][]
+- list languages with category "common" in SUPPORTED_LANGUAGES [Marc Bernard][]
+- remind contributors to run `npm i` [Proliecan][]
+- fix typos in README.CDN.md [Zitrone][]
 
 Themes:
 
-- added "vs Dark " theme [Twineee1][]
+- added Equinox theme [Griffon Langyer][]
+
+Build / Tooling:
+
+- (build) allow third-party packages to override default languages [Lysxia][]
+- (build) use Trusted Publishers in the publishing pipeline [allejo][]
+- fix(types) allow RegExp in `Mode.keywords` [KJyang-0114][]
+- refactor(tools) replace `@colors/colors` with ansis [webdiscus][]
+- chore: dependency updates
+
+CONTRIBUTORS
+
+[spokodev]: https://github.com/spokodev
+[gg582]: https://github.com/gg582
+[Dhruv Maniya]: https://github.com/iamdhrv
+[jiaopengzi]: https://github.com/jiaopengzi
+[Mark Scherer]: https://github.com/dereuromark
+[Ryne Andal]: https://github.com/ryneandal
+[Lehlogonolo Poole]: https://github.com/yetnt
+[Romain Beauxis]: https://github.com/toots
+[Kaida-Amethyst]: https://github.com/Kaida-Amethyst
+[Dan Chao]: https://github.com/bioball
+[Joshua Raphael]: https://github.com/joshraphael
+[Naoya Hatta]: https://github.com/dalance
+[JGalego]: https://github.com/JGalego
+[patricksalo]: https://github.com/patricksalo
+[Styx0x6]: https://github.com/styx0x6
+[Mark Xian]: https://github.com/xianjianlf2
+[Arron Zou]: https://github.com/arronKler
+[Jayesh Bhade]: https://github.com/Jaybhade
+[Pablo]: https://github.com/MsfPablo
+[David Pavlovschii]: https://github.com/davidpavlovschi
+[Anonymous Maarten]: https://github.com/madebr
+[Zain Asif]: https://github.com/zain-asif-dev
+[Sarath Francis]: https://github.com/sarathfrancis90
+[Hama Tanveer]: https://github.com/ezforhamza
+[Konstantin Baltsat]: https://github.com/Baltsat
+[guuido]: https://github.com/guuido
+[Joey Huang]: https://github.com/oiahoon
+[Checconio]: https://github.com/Checconio
+[Hashim Khan]: https://github.com/Hashim1999164
+[Hirse]: https://github.com/Hirse
+[greymoth]: https://github.com/mahirhir
+[Hannes Wallnoefer]: https://github.com/hns
+[Dsaquel]: https://github.com/Dsaquel
+[DarkMatter-999]: https://github.com/DarkMatter-999
+[Francesco Paolo Severino]: https://github.com/fpseverino
+[arturict]: https://github.com/arturict
+[utam-1]: https://github.com/utam-1
+[Nibiri]: https://github.com/NibiriTheMan
+[Mayank Gupta]: https://github.com/Mynk11
+[Jan T. Sott]: https://github.com/idleberg
+[Hugo van Kemenade]: https://github.com/hugovk
+[Peter Bierma]: https://github.com/ZeroIntensity
+[Nicolas Le Cam]: https://github.com/KuSh
+[Frances Wingerter]: https://github.com/fw-immunant
+[Shiva Kiran Koninty]: https://github.com/skr4n
+[usamoi]: https://github.com/usamoi
+[Xia Li-yao]: https://github.com/Lysxia
+[Ian Wienand]: https://github.com/ianw
+[LouMontana]: https://github.com/LouMontana
+[petejm]: https://github.com/petejm
+[Jan Schultke]: https://github.com/eisenwave
+[helpimnotdrowning]: https://github.com/helpimnotdrowning
+[Marc Bernard]: https://github.com/mbtools
+[Proliecan]: https://github.com/Proliecan
+[Zitrone]: https://github.com/quantenzitrone
+[Griffon Langyer]: https://github.com/rfon6ngy
+[Lysxia]: https://github.com/Lysxia
+[allejo]: https://github.com/allejo
+[KJyang-0114]: https://github.com/KJyang-0114
+[webdiscus]: https://github.com/webdiscus
+
+
+## Version 11.11.2
+
+Parser Engine:
+
+- fix illegal handling at end of input code [Josh Goebel][]
 
 New Grammars:
 
 - added 3rd party Aiken grammar to SUPPORTED_LANGUAGES [Josh Marchand][]
 - added 3rd party VoltScript grammar to SUPPORTED_LANGUAGES [Chester Moses][]
-- added 3rd party Prisma grammar to SUPPORTED_LANGUAGES [SungHyun Kim][]
-- added 3rd party Magik grammar to SUPPORTED_LANGUAGES [Sebastiaan Speck][]
 - added 3rd party Gleam grammar to SUPPORTED_LANGUAGES [Filip Hoffmann][]
-- added 3rd party L4 grammar to SUPPORTED_LANGUAGES [Thomas Gorissen][]
+- added 3rd party Magik grammar to SUPPORTED_LANGUAGES [Sebastiaan Speck][]
+- added 3rd party Prisma grammar to SUPPORTED_LANGUAGES [SungHyun Kim][]
 - added 3rd party Bicep grammar to SUPPORTED_LANGUAGES [Anthony Martin][]
+- added 3rd party L4 grammar to SUPPORTED_LANGUAGES [Thomas Gorissen][]
 - added 3rd party Abc Notation grammar to SUPPORTED_LANGUAGES [NriotHrreion][]
 
 Core Grammars:
 
-- fix(javascript) correctly highlight 'for await' again [wolfgang42][]
+- fix(cpp) exclude keywords from function calls [Eisenwave][]
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
-- fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
+- fix(javascript) correctly highlight 'for await' again [wolfgang42][]
 - fix(diff) fix unified diff hunk header regex to allow unpaired numbers [Chris Wilson][]
 - enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
+- fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - enh(json) add json5 support [Kerry Shetline][]
-- fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 
 Documentation:
 
+- update link to Odin grammar to maintained version [Marian Pekár][]
+- fix type `highlight` deprecated message [Brandon Dong][]
+- fixed typo and incorrect git command [SungHyun Kim][]
+- fix CONTRIBUTING.md broken badge link [SungHyun Kim][]
 - alphabetized languages + upper-cased BASIC in SUPPORTED_LANGUAGES.md [Adam Lui][]
+- deduplicate JSON from SUPPORTED_LANGUAGES [Lukasz Czajczyk][]
 
 Themes:
 
 - Fix: cybertopia themes render correctly in shadow DOM [hbgl][]
+- added "vs Dark " theme [Twineee1][]
+
+Themes:
+
+- Added `Night Coder Ash` theme [Ashkan Shirpour][]
+- Added `Night Coder Charcoal` theme [Ashkan Shirpour][]
+- Added `Night Coder Ember` theme [Ashkan Shirpour][]
+- Added `Night Coder Flame` theme [Ashkan Shirpour][]
+- Added `Paper` theme [Ashkan Shirpour][]
+- Added `Ice` theme [Ashkan Shirpour][]
 
 CONTRIBUTORS
 
+[Josh Goebel]: https://github.com/joshgoebel
+[Marian Pekár]: https://github.com/marianpekar
+[Eisenwave]: https://github.com/Eisenwave/
+[Brandon Dong]: https://github.com/brandondong
+[SungHyun Kim]: https://github.com/witch-factory
+[Lukasz Czajczyk]: https://github.com/LukeCz
 [Josh Marchand]: https://github.com/yHSJ
 [Max Liashuk]: https://github.com/probil
 [Max Reznik]: https://github.com/reznikmm
@@ -45,7 +221,6 @@ CONTRIBUTORS
 [Antoine Musso]: https://github.com/hashar
 [Chester Moses]: https://github.com/Chester-Moses-HCL
 [Kerry Shetline]: https://github.com/kshetline
-[SungHyun Kim]: https://github.com/witch-factory
 [Adam Lui]: https://github.com/adamlui
 [Sebastiaan Speck]: https://github.com/sebastiaanspeck
 [Filip Hoffmann]: https://github.com/folospior
@@ -56,6 +231,8 @@ CONTRIBUTORS
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
 
+
+[Ashkan Shirpour]: https://github.com/a5hk
 
 ## Version 11.11.1
 
@@ -93,6 +270,9 @@ Core Grammars:
 - enh(nix) support markdown comments [h7x4][]
 - enh(nix) support basic function params [h7x4][]
 - enh(nix) better parsing of attrsets [h7x4][]
+- enh(nsis) add missing language features [idleberg][]
+- enh(nsis) add test cases [idleberg][]
+- fix(nsis) prevent overlapping keywords to conflict [idleberg][]
 - fix(c) - Fixed hex numbers with decimals  [Dxuian]
 - fix(typescript) - Fixedoptional property not highlighted correctly  [Dxuian]
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
@@ -107,10 +287,12 @@ Core Grammars:
 - fix(nix) handle backslash string escapes [h7x4][]
 - fix(nix) don't mix escapes for `"` and `''` strings [h7x4][]
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
+ - enh(dns) character strings (with escapes), DNS classes, grouping parens; fix unquoted TXT vs `;` comments [Checconio][]
+
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
 - fix(cpp) - Exclude keywords from highlighting as function calls [Eisenwave]
-
+- fix(llvm) fixed highlighting for C-style block comments [utam-1] 
 New Grammars:
 
 - added 3rd party TTCN-3 grammar to SUPPORTED_LANGUAGES [Osmocom][]
@@ -153,6 +335,7 @@ CONTRIBUTORS
 [Lavan]: https://github.com/jvlavan
 [Somya]: https://github.com/somya-05
 [guuido]: https://github.com/guuido
+[Checconio]: https://github.com/Checconio
 [clsource]: https://github.com/clsource
 [Jake Leahy]: https://github.com/ire4ever1190
 [Laurel King]: https://github.com/laurelthorburn

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,218 +1,42 @@
-## Version 11.12.0
-
-Parser Engine:
-
-- fix(parser) count named capture groups when rewriting backreferences [spokodev][]
-
-New Grammars:
-
-- add FreeDesktop config file (`.desktop` / systemd) grammar [gg582][]
-- added 3rd party Cedar grammar to SUPPORTED_LANGUAGES [Dhruv Maniya][]
-- added 3rd party DAX and M (Power Query) grammars to SUPPORTED_LANGUAGES [jiaopengzi][]
-- added 3rd party Djot grammar to SUPPORTED_LANGUAGES [Mark Scherer][]
-- added 3rd party Igor Pro grammar to SUPPORTED_LANGUAGES [Ryne Andal][]
-- added 3rd party Jaiva grammar to SUPPORTED_LANGUAGES [Lehlogonolo Poole][]
-- added 3rd party Liquidsoap grammar to SUPPORTED_LANGUAGES [Romain Beauxis][]
-- added 3rd party MoonBit grammar to SUPPORTED_LANGUAGES [Kaida-Amethyst][]
-- added 3rd party Pkl grammar to SUPPORTED_LANGUAGES [Dan Chao][]
-- added 3rd party RAScript grammar to SUPPORTED_LANGUAGES [Joshua Raphael][]
-- added 3rd party Veryl grammar to SUPPORTED_LANGUAGES [Naoya Hatta][]
-- added 3rd party Why3 grammar to SUPPORTED_LANGUAGES [JGalego][]
-- added 3rd party Xojo grammar to SUPPORTED_LANGUAGES [patricksalo][]
-- referenced existing 3rd party ES|QL grammar in SUPPORTED_LANGUAGES [Styx0x6][]
-
-Core Grammars:
-
-- fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [Mark Xian][]
-- fix(c) do not highlight C++ std types as built-ins, issue #4103 [Arron Zou][]
-- fix(c, cpp) bound the run of type tokens in front of a function name (ReDoS), issue #4362 [Jayesh Bhade][]
-- fix(c, cpp) scope angle-bracket header string to `#include`, issue #3505 [Pablo][]
-- fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, issue #3585 [David Pavlovschii][]
-- enh(cmake) add `block` and `endblock` keywords [Anonymous Maarten][]
-- fix(cmake) only highlight standalone numbers, not digits that begin an identifier (e.g. `3rdparty`), issue #4170 [Mark Xian][]
-- fix(cpp) require a word boundary before numeric literals so digits inside identifiers aren't highlighted as numbers, issue #4231 [Mark Xian][]
-- fix(crystal) stop treating integer division `//` as a regex literal [Zain Asif][]
-- enh(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
-- enh(css) add corner-shape properties [Hama Tanveer][]
-- enh(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
-- enh(dart) add highlighting for class and function names [guuido][]
-- enh(dns) highlight registered CAA property tags, issue #4475 [Joey Huang][]
-- enh(dns) improve grammar: character strings, TXT, classes, escapes, addresses [Checconio][]
-- enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
-- enh(gherkin) update keyword list [Hirse][]
-- enh(gherkin) variables can't contain whitespace [Hirse][]
-- enh(gherkin) docstrings can use backticks [Hirse][]
-- enh(go) recognize binary integer literals [spokodev][]
-- enh(groovy) support underscores in numeric literals [greymoth][]
-- fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
-- enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
-- enh(javascript) add `self` to built-in variables [Dsaquel][]
-- enh(kotlin) add `ktm` and `ktx` aliases [DarkMatter-999][]
-- fix(leaf) fix bug in Leaf keyword highlighting [Francesco Paolo Severino][]
-- fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
-- enh(llvm) support block C-style comments [utam-1][]
-- enh(lua) add Lua 5.5 `global` keyword [Nibiri][]
-- fix(markdown) don't treat a `***` or `___` thematic break as the start of bold text, issue #3719 [Mayank Gupta][]
-- enh(nsis) enhance NSIS rules [Jan T. Sott][]
-- enh(python) add missing builtins: `aiter` and `anext` (3.10), `frozendict` and `sentinel` (3.15) [Hugo van Kemenade][]
-- enh(python) correctly highlight `lazy import` syntax from PEP 810 [Peter Bierma][]
-- enh(python) support t-strings [Nicolas Le Cam][]
-- fix(ruby) don't treat the scope resolution operator `::` as a symbol, issue #4294 [Hashim Khan][]
-- enh(rust) add `safe` keyword [Frances Wingerter][]
-- enh(rust) include the `raw` borrow operator in keywords [Shiva Kiran Koninty][]
-- enh(rust) parse f16 and f128 literals [usamoi][]
-- fix(rust) allow function invocations whose names start with a keyword [Xia Li-yao][]
-- fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
-- enh(shell) match period (.) as part of shell prompt [Ian Wienand][]
-- enh(sqf) update to Arma 3 v2.22 [LouMontana][]
-- fix(xml) remove recursive sublanguage references to prevent ReDoS [petejm][]
-
-Documentation:
-
-- docs(php) explain the difference between `php` and `php-template` [Zain Asif][]
-- document LLVM IR in SUPPORTED_LANGUAGES [Jan Schultke][]
-- document the existing `pwsh` alias for PowerShell [helpimnotdrowning][]
-- list languages with category "common" in SUPPORTED_LANGUAGES [Marc Bernard][]
-- remind contributors to run `npm i` [Proliecan][]
-- fix typos in README.CDN.md [Zitrone][]
+## Version 11.11.2
 
 Themes:
 
-- added Equinox theme [Griffon Langyer][]
-
-Build / Tooling:
-
-- (build) allow third-party packages to override default languages [Lysxia][]
-- (build) use Trusted Publishers in the publishing pipeline [allejo][]
-- fix(types) allow RegExp in `Mode.keywords` [KJyang-0114][]
-- refactor(tools) replace `@colors/colors` with ansis [webdiscus][]
-- chore: dependency updates
-
-CONTRIBUTORS
-
-[spokodev]: https://github.com/spokodev
-[gg582]: https://github.com/gg582
-[Dhruv Maniya]: https://github.com/iamdhrv
-[jiaopengzi]: https://github.com/jiaopengzi
-[Mark Scherer]: https://github.com/dereuromark
-[Ryne Andal]: https://github.com/ryneandal
-[Lehlogonolo Poole]: https://github.com/yetnt
-[Romain Beauxis]: https://github.com/toots
-[Kaida-Amethyst]: https://github.com/Kaida-Amethyst
-[Dan Chao]: https://github.com/bioball
-[Joshua Raphael]: https://github.com/joshraphael
-[Naoya Hatta]: https://github.com/dalance
-[JGalego]: https://github.com/JGalego
-[patricksalo]: https://github.com/patricksalo
-[Styx0x6]: https://github.com/styx0x6
-[Mark Xian]: https://github.com/xianjianlf2
-[Arron Zou]: https://github.com/arronKler
-[Jayesh Bhade]: https://github.com/Jaybhade
-[Pablo]: https://github.com/MsfPablo
-[David Pavlovschii]: https://github.com/davidpavlovschi
-[Anonymous Maarten]: https://github.com/madebr
-[Zain Asif]: https://github.com/zain-asif-dev
-[Sarath Francis]: https://github.com/sarathfrancis90
-[Hama Tanveer]: https://github.com/ezforhamza
-[Konstantin Baltsat]: https://github.com/Baltsat
-[guuido]: https://github.com/guuido
-[Joey Huang]: https://github.com/oiahoon
-[Checconio]: https://github.com/Checconio
-[Hashim Khan]: https://github.com/Hashim1999164
-[Hirse]: https://github.com/Hirse
-[greymoth]: https://github.com/mahirhir
-[Hannes Wallnoefer]: https://github.com/hns
-[Dsaquel]: https://github.com/Dsaquel
-[DarkMatter-999]: https://github.com/DarkMatter-999
-[Francesco Paolo Severino]: https://github.com/fpseverino
-[arturict]: https://github.com/arturict
-[utam-1]: https://github.com/utam-1
-[Nibiri]: https://github.com/NibiriTheMan
-[Mayank Gupta]: https://github.com/Mynk11
-[Jan T. Sott]: https://github.com/idleberg
-[Hugo van Kemenade]: https://github.com/hugovk
-[Peter Bierma]: https://github.com/ZeroIntensity
-[Nicolas Le Cam]: https://github.com/KuSh
-[Frances Wingerter]: https://github.com/fw-immunant
-[Shiva Kiran Koninty]: https://github.com/skr4n
-[usamoi]: https://github.com/usamoi
-[Xia Li-yao]: https://github.com/Lysxia
-[Ian Wienand]: https://github.com/ianw
-[LouMontana]: https://github.com/LouMontana
-[petejm]: https://github.com/petejm
-[Jan Schultke]: https://github.com/eisenwave
-[helpimnotdrowning]: https://github.com/helpimnotdrowning
-[Marc Bernard]: https://github.com/mbtools
-[Proliecan]: https://github.com/Proliecan
-[Zitrone]: https://github.com/quantenzitrone
-[Griffon Langyer]: https://github.com/rfon6ngy
-[Lysxia]: https://github.com/Lysxia
-[allejo]: https://github.com/allejo
-[KJyang-0114]: https://github.com/KJyang-0114
-[webdiscus]: https://github.com/webdiscus
-
-
-## Version 11.11.2
-
-Parser Engine:
-
-- fix illegal handling at end of input code [Josh Goebel][]
+- added "vs Dark " theme [Twineee1][]
 
 New Grammars:
 
 - added 3rd party Aiken grammar to SUPPORTED_LANGUAGES [Josh Marchand][]
 - added 3rd party VoltScript grammar to SUPPORTED_LANGUAGES [Chester Moses][]
-- added 3rd party Gleam grammar to SUPPORTED_LANGUAGES [Filip Hoffmann][]
-- added 3rd party Magik grammar to SUPPORTED_LANGUAGES [Sebastiaan Speck][]
 - added 3rd party Prisma grammar to SUPPORTED_LANGUAGES [SungHyun Kim][]
-- added 3rd party Bicep grammar to SUPPORTED_LANGUAGES [Anthony Martin][]
+- added 3rd party Magik grammar to SUPPORTED_LANGUAGES [Sebastiaan Speck][]
+- added 3rd party Gleam grammar to SUPPORTED_LANGUAGES [Filip Hoffmann][]
 - added 3rd party L4 grammar to SUPPORTED_LANGUAGES [Thomas Gorissen][]
+- added 3rd party Bicep grammar to SUPPORTED_LANGUAGES [Anthony Martin][]
 - added 3rd party Abc Notation grammar to SUPPORTED_LANGUAGES [NriotHrreion][]
 
 Core Grammars:
 
-- fix(cpp) exclude keywords from function calls [Eisenwave][]
+- fix(javascript) correctly highlight 'for await' again [wolfgang42][]
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
-- fix(javascript) correctly highlight 'for await' again [wolfgang42][]
+- fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - fix(diff) fix unified diff hunk header regex to allow unpaired numbers [Chris Wilson][]
 - enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
-- fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - enh(json) add json5 support [Kerry Shetline][]
-- fix(csharp) Support digit separators [te-ing][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
+- fix(csharp) Support digit separators [te-ing][]
 
 Documentation:
 
-- update link to Odin grammar to maintained version [Marian Pekár][]
-- fix type `highlight` deprecated message [Brandon Dong][]
-- fixed typo and incorrect git command [SungHyun Kim][]
-- fix CONTRIBUTING.md broken badge link [SungHyun Kim][]
 - alphabetized languages + upper-cased BASIC in SUPPORTED_LANGUAGES.md [Adam Lui][]
-- deduplicate JSON from SUPPORTED_LANGUAGES [Lukasz Czajczyk][]
 
 Themes:
 
 - Fix: cybertopia themes render correctly in shadow DOM [hbgl][]
-- added "vs Dark " theme [Twineee1][]
-
-Themes:
-
-- Added `Night Coder Ash` theme [Ashkan Shirpour][]
-- Added `Night Coder Charcoal` theme [Ashkan Shirpour][]
-- Added `Night Coder Ember` theme [Ashkan Shirpour][]
-- Added `Night Coder Flame` theme [Ashkan Shirpour][]
-- Added `Paper` theme [Ashkan Shirpour][]
-- Added `Ice` theme [Ashkan Shirpour][]
 
 CONTRIBUTORS
 
-[Josh Goebel]: https://github.com/joshgoebel
-[Marian Pekár]: https://github.com/marianpekar
-[Eisenwave]: https://github.com/Eisenwave/
-[Brandon Dong]: https://github.com/brandondong
-[SungHyun Kim]: https://github.com/witch-factory
-[Lukasz Czajczyk]: https://github.com/LukeCz
 [Josh Marchand]: https://github.com/yHSJ
 [Max Liashuk]: https://github.com/probil
 [Max Reznik]: https://github.com/reznikmm
@@ -221,6 +45,7 @@ CONTRIBUTORS
 [Antoine Musso]: https://github.com/hashar
 [Chester Moses]: https://github.com/Chester-Moses-HCL
 [Kerry Shetline]: https://github.com/kshetline
+[SungHyun Kim]: https://github.com/witch-factory
 [Adam Lui]: https://github.com/adamlui
 [Sebastiaan Speck]: https://github.com/sebastiaanspeck
 [Filip Hoffmann]: https://github.com/folospior
@@ -231,8 +56,6 @@ CONTRIBUTORS
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
 
-
-[Ashkan Shirpour]: https://github.com/a5hk
 
 ## Version 11.11.1
 
@@ -270,9 +93,6 @@ Core Grammars:
 - enh(nix) support markdown comments [h7x4][]
 - enh(nix) support basic function params [h7x4][]
 - enh(nix) better parsing of attrsets [h7x4][]
-- enh(nsis) add missing language features [idleberg][]
-- enh(nsis) add test cases [idleberg][]
-- fix(nsis) prevent overlapping keywords to conflict [idleberg][]
 - fix(c) - Fixed hex numbers with decimals  [Dxuian]
 - fix(typescript) - Fixedoptional property not highlighted correctly  [Dxuian]
 - fix(ruby) - fix `|=` operator false positives (as block arguments) [Aboobacker MK]
@@ -287,12 +107,10 @@ Core Grammars:
 - fix(nix) handle backslash string escapes [h7x4][]
 - fix(nix) don't mix escapes for `"` and `''` strings [h7x4][]
 - fix(swift) - Fixed syntax highlighting for class func/var declarations [guuido]
- - enh(dns) character strings (with escapes), DNS classes, grouping parens; fix unquoted TXT vs `;` comments [Checconio][]
-
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
 - fix(cpp) - Exclude keywords from highlighting as function calls [Eisenwave]
-- fix(llvm) fixed highlighting for C-style block comments [utam-1] 
+
 New Grammars:
 
 - added 3rd party TTCN-3 grammar to SUPPORTED_LANGUAGES [Osmocom][]
@@ -335,7 +153,6 @@ CONTRIBUTORS
 [Lavan]: https://github.com/jvlavan
 [Somya]: https://github.com/somya-05
 [guuido]: https://github.com/guuido
-[Checconio]: https://github.com/Checconio
 [clsource]: https://github.com/clsource
 [Jake Leahy]: https://github.com/ire4ever1190
 [Laurel King]: https://github.com/laurelthorburn

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -25,6 +25,22 @@ export default function(hljs) {
       IDENT_RE,
       regex.lookahead(/\s*\(/))
   };
+  const META_COMMENT = [
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.COMMENT('/\\*', '\\*/', { contains: [ 'self' ] })
+  ];
+  const META_STRING = [
+    {
+      scope: 'string',
+      begin: /"/,
+      end: /"/,
+      contains: [ hljs.BACKSLASH_ESCAPE ]
+    },
+    {
+      scope: 'string',
+      begin: /b?r(#*)"(.|\n)*?"\1(?!#)/
+    }
+  ];
   const NUMBER_SUFFIX = '([ui](8|16|32|64|128|size)|f(16|32|64|128))\?';
   const KEYWORDS = [
     "abstract",
@@ -260,12 +276,27 @@ export default function(hljs) {
         begin: '#!?\\[',
         end: '\\]',
         contains: [
+          ...META_COMMENT,
+          ...META_STRING,
           {
-            scope: 'string',
-            begin: /"/,
-            end: /"/,
+            variants: [
+              {
+                begin: /\(/,
+                end: /\)/
+              },
+              {
+                begin: /\[/,
+                end: /\]/
+              },
+              {
+                begin: /\{/,
+                end: /\}/
+              }
+            ],
             contains: [
-              hljs.BACKSLASH_ESCAPE
+              'self',
+              ...META_COMMENT,
+              ...META_STRING
             ]
           }
         ]

--- a/test/markup/rust/attributes.expect.txt
+++ b/test/markup/rust/attributes.expect.txt
@@ -1,0 +1,18 @@
+<span class="hljs-meta">#[foo]</span>
+<span class="hljs-meta">#![foo]</span>
+
+<span class="hljs-meta">#[foo(bar)]</span>
+<span class="hljs-meta">#[foo = bar]</span>
+<span class="hljs-meta">#[foo(<span class="hljs-string">&quot;a \&quot;b\&quot; c&quot;</span>)]</span>
+<span class="hljs-meta">#[foo(bar = [a, b, c])]</span>
+<span class="hljs-meta">#[foo[bar]]</span>
+<span class="hljs-meta">#[foo{bar}]</span>
+
+<span class="hljs-meta">#![no_std]</span>
+<span class="hljs-meta">#[doc = <span class="hljs-string">&quot;example&quot;</span>]</span>
+<span class="hljs-meta">#[allow(unused, clippy::inline_always)]</span>
+<span class="hljs-meta">#[macro_use(foo, bar)]</span>
+<span class="hljs-meta">#[link(name = <span class="hljs-string">&quot;CoreFoundation&quot;</span>, kind = <span class="hljs-string">&quot;framework&quot;</span>)]</span>
+
+<span class="hljs-meta">#[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]</span>
+<span class="hljs-meta">#[task(binds = USB_OTG1, local = [poller])]</span>

--- a/test/markup/rust/attributes.expect.txt
+++ b/test/markup/rust/attributes.expect.txt
@@ -17,3 +17,8 @@
 <span class="hljs-meta">#[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]</span>
 <span class="hljs-meta">#[task(binds = USB_OTG1, local = [poller])]</span>
 <span class="hljs-meta">#[arg(short, long, default_values_t = [66, 77])]</span>
+
+<span class="hljs-meta">#[doc = <span class="hljs-string">r#&quot;see ] inside raw&quot;#</span>]</span>
+<span class="hljs-meta">#[foo(<span class="hljs-comment">/* ] in block */</span> bar)]</span>
+<span class="hljs-meta">#[foo(<span class="hljs-comment">// ] in line</span>
+bar)]</span>

--- a/test/markup/rust/attributes.expect.txt
+++ b/test/markup/rust/attributes.expect.txt
@@ -16,3 +16,4 @@
 
 <span class="hljs-meta">#[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]</span>
 <span class="hljs-meta">#[task(binds = USB_OTG1, local = [poller])]</span>
+<span class="hljs-meta">#[arg(short, long, default_values_t = [66, 77])]</span>

--- a/test/markup/rust/attributes.txt
+++ b/test/markup/rust/attributes.txt
@@ -1,0 +1,18 @@
+#[foo]
+#![foo]
+
+#[foo(bar)]
+#[foo = bar]
+#[foo("a \"b\" c")]
+#[foo(bar = [a, b, c])]
+#[foo[bar]]
+#[foo{bar}]
+
+#![no_std]
+#[doc = "example"]
+#[allow(unused, clippy::inline_always)]
+#[macro_use(foo, bar)]
+#[link(name = "CoreFoundation", kind = "framework")]
+
+#[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]
+#[task(binds = USB_OTG1, local = [poller])]

--- a/test/markup/rust/attributes.txt
+++ b/test/markup/rust/attributes.txt
@@ -16,3 +16,4 @@
 
 #[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]
 #[task(binds = USB_OTG1, local = [poller])]
+#[arg(short, long, default_values_t = [66, 77])]

--- a/test/markup/rust/attributes.txt
+++ b/test/markup/rust/attributes.txt
@@ -17,3 +17,8 @@
 #[rtic::app(device = lm3s6965, dispatchers = [UART0, UART1])]
 #[task(binds = USB_OTG1, local = [poller])]
 #[arg(short, long, default_values_t = [66, 77])]
+
+#[doc = r#"see ] inside raw"#]
+#[foo(/* ] in block */ bar)]
+#[foo(// ] in line
+bar)]


### PR DESCRIPTION
Fixes #4032.

### Changes
Rust attributes can contain nested brackets, braces, and parentheses. This PR adds sub-modes for these nested delimiter groups, ensuring that attribute matches ends only when nested square brackets and other delimiters are balanced.

Syntax reference: [The Rust Reference: Attributes](https://doc.rust-lang.org/reference/attributes.html#r-attributes.syntax). (The actual set of recognized bracket types is derived from *DelimTokenTree* which is defined in [Macros](https://doc.rust-lang.org/reference/macros.html#r-macro.invocation.syntax)).

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
