### PR TITLE
Add support for JSON5 as an alias of JavaScript.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - fix(diff) fix unified diff hunk header regex to allow unpaired numbers [Chris Wilson][]
 - enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
+- enh(javascript) add json5 as alias for javascript [Kerry Shetline][]
 
 CONTRIBUTORS
 
@@ -23,6 +24,7 @@ CONTRIBUTORS
 [Chris Wilson]: https://github.com/sushicw
 [Antoine Musso]: https://github.com/hashar
 [Chester Moses]: https://github.com/Chester-Moses-HCL
+[Kerry Shetline]: https://github.com/kshetline
 
 
 ## Version 11.11.1

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -115,7 +115,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | JSON                    | json, jsonc            |         |
 | JSONata                 | jsonata                | [highlightjs-jsonata](https://github.com/DevDimov/highlightjs-jsonata) |
 | Java                    | java, jsp              |         |
-| JavaScript              | javascript, js, jsx    |         |
+| JavaScript              | javascript, js, json5, jsx    |         |
 | Jolie                   | jolie, iol, ol         | [highlightjs-jolie](https://github.com/xiroV/highlightjs-jolie) |
 | Julia                   | julia, jl               |         |
 | Julia REPL              | julia-repl             |         |

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -453,11 +453,11 @@ export default function(hljs) {
 
   return {
     name: 'JavaScript',
-    aliases: ['js', 'jsx', 'mjs', 'cjs'],
+    aliases: ['js', 'json5', 'jsx', 'mjs', 'cjs'],
     keywords: KEYWORDS,
     // this will be extended by TypeScript
     exports: { PARAMS_CONTAINS, CLASS_REFERENCE },
-    illegal: /#(?![$_A-z])/,
+    illegal: /#(?![$_A-Z])/i,
     contains: [
       hljs.SHEBANG({
         label: "shebang",

--- a/test/detect/json5/default.txt
+++ b/test/detect/json5/default.txt
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "apples",
+    "count": [12000, 20000],
+    "description": {"text": "...", "sensitive": false}
+  },
+  { // Like JSON, but can also include comments and unquoted identifiers.
+    title: "oranges",
+    count: [17500, null, 0x1F2B], // Hexadecimal allowed
+    description: {'text': '...', 'sensitive': false} /* Single-quoted strings allowed */
+  }, // Trailing commas allowed
+]

--- a/test/markup/json5/default.expect.txt
+++ b/test/markup/json5/default.expect.txt
@@ -1,0 +1,12 @@
+[
+  {
+    <span class="hljs-string">&quot;title&quot;</span>: <span class="hljs-string">&quot;apples&quot;</span>,
+    <span class="hljs-string">&quot;count&quot;</span>: [<span class="hljs-number">12000</span>, <span class="hljs-number">20000</span>],
+    <span class="hljs-string">&quot;description&quot;</span>: {<span class="hljs-string">&quot;text&quot;</span>: <span class="hljs-string">&quot;...&quot;</span>, <span class="hljs-string">&quot;sensitive&quot;</span>: <span class="hljs-literal">false</span>}
+  },
+  { <span class="hljs-comment">// Like JSON, but can also include comments and unquoted identifiers.</span>
+    <span class="hljs-attr">title</span>: <span class="hljs-string">&quot;oranges&quot;</span>,
+    <span class="hljs-attr">count</span>: [<span class="hljs-number">17500</span>, <span class="hljs-literal">null</span>, <span class="hljs-number">0x1F2B</span>], <span class="hljs-comment">// Hexadecimal allowed</span>
+    <span class="hljs-attr">description</span>: {<span class="hljs-string">&#x27;text&#x27;</span>: <span class="hljs-string">&#x27;...&#x27;</span>, <span class="hljs-string">&#x27;sensitive&#x27;</span>: <span class="hljs-literal">false</span>} <span class="hljs-comment">/* Single-quoted strings allowed */</span>
+  }, <span class="hljs-comment">// Trailing commas allowed</span>
+]

--- a/test/markup/json5/default.txt
+++ b/test/markup/json5/default.txt
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "apples",
+    "count": [12000, 20000],
+    "description": {"text": "...", "sensitive": false}
+  },
+  { // Like JSON, but can also include comments and unquoted identifiers.
+    title: "oranges",
+    count: [17500, null, 0x1F2B], // Hexadecimal allowed
+    description: {'text': '...', 'sensitive': false} /* Single-quoted strings allowed */
+  }, // Trailing commas allowed
+]


### PR DESCRIPTION
Simple addition of JSON5 as an alias for JavaScript.

Resolves #4255

### Changes

In addition to simply adding 'json5' to the javascript.js alias list, I noticed a very suspicious looking regex just a few lines below the alias list, so I've included a fix for that issue as well. I can make this fix and all tests still pass, so I think including this change is a good idea. The suspicious regex, at line 460, is this:

```javascript
    illegal: /#(?![$_A-z])/,
```

It seems highly doubtful this was meant to be the range from uppercase A to lowercase z, which isn't just letters, but the punctuation " [ \ ] _ ` " as well.


### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
- [x] Updated aliases listed for JavaScript at `SUPPORTED_LANGUAGES.md`
