### PR TITLE
fix(haxe) Restore highlighting of type after new keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(json) add json5 support [Kerry Shetline][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- fix(haxe) Restore highlighting of type after new keyword [Josh Tynjala][]
 
 Documentation:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[Josh Tynjala]: https://github.com/joshtynjala
 
 
 ## Version 11.11.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,6 @@ Core Grammars:
 - enh(gherkin) docstrings can use backticks [Hirse][]
 - enh(go) recognize binary integer literals [spokodev][]
 - enh(groovy) support underscores in numeric literals [greymoth][]
-- fix(haxe) restore highlighting of type after new keyword [Josh Tynjala][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
@@ -121,7 +120,6 @@ CONTRIBUTORS
 [Checconio]: https://github.com/Checconio
 [Hashim Khan]: https://github.com/Hashim1999164
 [Hirse]: https://github.com/Hirse
-[Josh Tynjala]: https://github.com/joshtynjala
 [greymoth]: https://github.com/mahirhir
 [Hannes Wallnoefer]: https://github.com/hns
 [Dsaquel]: https://github.com/Dsaquel
@@ -232,7 +230,6 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
-[Josh Tynjala]: https://github.com/joshtynjala
 
 
 [Ashkan Shirpour]: https://github.com/a5hk

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Core Grammars:
 - enh(gherkin) docstrings can use backticks [Hirse][]
 - enh(go) recognize binary integer literals [spokodev][]
 - enh(groovy) support underscores in numeric literals [greymoth][]
+- fix(haxe) restore highlighting of type after new keyword [Josh Tynjala][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
@@ -120,6 +121,7 @@ CONTRIBUTORS
 [Checconio]: https://github.com/Checconio
 [Hashim Khan]: https://github.com/Hashim1999164
 [Hirse]: https://github.com/Hirse
+[Josh Tynjala]: https://github.com/joshtynjala
 [greymoth]: https://github.com/mahirhir
 [Hannes Wallnoefer]: https://github.com/hns
 [Dsaquel]: https://github.com/Dsaquel
@@ -230,6 +232,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[Josh Tynjala]: https://github.com/joshtynjala
 
 
 [Ashkan Shirpour]: https://github.com/a5hk

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -89,7 +89,7 @@ export default function(hljs) {
       },
       {
         className: 'type', // instantiation
-        beginKeywords: 'new',
+        begin: /new[ \t]+/,
         end: /\W/,
         excludeBegin: true,
         excludeEnd: true

--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -88,11 +88,15 @@ export default function(hljs) {
         excludeEnd: true
       },
       {
-        className: 'type', // instantiation
-        begin: /new[ \t]+/,
-        end: /\W/,
-        excludeBegin: true,
-        excludeEnd: true
+        match: [
+          /\bnew\b/,
+          /\s+/,
+          IDENT_RE + '(?:\\.' + IDENT_RE + ')*'
+        ],
+        scope: {
+          1: "keyword",
+          3: "type"
+        }
       },
       {
         className: 'title.class', // enums

--- a/test/markup/haxe/default.expect.txt
+++ b/test/markup/haxe/default.expect.txt
@@ -84,7 +84,7 @@
 
 <span class="hljs-title class_"><span class="hljs-keyword">class</span> <span class="hljs-title">Main</span> <span class="hljs-keyword"><span class="hljs-keyword">extends</span> <span class="hljs-type">BaseClass</span></span> <span class="hljs-keyword"><span class="hljs-keyword">implements</span> <span class="hljs-type">SomeFunctionality</span></span> </span>{
     <span class="hljs-keyword">var</span> callback:<span class="hljs-type">Void-&gt;Void </span>= <span class="hljs-literal">null</span>;
-    <span class="hljs-keyword">var</span> myArray:<span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt; = <span class="hljs-keyword">new</span><span class="hljs-type"></span> <span class="hljs-keyword">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt;();
+    <span class="hljs-keyword">var</span> myArray:<span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt; = <span class="hljs-keyword">new</span> <span class="hljs-type">Array</span>&lt;<span class="hljs-keyword">Float</span>&gt;();
     <span class="hljs-keyword">var</span> arr = [<span class="hljs-number">4</span>,<span class="hljs-number">8</span>,<span class="hljs-number">0</span>,<span class="hljs-number">3</span>,<span class="hljs-number">9</span>,<span class="hljs-number">1</span>,<span class="hljs-number">5</span>,<span class="hljs-number">2</span>,<span class="hljs-number">6</span>,<span class="hljs-number">7</span>];
 
     <span class="hljs-keyword">public</span> <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">new</span></span>(x) {
@@ -120,8 +120,8 @@
             done = <span class="hljs-literal">true</span>;
         }
 
-        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span><span class="hljs-type"></span> MyAbstract(<span class="hljs-number">42</span>);
-        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span><span class="hljs-type"></span> MyAbstract(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
+        <span class="hljs-keyword">var</span> H:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span> <span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">42</span>);
+        <span class="hljs-keyword">var</span> h:<span class="hljs-type">Int </span>= <span class="hljs-keyword">cast</span>(<span class="hljs-keyword">new</span> <span class="hljs-type">MyAbstract</span>(<span class="hljs-number">31</span>), <span class="hljs-keyword">Int</span>);
 
         <span class="hljs-keyword">try</span> {
             <span class="hljs-keyword">throw</span> <span class="hljs-string">&quot;error&quot;</span>;
@@ -130,7 +130,7 @@
             <span class="hljs-built_in">trace</span>(err);
         }
         
-        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span><span class="hljs-type"></span> haxe.ds.IntMap&lt;<span class="hljs-keyword">String</span>&gt;();
+        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span> <span class="hljs-type">haxe</span>.ds.IntMap&lt;<span class="hljs-keyword">String</span>&gt;();
         <span class="hljs-keyword">var</span> f = map.<span class="hljs-keyword">set</span>.bind(<span class="hljs-literal">_</span>, <span class="hljs-string">&quot;12&quot;</span>);
     }
 
@@ -178,7 +178,7 @@
 
     <span class="hljs-title function_"><span class="hljs-keyword">function</span> <span class="hljs-title">generateNewArray</span></span>(newArray:<span class="hljs-type">Array</span>):<span class="hljs-type">Void </span>{
         <span class="hljs-keyword">var</span> i = newArray;
-        <span class="hljs-keyword">var</span> array = <span class="hljs-keyword">new</span><span class="hljs-type"></span> <span class="hljs-keyword">Array</span>();
+        <span class="hljs-keyword">var</span> array = <span class="hljs-keyword">new</span> <span class="hljs-type">Array</span>();
     }
 
 }

--- a/test/markup/haxe/default.expect.txt
+++ b/test/markup/haxe/default.expect.txt
@@ -130,7 +130,7 @@
             <span class="hljs-built_in">trace</span>(err);
         }
         
-        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span> <span class="hljs-type">haxe</span>.ds.IntMap&lt;<span class="hljs-keyword">String</span>&gt;();
+        <span class="hljs-keyword">var</span> map = <span class="hljs-keyword">new</span> <span class="hljs-type">haxe.ds.IntMap</span>&lt;<span class="hljs-keyword">String</span>&gt;();
         <span class="hljs-keyword">var</span> f = map.<span class="hljs-keyword">set</span>.bind(<span class="hljs-literal">_</span>, <span class="hljs-string">&quot;12&quot;</span>);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->
	
PR #3993 fixed incorrect highlighting of variable names starting with new (like `newValue`), but at the same time, it removed highlighting of type names that follow the `new` keyword.

This PR restores the lost highlighting for type names after the `new` keyword, while still ensuring that new at the start of a variable name is not highlighted as a keyword.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
