### PR TITLE
Fix: cybertopia themes render correctly in shadow DOM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@ Documentation:
 
 - alphabetized languages + upper-cased BASIC in SUPPORTED_LANGUAGES.md [Adam Lui][]
 
+Themes:
+
+- Fix: cybertopia themes render correctly in shadow DOM [hbgl][]
+
 CONTRIBUTORS
 
 [Josh Marchand]: https://github.com/yHSJ
@@ -36,6 +40,7 @@ CONTRIBUTORS
 [Sebastiaan Speck]: https://github.com/sebastiaanspeck
 [Filip Hoffmann]: https://github.com/folospior
 [Kerry Shetline]: https://github.com/kshetline
+[hbgl]: https://github.com/hbgl
 
 ## Version 11.11.1
 

--- a/src/styles/cybertopia-cherry.css
+++ b/src/styles/cybertopia-cherry.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/src/styles/cybertopia-dimmer.css
+++ b/src/styles/cybertopia-dimmer.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/src/styles/cybertopia-icecap.css
+++ b/src/styles/cybertopia-icecap.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/src/styles/cybertopia-saturated.css
+++ b/src/styles/cybertopia-saturated.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;


### PR DESCRIPTION
### Changes
The cybertopia themes used the `:root` selector to define CSS variables for theming. The `:root` selector does not work when inside a shadow DOM. To fix the issue I changed the selector `:root` to `:root, :host` to make it work in both light and shadow DOM.

### Checklist
- [x] Markup tests, because the change only related to theming
- [x] Updated the changelog at `CHANGES.md`
