### PR TITLE
fix(bash): highlight command line options (--option)

### DIFF
--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -145,6 +145,13 @@ export default function(hljs) {
   // to consume paths to prevent keyword matches inside them
   const PATH_MODE = { match: /(\/[a-z._-]+)+/ };
 
+  // Command long options (--option) - only match long options to avoid conflicts
+  const OPTION = {
+    className: 'attribute',
+    begin: /\s--[\w-]+/,
+    relevance: 0
+  };
+
   // http://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html
   const SHELL_BUILT_INS = [
     "break",
@@ -397,6 +404,7 @@ export default function(hljs) {
       COMMENT,
       HERE_DOC,
       PATH_MODE,
+      OPTION,
       QUOTE_STRING,
       ESCAPED_QUOTE,
       APOS_STRING,

--- a/test/markup/bash/token-containing-keyword.expect.txt
+++ b/test/markup/bash/token-containing-keyword.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-comment"># a keyword as part of an option</span>
-mycmd --disable-foo
+mycmd<span class="hljs-attribute"> --disable-foo</span>
 
 <span class="hljs-comment"># a keyword as part of a parameter</span>
 some-cmd set-some-setting

--- a/test/markup/shell/command-continuation.expect.txt
+++ b/test/markup/shell/command-continuation.expect.txt
@@ -1,11 +1,11 @@
 <span class="hljs-meta prompt_">$ </span><span class="language-bash">docker run \
-      --publish=7474:7474 --publish=7687:7687 \
-      --volume=/neo4j/data:/data \
-      --volume=/neo4j/plugins:/plugins \
-      --volume=/neo4j/conf:/conf \
-      --volume=/logs/neo4j:/logs \
-      --user=<span class="hljs-string">&quot;<span class="hljs-subst">$(id -u neo4j)</span>:<span class="hljs-subst">$(id -g neo4j)</span>&quot;</span> \
-      --group-add=<span class="hljs-variable">$groups</span> \
+     <span class="hljs-attribute"> --publish</span>=7474:7474<span class="hljs-attribute"> --publish</span>=7687:7687 \
+     <span class="hljs-attribute"> --volume</span>=/neo4j/data:/data \
+     <span class="hljs-attribute"> --volume</span>=/neo4j/plugins:/plugins \
+     <span class="hljs-attribute"> --volume</span>=/neo4j/conf:/conf \
+     <span class="hljs-attribute"> --volume</span>=/logs/neo4j:/logs \
+     <span class="hljs-attribute"> --user</span>=<span class="hljs-string">&quot;<span class="hljs-subst">$(id -u neo4j)</span>:<span class="hljs-subst">$(id -g neo4j)</span>&quot;</span> \
+     <span class="hljs-attribute"> --group-add</span>=<span class="hljs-variable">$groups</span> \
       neo4j:3.4</span>
 <span class="hljs-meta prompt_">&gt; </span><span class="language-bash">/bin/cat \.travis.yml\
  -b | <span class="hljs-built_in">head</span> -n1</span>


### PR DESCRIPTION
This PR adds highlighting for long command line options (--option) in bash to address issue #4288.

## Problem

Previously, command line options like `--project`, `--env`, `--deployment-package` were not highlighted consistently across lines in bash code blocks. Some would have `hljs-built_in` class while others had no class at all.

## Solution

Add an OPTION pattern that highlights long options when they appear after whitespace. This makes CLI examples more readable.

## Testing

Tested manually:
```bash
epi deployment start --project my-project --env Integration --direct-deploy true
```

Now outputs:
```
epi deployment start<span class="hljs-attribute"> --project</span> my-project<span class="hljs-attribute"> --env</span> Integration<span class="hljs-attribute"> --direct-deploy</span> <span class="hljs-literal">true</span>
```

## Test Updates

Updated 2 test expectation files to reflect the new behavior:
- `test/markup/bash/token-containing-keyword.expect.txt`
- `test/markup/shell/command-continuation.expect.txt`

All tests now pass (1570 passing).

## Fixes

Fixes #4288