### PR TITLE
fix(markdown) Ignore mid_word underscores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(json) add json5 support [Kerry Shetline][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- fix(markdown) Ignore mid_word underscores, issue #4279 [Dan Vanderkam]
 
 Documentation:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[Dan Vanderkam]: https://github.com/danvk
 
 
 ## Version 11.11.1

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -156,8 +156,8 @@ export default function(hljs) {
         end: /\*/
       },
       {
-        begin: /_(?![_\s])/,
-        end: /_/,
+        begin: /(?<![a-zA-Z0-9])_(?![_\s])/,
+        end: /_(?![a-zA-Z0-9])/,
         relevance: 0
       }
     ]

--- a/test/markup/markdown/bold_italics.expect.txt
+++ b/test/markup/markdown/bold_italics.expect.txt
@@ -31,3 +31,6 @@ _ not italic_
 <span class="hljs-quote">&gt; * One (this point is italic)</span>
 <span class="hljs-quote">&gt; * Two</span>
 <span class="hljs-quote">&gt; * Three</span>
+
+No italics mid_word underscores.
+But italics for <span class="hljs-emphasis">_full_word_</span> with underscores.

--- a/test/markup/markdown/bold_italics.txt
+++ b/test/markup/markdown/bold_italics.txt
@@ -31,3 +31,6 @@ _ not italic_
 > * One (this point is italic)
 > * Two
 > * Three
+
+No italics mid_word underscores.
+But italics for _full_word_ with underscores.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Resolves #4279 

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

This changes the markdown rule to ignore mid-word `_` characters. This brings highlight.js in line with GFM (GitHub-Flavored Markdown). There's no official standard for Markdown and different renderers vary in how they handle `mid_word` underscores. Not italicizing them is the more conservative behavior, and avoids the common situation where a large fraction of your Markdown file turns italic with highlight.js when it does not with GitHub.

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
