### PR TITLE
fix(javascript) correctly highlight 'for await' again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New Grammars:
 
 Core Grammars:
 
+- fix(javascript) correctly highlight 'for await' again [wolfgang42][]
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
 

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -387,7 +387,8 @@ export default function(hljs) {
       noneOf([
         ...ECMAScript.BUILT_IN_GLOBALS,
         "super",
-        "import"
+        "import",
+        "await",
       ].map(x => `${x}\\s*\\(`)),
       IDENT_RE, regex.lookahead(/\s*\(/)),
     className: "title.function",

--- a/test/markup/javascript/keywords.expect.txt
+++ b/test/markup/javascript/keywords.expect.txt
@@ -11,4 +11,7 @@
       <span class="hljs-keyword">return</span> <span class="hljs-regexp">/\d+[\s/]/g</span>;
   }
   <span class="hljs-keyword">using</span> val = <span class="hljs-title function_">condition</span>();
+  <span class="hljs-keyword">for</span> <span class="hljs-keyword">await</span> (<span class="hljs-keyword">const</span> item <span class="hljs-keyword">of</span> items) {
+    <span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(item);
+  }
 }

--- a/test/markup/javascript/keywords.txt
+++ b/test/markup/javascript/keywords.txt
@@ -11,4 +11,7 @@ function $initHighlight(block, cls) {
       return /\d+[\s/]/g;
   }
   using val = condition();
+  for await (const item of items) {
+    console.log(item);
+  }
 }


### PR DESCRIPTION
Fixes highlighting for `for await (foo) {}`, which had regressed.

Closes #4235.

### Changes
The `FUNCTION_CALL` highlighting function has a list of excluded keywords; adding `await` there fixed the highlighting.

However, I’m not sure this is the correct fix. I notice there is another special case as well:

https://github.com/highlightjs/highlight.js/blob/85b20421a2620b765508f16289e0592e0563cfcb/src/languages/javascript.js#L557-L561

This implies to me that perhaps something in this grammar is in the wrong order, or needs its relevance adjusted, but that seems like a much bigger change and I’m having a hard time figuring out what it would need to look like. 

Also, it is technically possible (if very confusing) to have a function called `await`, and this would be highlighted incorrectly:
```js
async function await() {}
await await()
```

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
