### PR TITLE
fix(typescript): prevent type assertions with array brackets or ? from being treated as HTML tags

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -47,7 +47,13 @@ export default function(hljs) {
         nextChar === "<" ||
         // the , gives away that this is not HTML
         // `<T, A extends keyof T, V>`
-        nextChar === ","
+        nextChar === "," ||
+        // TypeScript type assertion with array notation
+        // `<string[]>`, `<number[]>`, `<T[]>`, etc.
+        nextChar === "[" ||
+        // TypeScript optional type assertion
+        // `<string?>`, etc.
+        nextChar === "?"
         ) {
         response.ignoreMatch();
         return;
@@ -85,6 +91,13 @@ export default function(hljs) {
           // eslint-disable-next-line no-useless-return
           return;
         }
+      }
+
+      // TypeScript type assertions with whitespace before brackets or question mark
+      // `<string []>`, `<T []>`, `<string ?>`, `<T ?>`
+      if ((m = afterMatch.match(/^\s*\[\]/)) || (m = afterMatch.match(/^\s+\?/))) {
+        response.ignoreMatch();
+        return;
       }
     }
   };


### PR DESCRIPTION
## Summary

Fixes #4301 - `<string[]>` (and `<string?>`) break TypeScript highlighting.

## Root Cause

The `isTrulyOpeningTag` function in `src/languages/javascript.js` checks various patterns to determine whether a `<` followed by word characters is an HTML/XML tag or a TypeScript/JavaScript type expression. It handles `<` (nested generics) and `,` (generic parameters), but was missing checks for:

- `[` — TypeScript type assertions with array notation like `<string[]>`
- `?` — TypeScript non-null assertions like `<string?>`

When encountering `<string[]>`, `nextChar` after the tag name `<string` is `[`. Since this wasn't recognized, the function proceeded to look for a closing `</string>` tag, treating everything after the `>` as HTML text until it found one.

## Fix

Added two new conditions to the `isTrulyOpeningTag` ignoreMatch check:

1. `nextChar === "["` — catches `<string[]>`, `<number[]>`, `<T[]>` directly
2. `nextChar === "?"` — catches `<string?>`, `<T?>` directly

Also added `afterMatch` regex checks for whitespace variants:
- `/^\s*\[\]/` — catches `<string []>`
- `/^\s+\?/` — catches `<string ?>`

## Test Evidence

**Before fix:**
```
INPUT: const myVar = <string[]>this.service.invoke();
OUTPUT: <span class="language-xml">&lt;string[]&gt;this.service.invoke();</span>  ← BROKEN
```

**After fix:**
```
INPUT: const myVar = <string[]>this.service.invoke();
OUTPUT: &lt;<span class="hljs-built_in">string</span>[]&gt;<span class="hljs-variable language_">this</span>.<span class="hljs-property">service</span>.<span class="hljs-title function_">invoke</span>();
```

JSX constructs like `<Component />` and real HTML like `<div>` continue to be correctly highlighted as XML.

## Validation

- All 1570 existing tests pass (0 new failures)
- Manually verified: `<string[]>`, `<number[]>`, `<T[]>`, `<string?>`, `<string []>` all no longer break highlighting
- JSX: `<div>`, `<Component />`, `<MyComponent prop=\"val\" />` still correctly highlighted

## Risk & Rollback

- **Risk**: Low — only affects the tag-detection logic in `isTrulyOpeningTag`, which already had similar ignore patterns for `<` and `,`
- **Rollback**: Single file (`src/languages/javascript.js`) revert to previous state
- **Affected languages**: TypeScript and JavaScript (which extends the same base)