### PR TITLE
fix(sql) escaped single quotes breaks highlight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Core Grammars:
 - fix(ex) adds support for `?'` char literal and missing `defguardp` keyword [Kevin Bloch][]
 - fix(diff) fix unified diff hunk header regex to allow unpaired numbers [Chris Wilson][]
 - enh(php) support single line and hash comments in attributes, constructor and functions [Antoine Musso][]
+- fix(sql) escaped single quotes breaks highlight [EN Systems][]
 
 Documentation:
 
@@ -34,6 +35,7 @@ CONTRIBUTORS
 [Adam Lui]: https://github.com/adamlui
 [Sebastiaan Speck]: https://github.com/sebastiaanspeck
 [Filip Hoffmann]: https://github.com/folospior
+[EN Systems]: https://github.com/erikn69
 
 
 ## Version 11.11.1

--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -29,7 +29,7 @@ export default function(hljs) {
       {
         begin: /'/,
         end: /'/,
-        contains: [ { match: /''/ } ]
+        contains: [ { match: /\\./ }, { match: /''/ } ]
       }
     ]
   };

--- a/test/markup/sql/string-types.expect.txt
+++ b/test/markup/sql/string-types.expect.txt
@@ -1,7 +1,12 @@
-<span class="hljs-keyword">SELECT</span> <span class="hljs-string">&#x27;\&#x27;</span>;
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">&#x27;&#x27;</span>;
+
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">&#x27;\&#x27;&#x27;</span>;
+
+<span class="hljs-keyword">SELECT</span> <span class="hljs-string">&#x27;\\&#x27;</span>;
 
 <span class="hljs-comment">-- this is not a string in SQL, it&#x27;s an identifier</span>
 <span class="hljs-keyword">SELECT</span> &quot;name&quot; <span class="hljs-keyword">from</span> users;
 
 <span class="hljs-comment">-- not in the SQL spec</span>
-<span class="hljs-keyword">SELECT</span> `\`;
+<span class="hljs-keyword">SELECT</span> ``;
+<span class="hljs-keyword">SELECT</span> `\``;

--- a/test/markup/sql/string-types.txt
+++ b/test/markup/sql/string-types.txt
@@ -1,7 +1,12 @@
-SELECT '\';
+SELECT '';
+
+SELECT '\'';
+
+SELECT '\\';
 
 -- this is not a string in SQL, it's an identifier
 SELECT "name" from users;
 
 -- not in the SQL spec
-SELECT `\`;
+SELECT ``;
+SELECT `\``;


### PR DESCRIPTION
Does this depend on the db??

Closes #4269
> Queries with escaped values breaks highlight
>![Image](https://github.com/user-attachments/assets/fc572b4e-a9ed-419e-b8e1-931f539441eb)
> 
> but the query is correct and works in the DB.
>![Image](https://github.com/user-attachments/assets/d88c4bd0-55c6-4f39-83ae-e786e444f49f)

### Changes
Backslash(`\`) check added

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
