### PR TITLE
fix(types): allow $pattern RegExp in Mode keywords type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -250,7 +250,7 @@ declare module 'highlight.js' {
         parent?: Mode
         starts?:Mode
         lexemes?: string | RegExp
-        keywords?: string | string[] | Record<string, string | string[]>
+        keywords?: string | string[] | Record<string, string | string[] | RegExp>
         beginKeywords?: string
         relevance?: number
         illegal?: string | RegExp | Array<string | RegExp>


### PR DESCRIPTION
Fixes #4365

The TypeScript type definition for `keywords` in `ModeDetails` only allows `string | string[] | Record<string, string | string[]>`, but language definitions (like Python, SQL, etc.) legitimately include `$pattern: RegExp` in their keywords objects.

The runtime compiler in `mode_compiler.js` already handles `$pattern` correctly - this just updates the type to match the actual runtime behavior by adding `RegExp` to the `Record` value union.