### PR TITLE
fix(haxe): after colon, highlight non-identifiers like numbers and strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(json) add json5 support [Kerry Shetline][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- fix(haxe) After colon, highlight non-identifiers like numbers and strings [Josh Tynjala][]
 
 Documentation:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[Josh Tynjala]: https://github.com/joshtynjala
 
 
 ## Version 11.11.1

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -74,7 +74,7 @@ export default function(hljs) {
       },
       {
         className: 'type', // function types
-        begin: /:[ \t]*/,
+        begin: ":[ \t]*(?=\\(|" + IDENT_RE + ")",
         end: /[^A-Za-z0-9_ \t\->]/,
         excludeBegin: true,
         excludeEnd: true,
@@ -82,7 +82,7 @@ export default function(hljs) {
       },
       {
         className: 'type', // types
-        begin: /:[ \t]*/,
+        begin: ":[ \t]*(?=" + IDENT_RE + ")",
         end: /\W/,
         excludeBegin: true,
         excludeEnd: true

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -73,19 +73,14 @@ export default function(hljs) {
         keywords: { keyword: 'if else elseif end error' }
       },
       {
-        className: 'type', // function types
-        begin: ":[ \t]*(?=\\(|" + IDENT_RE + ")",
-        end: /[^A-Za-z0-9_ \t\->]/,
-        excludeBegin: true,
-        excludeEnd: true,
-        relevance: 0
-      },
-      {
-        className: 'type', // types
-        begin: ":[ \t]*(?=" + IDENT_RE + ")",
-        end: /\W/,
-        excludeBegin: true,
-        excludeEnd: true
+        match: [
+          /:/,
+          /[ \t]*/,
+          '(?!(?:true|false|null)\\b)' + IDENT_RE
+        ],
+        scope: {
+          3: "type"
+        }
       },
       {
         match: [

--- a/test/markup/haxe/colon.expect.txt
+++ b/test/markup/haxe/colon.expect.txt
@@ -1,0 +1,2 @@
+<span class="hljs-keyword">var</span> obj = { y: <span class="hljs-literal">true</span>, z: <span class="hljs-literal">false</span>, n: <span class="hljs-literal">null</span>, t: <span class="hljs-type">Int</span> };
+<span class="hljs-keyword">var</span> cb:<span class="hljs-type">Void</span>-&gt;<span class="hljs-keyword">Void</span> = <span class="hljs-literal">null</span>;

--- a/test/markup/haxe/colon.txt
+++ b/test/markup/haxe/colon.txt
@@ -1,0 +1,2 @@
+var obj = { y: true, z: false, n: null, t: Int };
+var cb:Void->Void = null;

--- a/test/markup/haxe/default.expect.txt
+++ b/test/markup/haxe/default.expect.txt
@@ -98,11 +98,11 @@
         <span class="hljs-comment">// switch statements!</span>
         <span class="hljs-keyword">var</span> c:<span class="hljs-type">Color </span>= Color.Green;
         <span class="hljs-keyword">var</span> x:<span class="hljs-type">Int </span>= <span class="hljs-keyword">switch</span>(c) {
-            <span class="hljs-keyword">case</span> Red: <span class="hljs-type">0</span>;
-            <span class="hljs-keyword">case</span> Green: <span class="hljs-type">1</span>;
-            <span class="hljs-keyword">case</span> Blue: <span class="hljs-type">2</span>;
-            <span class="hljs-keyword">case</span> Rgb(r, g, b): <span class="hljs-type">3</span>;
-            <span class="hljs-keyword">case</span> <span class="hljs-literal">_</span>: <span class="hljs-type">-1</span>;
+            <span class="hljs-keyword">case</span> Red: <span class="hljs-number">0</span>;
+            <span class="hljs-keyword">case</span> Green: <span class="hljs-number">1</span>;
+            <span class="hljs-keyword">case</span> Blue: <span class="hljs-number">2</span>;
+            <span class="hljs-keyword">case</span> Rgb(r, g, b): <span class="hljs-number">3</span>;
+            <span class="hljs-keyword">case</span> <span class="hljs-literal">_</span>: <span class="hljs-number">-1</span>;
         }
 
         <span class="hljs-keyword">for</span>(i <span class="hljs-keyword">in</span> <span class="hljs-number">0.</span>.<span class="hljs-number">.3</span>) {
@@ -139,21 +139,24 @@
 
     <span class="hljs-keyword">private</span> <span class="hljs-keyword">inline</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">func</span></span>(a:<span class="hljs-type">Int</span>, b:<span class="hljs-type">Float</span>, ?c:<span class="hljs-type">String</span>, d:<span class="hljs-type">Bool</span>=<span class="hljs-literal">false</span>):<span class="hljs-type">Dynamic </span>{
         <span class="hljs-keyword">return</span> {
-            x: <span class="hljs-type">0</span>,
+            x: <span class="hljs-number">0</span>,
             y: <span class="hljs-type">true</span>,
             z: <span class="hljs-type">false</span>,
 
-            a: <span class="hljs-type">1</span>.<span class="hljs-number">53</span>,
-            b: <span class="hljs-type">5e10</span>,
-            c: <span class="hljs-type">-12</span>,
-            d: <span class="hljs-type">1_0_0_0_0</span>,
+            a: <span class="hljs-number">1.53</span>,
+            b: <span class="hljs-number">5e10</span>,
+            c: <span class="hljs-number">-12</span>,
+            d: <span class="hljs-number">1</span>_0_0_0_0,
 
-            i: <span class="hljs-type">10000i32</span>,
-            u: <span class="hljs-type">2147483648u32</span>,
-            l: <span class="hljs-type">10000000000i64</span>,
-            f: <span class="hljs-type">5f64</span>,
+            i: <span class="hljs-number">10000i32</span>,
+            u: <span class="hljs-number">2147483648u32</span>,
+            l: <span class="hljs-number">10000000000i64</span>,
+            f: <span class="hljs-number">5f64</span>,
 
             n: <span class="hljs-type">null</span>,
+
+            s1: <span class="hljs-string">&quot;double&quot;</span>,
+            s2: <span class="hljs-string">&#x27;single&#x27;</span>,
         };
     }
 

--- a/test/markup/haxe/default.expect.txt
+++ b/test/markup/haxe/default.expect.txt
@@ -43,7 +43,7 @@
 }
 
 <span class="hljs-meta">@author</span>(<span class="hljs-string">&quot;Santa&quot;</span>, <span class="hljs-number">24</span> - <span class="hljs-number">12</span>)
-<span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">makeWinter</span></span>(callback: <span class="hljs-type"></span>() -&gt; <span class="hljs-keyword">Void</span>) {
+<span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">makeWinter</span></span>(callback: () -&gt; <span class="hljs-keyword">Void</span>) {
     <span class="hljs-built_in">trace</span>(<span class="hljs-string">&#x27;it is winter.&#x27;</span>);
     callback();
 }
@@ -56,7 +56,7 @@
         <span class="hljs-keyword">final</span> s = <span class="hljs-string">&quot;string&quot;</span>;
         <span class="hljs-built_in">trace</span>(s.<span class="hljs-variable">$ident</span>);
 
-        <span class="hljs-keyword">final</span> m = ([<span class="hljs-string">&quot;a&quot;</span> =&gt; <span class="hljs-number">1</span>] : <span class="hljs-type"></span>$ct);
+        <span class="hljs-keyword">final</span> m = ([<span class="hljs-string">&quot;a&quot;</span> =&gt; <span class="hljs-number">1</span>] : <span class="hljs-type">$ct</span>);
 
         <span class="hljs-keyword">final</span> arr = <span class="hljs-variable">$a</span>{[<span class="hljs-keyword">macro</span> <span class="hljs-number">0</span>, <span class="hljs-keyword">macro</span> <span class="hljs-number">1</span>, <span class="hljs-keyword">macro</span> <span class="hljs-number">2</span>]};
         <span class="hljs-keyword">final</span> field = <span class="hljs-variable">$p</span>{[<span class="hljs-string">&quot;String&quot;</span>, <span class="hljs-string">&quot;fromCharCode&quot;</span>]};
@@ -83,7 +83,7 @@
 }
 
 <span class="hljs-title class_"><span class="hljs-keyword">class</span> <span class="hljs-title">Main</span> <span class="hljs-keyword"><span class="hljs-keyword">extends</span> <span class="hljs-type">BaseClass</span></span> <span class="hljs-keyword"><span class="hljs-keyword">implements</span> <span class="hljs-type">SomeFunctionality</span></span> </span>{
-    <span class="hljs-keyword">var</span> callback:<span class="hljs-type">Void-&gt;Void </span>= <span class="hljs-literal">null</span>;
+    <span class="hljs-keyword">var</span> callback:<span class="hljs-type">Void</span>-&gt;<span class="hljs-keyword">Void</span> = <span class="hljs-literal">null</span>;
     <span class="hljs-keyword">var</span> myArray:<span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt; = <span class="hljs-keyword">new</span> <span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt;();
     <span class="hljs-keyword">var</span> arr = [<span class="hljs-number">4</span>,<span class="hljs-number">8</span>,<span class="hljs-number">0</span>,<span class="hljs-number">3</span>,<span class="hljs-number">9</span>,<span class="hljs-number">1</span>,<span class="hljs-number">5</span>,<span class="hljs-number">2</span>,<span class="hljs-number">6</span>,<span class="hljs-number">7</span>];
 
@@ -96,8 +96,8 @@
         <span class="hljs-built_in">trace</span>(<span class="hljs-string">&#x27;Hi, <span class="hljs-subst">${name}</span>!&#x27;</span>);
 
         <span class="hljs-comment">// switch statements!</span>
-        <span class="hljs-keyword">var</span> c:<span class="hljs-type">Color </span>= Color.Green;
-        <span class="hljs-keyword">var</span> x:<span class="hljs-type">Int </span>= <span class="hljs-keyword">switch</span>(c) {
+        <span class="hljs-keyword">var</span> c:<span class="hljs-type">Color</span> = Color.Green;
+        <span class="hljs-keyword">var</span> x:<span class="hljs-type">Int</span> = <span class="hljs-keyword">switch</span>(c) {
             <span class="hljs-keyword">case</span> Red: <span class="hljs-number">0</span>;
             <span class="hljs-keyword">case</span> Green: <span class="hljs-number">1</span>;
             <span class="hljs-keyword">case</span> Blue: <span class="hljs-number">2</span>;
@@ -115,13 +115,13 @@
             <span class="hljs-built_in">trace</span>(<span class="hljs-string">&quot;Hey-o!&quot;</span>);
         } <span class="hljs-keyword">while</span>(<span class="hljs-literal">false</span>);
 
-        <span class="hljs-keyword">var</span> done:<span class="hljs-type">Bool </span>= <span class="hljs-literal">false</span>;
+        <span class="hljs-keyword">var</span> done:<span class="hljs-type">Bool</span> = <span class="hljs-literal">false</span>;
         <span class="hljs-keyword">while</span>(!done) {
             done = <span class="hljs-literal">true</span>;
         }
 
-        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">42</span>);
-        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
+        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int</span> = <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">42</span>);
+        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int</span> = <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
 
         <span class="hljs-keyword">try</span> {
             <span class="hljs-keyword">throw</span> <span class="hljs-string">&quot;error&quot;</span>;
@@ -137,11 +137,11 @@
     <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">nothing</span></span>():<span class="hljs-type">Void</span>
         <span class="hljs-built_in">trace</span>(<span class="hljs-string">&quot;nothing!&quot;</span>);
 
-    <span class="hljs-keyword">private</span> <span class="hljs-keyword">inline</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">func</span></span>(a:<span class="hljs-type">Int</span>, b:<span class="hljs-type">Float</span>, ?c:<span class="hljs-type">String</span>, d:<span class="hljs-type">Bool</span>=<span class="hljs-literal">false</span>):<span class="hljs-type">Dynamic </span>{
+    <span class="hljs-keyword">private</span> <span class="hljs-keyword">inline</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">func</span></span>(a:<span class="hljs-type">Int</span>, b:<span class="hljs-type">Float</span>, ?c:<span class="hljs-type">String</span>, d:<span class="hljs-type">Bool</span>=<span class="hljs-literal">false</span>):<span class="hljs-type">Dynamic</span> {
         <span class="hljs-keyword">return</span> {
             x: <span class="hljs-number">0</span>,
-            y: <span class="hljs-type">true</span>,
-            z: <span class="hljs-type">false</span>,
+            y: <span class="hljs-literal">true</span>,
+            z: <span class="hljs-literal">false</span>,
 
             a: <span class="hljs-number">1.53</span>,
             b: <span class="hljs-number">5e10</span>,
@@ -153,7 +153,7 @@
             l: <span class="hljs-number">10000000000i64</span>,
             f: <span class="hljs-number">5f64</span>,
 
-            n: <span class="hljs-type">null</span>,
+            n: <span class="hljs-literal">null</span>,
 
             s1: <span class="hljs-string">&quot;double&quot;</span>,
             s2: <span class="hljs-string">&#x27;single&#x27;</span>,
@@ -161,7 +161,7 @@
     }
 
 
-    <span class="hljs-keyword">override</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">quicksort</span></span>( lo : <span class="hljs-type">Int</span>, hi : <span class="hljs-type">Int </span>) : <span class="hljs-type">Void </span>{
+    <span class="hljs-keyword">override</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">quicksort</span></span>( lo : <span class="hljs-type">Int</span>, hi : <span class="hljs-type">Int</span> ) : <span class="hljs-type">Void</span> {
         <span class="hljs-keyword">var</span> i = lo;
         <span class="hljs-keyword">var</span> j = hi;
         <span class="hljs-keyword">var</span> buf = arr;
@@ -179,7 +179,7 @@
         <span class="hljs-keyword">if</span>( i &lt; hi ) quicksort( i, hi );
     }
 
-    <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">generateNewArray</span></span>(newArray:<span class="hljs-type">Array</span>):<span class="hljs-type">Void </span>{
+    <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">generateNewArray</span></span>(newArray:<span class="hljs-type">Array</span>):<span class="hljs-type">Void</span> {
         <span class="hljs-keyword">var</span> i = newArray;
         <span class="hljs-keyword">var</span> array = <span class="hljs-keyword">new</span> <span class="hljs-type">Array</span>();
     }

--- a/test/markup/haxe/default.txt
+++ b/test/markup/haxe/default.txt
@@ -154,6 +154,9 @@ class Main extends BaseClass implements SomeFunctionality {
             f: 5f64,
 
             n: null,
+
+            s1: "double",
+            s2: 'single',
         };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

Issue: Numbers and strings after a colon were treated as type names, which could cause problems with highlighting for anonymous structures, like this one:

```haxe
var obj = { num: 123.4, str: "hello" };
```

With this change, non-identifiers are excluded from being treated as a type name.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
