### PR TITLE
Add 3rd party Why3 grammar to Supported Languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ New Grammars:
 - added 3rd party Bicep grammar to SUPPORTED_LANGUAGES [Anthony Martin][]
 - added 3rd party L4 grammar to SUPPORTED_LANGUAGES [Thomas Gorissen][]
 - added 3rd party Abc Notation grammar to SUPPORTED_LANGUAGES [NriotHrreion][]
+- added 3rd party Why3 grammar to SUPPORTED_LANGUAGES [JGalego][]
 
 Core Grammars:
 
@@ -79,7 +80,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
-
+[JGalego]: https://github.com/JGalego
 
 ## Version 11.11.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ New Grammars:
 - added 3rd party L4 grammar to SUPPORTED_LANGUAGES [Thomas Gorissen][]
 - added 3rd party Bicep grammar to SUPPORTED_LANGUAGES [Anthony Martin][]
 - added 3rd party Abc Notation grammar to SUPPORTED_LANGUAGES [NriotHrreion][]
+- added 3rd party Why3 grammar to SUPPORTED_LANGUAGES [JGalego][]
 
 Core Grammars:
 
@@ -55,7 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
-
+[JGalego]: https://github.com/JGalego
 
 ## Version 11.11.1
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -262,6 +262,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Vim Script              | vim                    |         |
 | VoltScript              | voltscript, vss, lotusscript, lss | [highlightjs-voltscript](https://github.com/HCL-TECH-SOFTWARE/highlightjs-voltscript) |
 | WGSL                    | wgsl                   | [highlightjs-wgsl](https://github.com/highlightjs/highlightjs-wgsl) |
+| Why3                    | whyml, mlw             | [highlightjs-why3](https://github.com/JGalego/highlightjs-why3) |
 | X#                      | xsharp, xs, prg        | [highlightjs-xsharp](https://github.com/InfomindsAg/highlightjs-xsharp) |
 | X++                     | axapta, x++            |         |
 | x86 Assembly            | x86asm                 |         |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -261,6 +261,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Vim Script              | vim                    |         |
 | VoltScript              | voltscript, vss, lotusscript, lss | [highlightjs-voltscript](https://github.com/HCL-TECH-SOFTWARE/highlightjs-voltscript) |
 | WGSL                    | wgsl                   | [highlightjs-wgsl](https://github.com/highlightjs/highlightjs-wgsl) |
+| Why3                    | whyml, mlw             | [highlightjs-why3](https://github.com/JGalego/highlightjs-why3) |
 | X#                      | xsharp, xs, prg        | [highlightjs-xsharp](https://github.com/InfomindsAg/highlightjs-xsharp) |
 | X++                     | axapta, x++            |         |
 | x86 Assembly            | x86asm                 |         |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
<!-- ie, `Resolves #1234`, etc... so GitHub can magically link it -->

### Changes

Added [highlightjs-why3](https://github.com/JGalego/highlightjs-why3) to `SUPPORTED_LANGUAGES.md`

<img width="529" height="303" alt="image" src="https://github.com/user-attachments/assets/8830f31a-e61d-4e3c-9e79-9b30f92875f9" />

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] Updated the changelog at `CHANGES.md`
