### PR TITLE
(docs) Add LLVM IR to supported languages list

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -135,6 +135,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Lisp                    | lisp                   |         |
 | LiveCode Server         | livecodeserver         |         |
 | LiveScript              | livescript, ls         |         |
+| LLVM IR                 | llvm                   |         |
 | LookML                  | lookml                 | [highlightjs-lookml](https://github.com/spectacles-ci/highlightjs-lookml) |
 | Lua                     | lua, pluto             |         |
 | Luau                    | luau                   | [highlightjs-luau](https://github.com/highlightjs/highlightjs-luau) |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -139,6 +139,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Lisp                    | lisp                   |         |
 | LiveCode Server         | livecodeserver         |         |
 | LiveScript              | livescript, ls         |         |
+| LLVM IR                 | llvm                   |         |
 | LookML                  | lookml                 | [highlightjs-lookml](https://github.com/spectacles-ci/highlightjs-lookml) |
 | Lua                     | lua, pluto             |         |
 | Luau                    | luau                   | [highlightjs-luau](https://github.com/highlightjs/highlightjs-luau) |


### PR DESCRIPTION
This adds LLVM IR to the list of support languages. LLVM IR is already supported, but not listed for reason.

I'm not sure if I need to update the changelog for documentation changes, but I can do that if need be.

### Checklist
- [x] Markup tests not needed
- [ ] Updated the changelog at `CHANGES.md`
