### PR TITLE
docs: use npm build scripts in 3rd-party quick start

### DIFF
--- a/extra/3RD_PARTY_QUICK_START.md
+++ b/extra/3RD_PARTY_QUICK_START.md
@@ -40,7 +40,7 @@ Switching back to your clone of the `highlight-js` core repository now, `git clo
 To test (detect and markup tests), just build Highlight.js and test it.  Your tests should be automatically run with the full suite:
 
 ```bash
-node ./tools/build.js -t node
+npm run build
 npm run test
 ```
 
@@ -62,7 +62,7 @@ Users will expect your package to include a minified CDN distributable in your `
 *The Highlight.js CDN build process will build this file for you automatically.* You can simply commit and push your repo, and done.
 
 ```bash
-node ./tools/build.js -t cdn
+npm run build-cdn
 
 ...
 Building extra/highlightjs-your-language/dist/your-language.min.js.


### PR DESCRIPTION
Hello, just a proposal to change raw command to build commands as I noticed it was in the package.json.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
