### PR TITLE
Add 3rd party Magik grammar to Supported Languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ New Grammars:
 
 - added 3rd party Aiken grammar to SUPPORTED_LANGUAGES [Josh Marchand][]
 - added 3rd party VoltScript grammar to SUPPORTED_LANGUAGES [Chester Moses][]
+- added 3rd party Magik grammar to SUPPORTED_LANGUAGES [Sebastiaan Speck][]
 
 Core Grammars:
 
@@ -28,6 +29,7 @@ CONTRIBUTORS
 [Antoine Musso]: https://github.com/hashar
 [Chester Moses]: https://github.com/Chester-Moses-HCL
 [Adam Lui]: https://github.com/adamlui
+[Sebastiaan Speck]: https://github.com/sebastiaanspeck
 
 
 ## Version 11.11.1

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -135,6 +135,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Lua                     | lua, pluto             |         |
 | Luau                    | luau                   | [highlightjs-luau](https://github.com/highlightjs/highlightjs-luau) |
 | Macaulay2               | macaulay2              | [highlightjs-macaulay2](https://github.com/d-torrance/highlightjs-macaulay2) |
+| Magik                   | magik                  | [highlightjs-magik](https://github.com/sebastiaanspeck/highlightjs-magik) |
 | Makefile                | makefile, mk, mak, make |        |
 | Markdown                | markdown, md, mkdown, mkd |      |
 | Mathematica             | mathematica, mma, wl   |         |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Added [highlightjs-magik](https://github.com/sebastiaanspeck/highlightjs-magik) to SUPPORTED_LANGUAGES.md

### Checklist
- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
