### PR TITLE
Fix #3928: support digit separators (') in C++ integer literals in #define

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -112,7 +112,8 @@ export default function(hljs) {
         begin: /<.*?>/
       },
       C_LINE_COMMENT_MODE,
-      hljs.C_BLOCK_COMMENT_MODE
+      hljs.C_BLOCK_COMMENT_MODE,
+      NUMBERS
     ]
   };
 

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -28,6 +28,10 @@ if (p) {
 #endif
 }
 
+// Test : digit separators in integer literals
+#define MILLION 1'000'000
+int x = 1'000'000;
+
 // this is a continued\
 comment.
 end


### PR DESCRIPTION
#### This PR fixes issue #3928 by adding support for single-quote (') digit separators in C++ integer literals inside #define macros and normal code. Previously, such literals were not highlighted correctly in highlight.js.

#### Changes made:
 - Updated src/languages/cpp.js to include NUMBERS in PREPROCESSOR.contains so numbers in preprocessor lines are highlighted
 - Added a test snippet in test/markup/cpp/preprocessor.txt

#### Existing preprocessor tests may highlight numbers differently due to the fix; this is expected.Also the behavior for digit separators in integer literals is changed; all other syntax highlighting remains unchanged.

### Closes#3928