### PR TITLE
Add Djot language to supported languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -72,6 +72,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Django                  | django, jinja          |         |
 | DNS Zone file           | dns, zone, bind        |         |
 | Dockerfile              | dockerfile, docker     |         |
+| Djot                    | djot, dj               |[highlightjs-djot](https://github.com/php-collective/highlightjs-djot) |
 | DOS                     | dos, bat, cmd          |         |
 | dsconfig                | dsconfig               |         |
 | DTS (Device Tree)       | dts                    |         |


### PR DESCRIPTION
## Summary

Add [Djot](https://djot.net) markup language to the list of supported 3rd party languages.

[Djot](https://djot.net) is a light markup language created by John MacFarlane (author of CommonMark/Pandoc). It aims to fix some of Markdown's quirks while keeping the simplicity that made Markdown popular.

**3rd party package:** <https://github.com/php-collective/highlightjs-djot>

## Features highlighted

- Headings, emphasis, strong
- Links, images, autolinks
- Code blocks and inline code
- Lists (bullet, numbered, task lists)
- Tables, block quotes
- Footnotes, math expressions
- Attributes, symbols, comments
- And more Djot-specific syntax