### PR TITLE
rust: add `safe` keyword

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -17,7 +17,7 @@ export default function(hljs) {
   const IDENT_RE = regex.concat(RAW_IDENTIFIER, hljs.IDENT_RE);
   // ============================================
   const FUNCTION_INVOKE = {
-    className: "title.function.invoke",
+    scope: "title.function.invoke",
     relevance: 0,
     begin: regex.concat(
       /\b/,
@@ -202,7 +202,7 @@ export default function(hljs) {
         illegal: null
       }),
       {
-        className: 'symbol',
+        scope: 'symbol',
         // negative lookahead to avoid matching `'`
         begin: /'[a-zA-Z_][a-zA-Z0-9_]*(?!')/
       },
@@ -223,7 +223,7 @@ export default function(hljs) {
         ]
       },
       {
-        className: 'number',
+        scope: 'number',
         variants: [
           { begin: '\\b0b([01_]+)' + NUMBER_SUFFIX },
           { begin: '\\b0o([0-7_]+)' + NUMBER_SUFFIX },
@@ -239,18 +239,18 @@ export default function(hljs) {
           /\s+/,
           UNDERSCORE_IDENT_RE
         ],
-        className: {
+        scope: {
           1: "keyword",
           3: "title.function"
         }
       },
       {
-        className: 'meta',
+        scope: 'meta',
         begin: '#!?\\[',
         end: '\\]',
         contains: [
           {
-            className: 'string',
+            scope: 'string',
             begin: /"/,
             end: /"/,
             contains: [
@@ -266,7 +266,7 @@ export default function(hljs) {
           /(?:mut\s+)?/,
           UNDERSCORE_IDENT_RE
         ],
-        className: {
+        scope: {
           1: "keyword",
           3: "keyword",
           4: "variable"
@@ -281,7 +281,7 @@ export default function(hljs) {
           /\s+/,
           /in/
         ],
-        className: {
+        scope: {
           1: "keyword",
           3: "variable",
           5: "keyword"
@@ -293,7 +293,7 @@ export default function(hljs) {
           /\s+/,
           UNDERSCORE_IDENT_RE
         ],
-        className: {
+        scope: {
           1: "keyword",
           3: "title.class"
         }
@@ -304,7 +304,7 @@ export default function(hljs) {
           /\s+/,
           UNDERSCORE_IDENT_RE
         ],
-        className: {
+        scope: {
           1: "keyword",
           3: "title.class"
         }
@@ -318,7 +318,7 @@ export default function(hljs) {
         }
       },
       {
-        className: "punctuation",
+        scope: "punctuation",
         begin: '->'
       },
       FUNCTION_INVOKE

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -235,6 +235,17 @@ export default function(hljs) {
       },
       {
         begin: [
+          /\bsafe/,
+          /\s+/,
+          /extern/,
+        ],
+        scope: {
+          1: "keyword",
+          3: "keyword",
+        }
+      },
+      {
+        begin: [
           /fn/,
           /\s+/,
           UNDERSCORE_IDENT_RE

--- a/test/markup/rust/extern.expect.txt
+++ b/test/markup/rust/extern.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-keyword">unsafe</span> <span class="hljs-keyword">extern</span> <span class="hljs-string">&quot;C&quot;</span> {
+<span class="hljs-keyword">unsafe</span> <span class="hljs-keyword">fn</span> <span class="hljs-title function_">foo</span>();
+safe <span class="hljs-keyword">fn</span> <span class="hljs-title function_">foo</span>();
+}

--- a/test/markup/rust/extern.txt
+++ b/test/markup/rust/extern.txt
@@ -1,0 +1,4 @@
+unsafe extern "C" {
+unsafe fn foo();
+safe fn foo();
+}


### PR DESCRIPTION
This is a "weak" keyword, only applicable in Rust 2024+ `unsafe extern` blocks: https://doc.rust-lang.org/reference/keywords.html#r-lex.keywords.weak.safe

<!--- Provide a general summary of your changes in the Title above -->

### Changes
Adds the `safe` keyword within a mode for `unsafe extern` blocks.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
