### PR TITLE
fix: highlight self as variable in JavaScript (fixes #4339)

### DIFF
--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -157,7 +157,8 @@ export const BUILT_IN_VARIABLES = [
   "localStorage",
   "sessionStorage",
   "module",
-  "global" // Node.js
+  "global", // Node.js
+  "self"
 ];
 
 const BUILT_INS = [].concat(


### PR DESCRIPTION
## Problem
The keyword `self` was not being highlighted as a language variable in JavaScript, unlike `window` and `document`.

## Solution
Added `self` to the `BUILT_IN_VARIABLES` array in `src/languages/lib/ecmascript.js`.

## Testing
- Built the project successfully (`npm run build`)
- All 1570 tests pass
- Verified the fix works: `hljs.highlight('self', {language: 'javascript'}).value` now returns `<span class="hljs-variable language_">self</span>`

## Checklist
- [x] Code changes are minimal and focused
- [x] Tests pass
- [x] Build succeeds