### PR TITLE
Fix: #4331 Prevent wrongly coloring multilines in Python string patterns in non-thrice quotes

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -216,24 +216,29 @@ export default function(hljs) {
       {
         begin: /([uU]|[rR])'/,
         end: /'/,
+        illegal: /\n/,
         relevance: 10
       },
       {
         begin: /([uU]|[rR])"/,
         end: /"/,
+        illegal: /\n/,
         relevance: 10
       },
       {
         begin: /([bB]|[bB][rR]|[rR][bB])'/,
-        end: /'/
+        end: /'/,
+        illegal: /\n/
       },
       {
         begin: /([bB]|[bB][rR]|[rR][bB])"/,
-        end: /"/
+        end: /"/,
+        illegal: /\n/
       },
       {
         begin: /([fF][rR]|[rR][fF]|[fF])'/,
         end: /'/,
+        illegal: /\n/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
           LITERAL_BRACKET,
@@ -243,6 +248,7 @@ export default function(hljs) {
       {
         begin: /([fF][rR]|[rR][fF]|[fF])"/,
         end: /"/,
+        illegal: /\n/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
           LITERAL_BRACKET,


### PR DESCRIPTION
Added 'illegal' property to string patterns to prevent newlines coloring.

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes
<!--- Describe your changes -->

### Checklist
- [ ] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`
