### PR TITLE
Add CMake block command

### DIFF
--- a/src/languages/cmake.js
+++ b/src/languages/cmake.js
@@ -14,8 +14,8 @@ export default function(hljs) {
     case_insensitive: true,
     keywords: { keyword:
         // scripting commands
-        'break cmake_host_system_information cmake_minimum_required cmake_parse_arguments '
-        + 'cmake_policy configure_file continue elseif else endforeach endfunction endif endmacro '
+        'block break cmake_host_system_information cmake_minimum_required cmake_parse_arguments '
+        + 'cmake_policy configure_file continue elseif else endblock endforeach endfunction endif endmacro '
         + 'endwhile execute_process file find_file find_library find_package find_path '
         + 'find_program foreach function get_cmake_property get_directory_property '
         + 'get_filename_component get_property if include include_guard list macro '


### PR DESCRIPTION
block/endblock are scope-related commands introduced in CMake 3.25:

https://cmake.org/cmake/help/latest/command/block.html

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Support highlighting of `block`/`endblock` cmake commands.

### Checklist
- [ ] Added markup tests, or they don't apply here because trivial change
- [ ] Updated the changelog at `CHANGES.md`
