### PR TITLE
Add `global` to Lua

### DIFF
--- a/src/languages/lua.js
+++ b/src/languages/lua.js
@@ -31,7 +31,7 @@ export default function(hljs) {
     keywords: {
       $pattern: hljs.UNDERSCORE_IDENT_RE,
       literal: "true false nil",
-      keyword: "and break do else elseif end for goto if in local not or repeat return then until while",
+      keyword: "and break do else elseif end for goto if in local global not or repeat return then until while",
       built_in:
         // Metatags and globals:
         '_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len '


### PR DESCRIPTION
Lua 5.5 introduces `global` as a keyword, so this change simply adds it.
See: https://www.lua.org/manual/5.5/manual.html#3.1
### Changes

Added `global` to the list of keywords.

### Checklist
- [x] Changes were too minor to need markup tests.
- [ ] Updated the changelog at `CHANGES.md`