### PR TITLE
Add better support for Python functions and props

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(json) add json5 support [Kerry Shetline][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- enh(python) add support for methods and properties [fibbo][]
 
 Documentation:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[fibbo]: https://github.com/fibbo
 
 
 ## Version 11.11.1

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -383,6 +383,39 @@ export default function(hljs) {
         relevance: 0
       },
       { match: /\bor\b/, scope: "keyword" },
+      // Method calls with parentheses
+      {
+        match: [
+          /\./,
+          IDENT_RE,
+          /(?=\s*\()/
+        ],
+        scope: {
+          2: "title.function.method"
+        }
+      },
+      // Chained method calls
+      {
+        match: [
+          /\./,
+          IDENT_RE,
+          /(?=\s*\.\s*\w)/
+        ],
+        scope: {
+          2: "title.function.method"
+        }
+      },
+      {
+        match: [
+          /(?<!(?:import|from)\s+[\w.]*)/,  // Negative lookbehind for import context
+          /\./,                             // Literal dot
+          IDENT_RE,                         // Property name
+          /(?!\s*[\(\[])/                   // Not followed by ( or [
+        ],
+        scope: {
+          3: "property"
+        }
+      },
       STRING,
       COMMENT_TYPE,
       hljs.HASH_COMMENT_MODE,

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -402,7 +402,7 @@ export default function(hljs) {
           /(?=\s*\()/
         ],
         scope: {
-          2: "title.function.method"
+          2: "title.function.invoke"
         }
       },
       {

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -388,7 +388,12 @@ export default function(hljs) {
         relevance: 0
       },
       { match: /\bor\b/, scope: "keyword" },
-      // Method calls with parentheses
+      {
+        beginKeywords: "from import",
+        end: /$/,
+        keywords: "from import as",
+        contains: [ hljs.HASH_COMMENT_MODE ]
+      },
       {
         match: [
           /\./,
@@ -399,26 +404,14 @@ export default function(hljs) {
           2: "title.function.method"
         }
       },
-      // Chained method calls
       {
         match: [
           /\./,
           IDENT_RE,
-          /(?=\s*\.\s*\w)/
+          /(?!\s*[\(\[])/
         ],
         scope: {
-          2: "title.function.method"
-        }
-      },
-      {
-        match: [
-          /(?<!(?:import|from)\s+[\w.]*)/,  // Negative lookbehind for import context
-          /\./,                             // Literal dot
-          IDENT_RE,                         // Property name
-          /(?!\s*[\(\[])/                   // Not followed by ( or [
-        ],
-        scope: {
-          3: "property"
+          2: "property"
         }
       },
       STRING,

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -388,6 +388,39 @@ export default function(hljs) {
         relevance: 0
       },
       { match: /\bor\b/, scope: "keyword" },
+      // Method calls with parentheses
+      {
+        match: [
+          /\./,
+          IDENT_RE,
+          /(?=\s*\()/
+        ],
+        scope: {
+          2: "title.function.method"
+        }
+      },
+      // Chained method calls
+      {
+        match: [
+          /\./,
+          IDENT_RE,
+          /(?=\s*\.\s*\w)/
+        ],
+        scope: {
+          2: "title.function.method"
+        }
+      },
+      {
+        match: [
+          /(?<!(?:import|from)\s+[\w.]*)/,  // Negative lookbehind for import context
+          /\./,                             // Literal dot
+          IDENT_RE,                         // Property name
+          /(?!\s*[\(\[])/                   // Not followed by ( or [
+        ],
+        scope: {
+          3: "property"
+        }
+      },
       STRING,
       COMMENT_TYPE,
       hljs.HASH_COMMENT_MODE,

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -389,6 +389,7 @@ export default function(hljs) {
       },
       { match: /\bor\b/, scope: "keyword" },
       {
+        // convert this to negative lookbehind in v12
         beginKeywords: "from import",
         end: /$/,
         keywords: "from import as",

--- a/test/markup/python-repl/sample.expect.txt
+++ b/test/markup/python-repl/sample.expect.txt
@@ -3,9 +3,9 @@
 &quot;foo = 42&quot;
 <span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(v)</span>
 foo = 42
-<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).rstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ method__">rstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 &quot;foo = 42
-<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).lstrip(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ method__">lstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 foo = 42&quot;
 
 <span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-string">&quot;&quot;&quot;</span></span>

--- a/test/markup/python-repl/sample.expect.txt
+++ b/test/markup/python-repl/sample.expect.txt
@@ -3,9 +3,9 @@
 &quot;foo = 42&quot;
 <span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(v)</span>
 foo = 42
-<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ method__">rstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ invoke__">rstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 &quot;foo = 42
-<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ method__">lstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
+<span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-built_in">print</span>(<span class="hljs-built_in">repr</span>(v).<span class="hljs-title function_ invoke__">lstrip</span>(<span class="hljs-string">&#x27;&quot;&#x27;</span>))</span>
 foo = 42&quot;
 
 <span class="hljs-meta prompt_">&gt;&gt;&gt;</span> <span class="language-python"><span class="hljs-string">&quot;&quot;&quot;</span></span>

--- a/test/markup/python/class_self.expect.txt
+++ b/test/markup/python/class_self.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">SelfTest</span>:
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-variable language_">self</span>.text = <span class="hljs-literal">True</span>
+        <span class="hljs-variable language_">self</span>.<span class="hljs-property">text</span> = <span class="hljs-literal">True</span>
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">method</span>(<span class="hljs-params">self</span>):
         <span class="hljs-keyword">pass</span>

--- a/test/markup/python/function-header-comments.expect.txt
+++ b/test/markup/python/function-header-comments.expect.txt
@@ -4,7 +4,7 @@
     <span class="hljs-keyword">pass</span>
 
 
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>(collections.namedtuple(<span class="hljs-string">&#x27;Test&#x27;</span>), (
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>(collections.<span class="hljs-title function_ method__">namedtuple</span>(<span class="hljs-string">&#x27;Test&#x27;</span>), (
     <span class="hljs-string">&#x27;name&#x27;</span>, <span class="hljs-comment"># comment</span>
 )):
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/function-header-comments.expect.txt
+++ b/test/markup/python/function-header-comments.expect.txt
@@ -4,7 +4,7 @@
     <span class="hljs-keyword">pass</span>
 
 
-<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>(collections.<span class="hljs-title function_ method__">namedtuple</span>(<span class="hljs-string">&#x27;Test&#x27;</span>), (
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Foo</span>(collections.<span class="hljs-title function_ invoke__">namedtuple</span>(<span class="hljs-string">&#x27;Test&#x27;</span>), (
     <span class="hljs-string">&#x27;name&#x27;</span>, <span class="hljs-comment"># comment</span>
 )):
     <span class="hljs-keyword">pass</span>

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -8,7 +8,7 @@ x = Shorty()
 <span class="hljs-keyword">if</span> <span class="hljs-literal">__debug__</span>:
     sys = <span class="hljs-built_in">__import__</span>(<span class="hljs-string">&#x27;sys&#x27;</span>)
 
-<span class="hljs-keyword">for</span> _ <span class="hljs-keyword">in</span> sys.path:
+<span class="hljs-keyword">for</span> _ <span class="hljs-keyword">in</span> sys.<span class="hljs-property">path</span>:
     <span class="hljs-built_in">print</span>(_)
 
 <span class="hljs-built_in">exec</span>(<span class="hljs-number">123</span>)

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -1,3 +1,6 @@
+<span class="hljs-keyword">from</span> base.derive <span class="hljs-keyword">import</span> test
+<span class="hljs-keyword">import</span> base.test
+
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Shorty</span>(<span class="hljs-title class_ inherited__">dict</span>):
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">len</span>(<span class="hljs-params">self</span>):
         <span class="hljs-keyword">return</span> <span class="hljs-literal">NotImplemented</span>

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -3,6 +3,7 @@
         <span class="hljs-keyword">return</span> <span class="hljs-literal">NotImplemented</span>
 
 x = Shorty()
+x.<span class="hljs-title function_ method__">len</span>()
 <span class="hljs-built_in">len</span>(x)
 
 <span class="hljs-keyword">if</span> <span class="hljs-literal">__debug__</span>:

--- a/test/markup/python/keywords.expect.txt
+++ b/test/markup/python/keywords.expect.txt
@@ -6,7 +6,7 @@
         <span class="hljs-keyword">return</span> <span class="hljs-literal">NotImplemented</span>
 
 x = Shorty()
-x.<span class="hljs-title function_ method__">len</span>()
+x.<span class="hljs-title function_ invoke__">len</span>()
 <span class="hljs-built_in">len</span>(x)
 
 <span class="hljs-keyword">if</span> <span class="hljs-literal">__debug__</span>:

--- a/test/markup/python/keywords.txt
+++ b/test/markup/python/keywords.txt
@@ -1,3 +1,6 @@
+from base.derive import test
+import base.test
+
 class Shorty(dict):
     def len(self):
         return NotImplemented

--- a/test/markup/python/keywords.txt
+++ b/test/markup/python/keywords.txt
@@ -3,6 +3,7 @@ class Shorty(dict):
         return NotImplemented
 
 x = Shorty()
+x.len()
 len(x)
 
 if __debug__:

--- a/test/markup/python/matrix-multiplication.expect.txt
+++ b/test/markup/python/matrix-multiplication.expect.txt
@@ -3,5 +3,5 @@
 
 <span class="hljs-meta">    @decorator</span>
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">f</span>(<span class="hljs-params">self, H, V, beta, r</span>):
-        S = (H @ beta - r).T @ inv(H @ V @ H.T) @ (H @ beta - r)
+        S = (H @ beta - r).<span class="hljs-property">T</span> @ inv(H @ V @ H.<span class="hljs-property">T</span>) @ (H @ beta - r)
         <span class="hljs-keyword">return</span> S

--- a/test/markup/python/methods-props.expect.txt
+++ b/test/markup/python/methods-props.expect.txt
@@ -3,8 +3,8 @@
 <span class="hljs-keyword">import</span> base.test
 <span class="hljs-keyword">import</span> pkg.sub  <span class="hljs-comment"># comment</span>
 
-x.<span class="hljs-title function_ method__">len</span>()
+x.<span class="hljs-title function_ invoke__">len</span>()
 sys.<span class="hljs-property">path</span>
-obj.<span class="hljs-property">foo</span>.<span class="hljs-title function_ method__">bar</span>()
+obj.<span class="hljs-property">foo</span>.<span class="hljs-title function_ invoke__">bar</span>()
 <span class="hljs-variable language_">self</span>.<span class="hljs-property">text</span>
 <span class="hljs-keyword">yield</span> <span class="hljs-keyword">from</span> gen.attr

--- a/test/markup/python/methods-props.expect.txt
+++ b/test/markup/python/methods-props.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-keyword">from</span> base.derive <span class="hljs-keyword">import</span> test
+<span class="hljs-keyword">from</span> pkg.sub <span class="hljs-keyword">import</span> name <span class="hljs-keyword">as</span> alias
+<span class="hljs-keyword">import</span> base.test
+<span class="hljs-keyword">import</span> pkg.sub  <span class="hljs-comment"># comment</span>
+
+x.<span class="hljs-title function_ method__">len</span>()
+sys.<span class="hljs-property">path</span>
+obj.<span class="hljs-property">foo</span>.<span class="hljs-title function_ method__">bar</span>()
+<span class="hljs-variable language_">self</span>.<span class="hljs-property">text</span>
+<span class="hljs-keyword">yield</span> <span class="hljs-keyword">from</span> gen.attr

--- a/test/markup/python/methods-props.txt
+++ b/test/markup/python/methods-props.txt
@@ -1,0 +1,10 @@
+from base.derive import test
+from pkg.sub import name as alias
+import base.test
+import pkg.sub  # comment
+
+x.len()
+sys.path
+obj.foo.bar()
+self.text
+yield from gen.attr

--- a/test/markup/python/numbers.expect.txt
+++ b/test/markup/python/numbers.expect.txt
@@ -29,7 +29,7 @@
 
 
 <span class="hljs-comment"># expressions containing numeric literals</span>
-<span class="hljs-number">0.</span>.__str__, <span class="hljs-number">1e1</span>.__str__, fn(<span class="hljs-number">.5</span>)
+<span class="hljs-number">0.</span>.<span class="hljs-property">__str__</span>, <span class="hljs-number">1e1</span>.<span class="hljs-property">__str__</span>, fn(<span class="hljs-number">.5</span>)
 <span class="hljs-number">0</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>, <span class="hljs-number">0l</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>
 <span class="hljs-number">0_0_0</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>, <span class="hljs-number">0_0_0l</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>
 <span class="hljs-number">0b0</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>, <span class="hljs-number">0b0l</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>
@@ -50,7 +50,7 @@
 <span class="hljs-number">0_0_0j</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>, <span class="hljs-number">0_0_9j</span><span class="hljs-keyword">is</span> <span class="hljs-number">0</span>
 
 <span class="hljs-comment"># expressions not containing numeric literals</span>
-x0.j
+x0.<span class="hljs-property">j</span>
 
 <span class="hljs-comment"># invalid pseudo-numeric expressions</span>
 1__0


### PR DESCRIPTION
This is an attempt to improve the syntax highlighting for Python (#4284)

It should now correctly highlight function calls, chained function calls, and properties.

### Changes
Added three more regex rules to the Python rules.

### Checklist
- [x] Added markup tests ~~TBD~~
- [x] Updated the changelog at `CHANGES.md` ~~TBD~~
