### PR TITLE
Added support for block highlighting in C-style comments.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,7 +110,7 @@ Core Grammars:
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
 - fix(cpp) - Exclude keywords from highlighting as function calls [Eisenwave]
-
+- fix(llvm) fixed highlighting for C-style block comments [utam-1] 
 New Grammars:
 
 - added 3rd party TTCN-3 grammar to SUPPORTED_LANGUAGES [Osmocom][]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,7 +217,7 @@ Core Grammars:
 - fix(yaml) - Fixed wrong escaping behavior in single quoted strings [guuido]
 - enh(nim) - Add `concept` and `defer` to list of Nim keywords [Jake Leahy]
 - fix(cpp) - Exclude keywords from highlighting as function calls [Eisenwave]
-
+- fix(llvm) fixed highlighting for C-style block comments [utam-1] 
 New Grammars:
 
 - added 3rd party TTCN-3 grammar to SUPPORTED_LANGUAGES [Osmocom][]

--- a/src/languages/llvm.js
+++ b/src/languages/llvm.js
@@ -111,6 +111,7 @@ export default function(hljs) {
       // another language than an actual comment
       hljs.COMMENT(/;\s*$/, null, { relevance: 0 }),
       hljs.COMMENT(/;/, /$/),
+      hljs.C_BLOCK_COMMENT_MODE,
       {
         className: 'string',
         begin: /"/,

--- a/test/markup/llvm/c.style.comments.expect.txt
+++ b/test/markup/llvm/c.style.comments.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-comment">/* C-style comment */</span>
+<span class="hljs-keyword">define</span> <span class="hljs-type">i32</span> <span class="hljs-title">@main</span>() {
+  <span class="hljs-comment">; semicolon comment</span>
+  <span class="hljs-keyword">ret</span> <span class="hljs-type">i32</span> <span class="hljs-number">0</span>
+}

--- a/test/markup/llvm/c.style.comments.txt
+++ b/test/markup/llvm/c.style.comments.txt
@@ -1,0 +1,5 @@
+/* C-style comment */
+define i32 @main() {
+  ; semicolon comment
+  ret i32 0
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Added hljs.C_BLOCK_COMMENT_MODE in src/languages/llvm.js
- Added tests in test/markup/llvm
<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->
Resolves #4328
### Changes
<!--- Describe your changes -->
The hljs.C_BLOCK_COMMENT_MODE is a built-in mode in highlight.js that handles /* ... */ style comments, and it was added inside contains in src/languages/llvm.js
### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
