### PR TITLE
fix(bash): correctly highlight doctags in comments again (#4234)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ New Grammars:
 
 Core Grammars:
 
+- fix(bash) resolve regression in comment doctag highlighting [wolfgang42][]
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
 

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -38,18 +38,7 @@ export default function(hljs) {
     end: /\)/,
     contains: [ hljs.BACKSLASH_ESCAPE ]
   };
-  const COMMENT = hljs.inherit(
-    hljs.COMMENT(),
-    {
-      match: [
-        /(^|\s)/,
-        /#.*$/
-      ],
-      scope: {
-        2: 'comment'
-      }
-    }
-  );
+  const COMMENT = hljs.COMMENT(/(?<=^|\s)#/, /$/);
   const HERE_DOC = {
     begin: /<<-?\s*(?=\w+)/,
     starts: { contains: [

--- a/test/markup/bash/not-comments.expect.txt
+++ b/test/markup/bash/not-comments.expect.txt
@@ -1,3 +1,5 @@
 <span class="hljs-built_in">echo</span> asdf#qwert yuiop
 
 <span class="hljs-built_in">echo</span> asdf <span class="hljs-comment">#qwert yuiop</span>
+
+<span class="hljs-comment"># <span class="hljs-doctag">TODO:</span> this *is* a comment</span>

--- a/test/markup/bash/not-comments.txt
+++ b/test/markup/bash/not-comments.txt
@@ -1,3 +1,5 @@
 echo asdf#qwert yuiop
 
 echo asdf #qwert yuiop
+
+# TODO: this *is* a comment


### PR DESCRIPTION
### Changes
Previously, because whitespace needed to be *detected* as part of the comment, but not *highlighted* that way, the match was split and only the second part of the match was assigned a scope. However, for reasons I couldn’t figure out, it seems that the presence of multiple `scope` values breaks the `contains` highlighting logic for a mode. (Or something to that effect.)

Rather than resolving whatever’s causing that problem, this PR changes the regex to use a [lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion), thus requiring the whitespace to be there without capturing it as part of the match.

I *think* this is a **breaking change:** #3890 says that negative lookbehinds aren’t allowed in Highlight.js until v12 because of Safari support; it seems like the same is true of *positive* lookbehind, in which case merging this requires a major version bump.

Closes #4234.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`

(Full disclosure: this patch was prepared with the assistance of an LLM. However I have prepared this PR description myself, and am confident that the changes are correct.)