### PR TITLE
Added support for Vento templates

### DIFF
--- a/src/languages/vento.js
+++ b/src/languages/vento.js
@@ -1,0 +1,37 @@
+/*
+Language: Vento
+Requires: xml.js, yaml.js, javascript.js
+Author: Óscar Otero <oom@oscarotero.com>
+Description: Syntax for Vento templates with front matter.
+Website: https://vento.js.org
+Category: template
+*/
+
+/** @type LanguageFn */
+export default function(hljs) {
+  return {
+    name: 'Vento',
+    aliases: ['vto'],
+    subLanguage: 'xml',
+    keywords: {
+      keyword: "for of if else include set layout echo function async function import from export await continue break slot"
+    },
+    contains: [
+      hljs.COMMENT("{{#", "#}}"),
+      {
+        begin: "{{[-]?",
+        end: "[-]?}}",
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: "^---\n",
+        end: "\n---\n",
+        subLanguage: "yaml",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+    ]
+  };
+}

--- a/test/markup/vento/default.expect.txt
+++ b/test/markup/vento/default.expect.txt
@@ -1,0 +1,14 @@
+<span class="language-xml">---
+</span><span class="language-yaml"><span class="hljs-attr">title:</span> <span class="hljs-string">&quot;This is a title&quot;</span></span><span class="language-xml">
+---
+</span><span class="hljs-comment">{{# this is a comment #}}</span><span class="language-xml">
+
+{{</span><span class="language-javascript"> <span class="hljs-keyword">for</span> post <span class="hljs-keyword">of</span> posts </span><span class="language-xml">}}
+  <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>{{</span><span class="language-javascript"> post.<span class="hljs-property">title</span> |&gt; toUpperCase </span><span class="language-xml">}}<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+{{</span><span class="language-javascript"> /<span class="hljs-keyword">for</span> </span><span class="language-xml">}}
+
+{{-</span><span class="language-javascript"> set value = things.<span class="hljs-title function_">select</span>(<span class="hljs-string">&quot;available=true&quot;</span>) </span><span class="language-xml">-}}
+{{</span><span class="language-javascript"> set x = <span class="hljs-number">1</span> + <span class="hljs-number">2</span> </span><span class="language-xml">}}
+{{</span><span class="language-javascript"> set value = <span class="hljs-string">`Thing <span class="hljs-subst">${title}</span> <span class="hljs-subst">${x}</span>`</span> </span><span class="language-xml">}}
+{{</span><span class="language-javascript"> value </span><span class="language-xml">}}
+</span>

--- a/test/markup/vento/default.txt
+++ b/test/markup/vento/default.txt
@@ -1,0 +1,13 @@
+---
+title: "This is a title"
+---
+{{# this is a comment #}}
+
+{{ for post of posts }}
+  <p>{{ post.title |> toUpperCase }}</p>
+{{ /for }}
+
+{{- set value = things.select("available=true") -}}
+{{ set x = 1 + 2 }}
+{{ set value = `Thing ${title} ${x}` }}
+{{ value }}


### PR DESCRIPTION
Vento is a template engine, similar to Liquid or Nunjucks but more JavaScript friendly.
- Vento website: https://vento.js.org/
- Vento is [detected and supported by GitHub](https://github.com/search?q=language%3AVento&type=code) 

### Changes
- Added the Vento language definition file
- Added a test

### Checklist
- [x] Added markup tests
- [ ] Updated the changelog at `CHANGES.md`.

I didn't update the CHANGES.md file because I'm not sure how to do it. Should I create a new version?
