### PR TITLE
Fix dead reference to non-existing template repository

### DIFF
--- a/extra/3RD_PARTY_QUICK_START.md
+++ b/extra/3RD_PARTY_QUICK_START.md
@@ -10,7 +10,7 @@ So you'd like to create and share your own language definition for Highlight.js.
 - [ ] Clone the main [highlight-js](https://github.com/highlightjs/highlight.js) repository from GitHub
 - [ ] Read our [Language Contributor Checklist](https://highlightjs.readthedocs.io/en/latest/language-contribution.html)
 - [ ] Review the [Language Definition Guide](https://highlightjs.readthedocs.io/en/latest/language-guide.html)
-- [ ] Start with our [repository template](https://github.com/highlightjs/highlightjs-language-template) to more easily follow the suggested layout. (this isn't ready yet!)
+- [ ] Start with our [repository template](https://github.com/sebastiaanspeck/highlightjs-language-template) to more easily follow the suggested layout. (this isn't ready yet!)
 
 ## Create your repository
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

Resolves #3038

### Changes
<!--- Describe your changes -->

Added a link to an up-to-date and working template repository. Feel free to migrate my template repository to highlight.js organisation.

### Checklist
- [x] Added markup tests, or they don't apply here because it doesn’t fix/update any grammar
- [x] Updated the changelog at `CHANGES.md`, doesn't apply here because nothing really changed
