### PR TITLE
Fix for CSS unicode-range support, issue #4253.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - fix(diff) fix unified diff hunk header regex to allow unpaired numbers [Chris Wilson][]
 - enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
+- fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 
 CONTRIBUTORS
 
@@ -23,6 +24,7 @@ CONTRIBUTORS
 [Chris Wilson]: https://github.com/sushicw
 [Antoine Musso]: https://github.com/hashar
 [Chester Moses]: https://github.com/Chester-Moses-HCL
+[Kerry Shetline]: https://github.com/kshetline
 
 
 ## Version 11.11.1

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -73,9 +73,10 @@ export default function(hljs) {
           modes.HEXCOLOR,
           modes.IMPORTANT,
           modes.CSS_NUMBER_MODE,
+          modes.UNICODE_RANGE,
           ...STRINGS,
           // needed to highlight these as strings and to avoid issues with
-          // illegal characters that might be inside urls that would tigger the
+          // illegal characters that might be inside urls that would trigger the
           // languages illegal stack
           {
             begin: /(url|data-uri)\(/,

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -7,7 +7,11 @@ export const MODES = (hljs) => {
     BLOCK_COMMENT: hljs.C_BLOCK_COMMENT_MODE,
     HEXCOLOR: {
       scope: 'number',
-      begin: /#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/
+      begin: /#(([0-9A-F]{3,4})|(([0-9A-F]{2}){3,4}))\b/i
+    },
+    UNICODE_RANGE: {
+      scope: 'number',
+      begin: /\bU\+[0-9A-F][0-9A-F?]{0,4}(-[0-9A-F][0-9A-F]{0,4})?/i
     },
     FUNCTION_DISPATCH: {
       className: "built_in",
@@ -777,6 +781,7 @@ export const ATTRIBUTES = [
   'transition-timing-function',
   'translate',
   'unicode-bidi',
+  'unicode-range',
   'user-modify',
   'user-select',
   'vector-effect',

--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -54,7 +54,7 @@
   <span class="hljs-attribute">font-variant</span>: no-common-ligatures proportional-nums;
   <span class="hljs-attribute">font-feature-settings</span>: <span class="hljs-string">&quot;liga&quot;</span> <span class="hljs-number">0</span>;
   <span class="hljs-attribute">font-variation-settings</span>: <span class="hljs-string">&quot;xhgt&quot;</span> <span class="hljs-number">0.7</span>;
-  <span class="hljs-comment">/* unicode-range: U+0025-00FF, U+4??; */</span>
+  <span class="hljs-attribute">unicode-range</span>: <span class="hljs-number">U+0025-00FF</span>, <span class="hljs-number">U+4??</span>;
   <span class="hljs-comment">/* it&#x27;s not 100% clear how url and format should be highlighted universally */</span>
   <span class="hljs-comment">/* src: url(&quot;/fonts/OpenSans-Regular-webfont.woff2&quot;) format(&quot;woff2&quot;),
        url(&quot;/fonts/OpenSans-Regular-webfont.woff&quot;) format(&quot;woff&quot;); */</span>

--- a/test/markup/css/css_consistency.txt
+++ b/test/markup/css/css_consistency.txt
@@ -54,7 +54,7 @@ a[href*="example"] {}
   font-variant: no-common-ligatures proportional-nums;
   font-feature-settings: "liga" 0;
   font-variation-settings: "xhgt" 0.7;
-  /* unicode-range: U+0025-00FF, U+4??; */
+  unicode-range: U+0025-00FF, U+4??;
   /* it's not 100% clear how url and format should be highlighted universally */
   /* src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
        url("/fonts/OpenSans-Regular-webfont.woff") format("woff"); */


### PR DESCRIPTION
Added support for CSS unicode-range keyword and associate range arguments.
Resolves issue #4253

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
