### PR TITLE
fix(types): add RegExp to Mode.keywords to match LanguageDetail.keywords

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -250,7 +250,7 @@ declare module 'highlight.js' {
         parent?: Mode
         starts?:Mode
         lexemes?: string | RegExp
-        keywords?: string | string[] | Record<string, string | string[]>
+        keywords?: string | string[] | Record<string, string | string[] | RegExp>
         beginKeywords?: string
         relevance?: number
         illegal?: string | RegExp | Array<string | RegExp>


### PR DESCRIPTION
## Summary

Fixes #4365 — TypeScript errors when dynamically importing language modules due to `$pattern: RegExp` in `keywords` not matching the type definition.

## Root Cause

`Language = LanguageDetail & Partial<Mode>`

- `LanguageDetail.keywords`: `string | string[] | Record<string, string | string[] | RegExp>` ✅
- `Mode.keywords`: `string | string[] | Record<string, string | string[]>` ❌ (missing `RegExp`)

Since `Language` is an intersection, TypeScript requires the narrower `Mode` type to be satisfied. When language modules include `$pattern: RegExp` in their `keywords` object, the type check fails.

## Fix

Updated `Mode.keywords` in `types/index.d.ts` to include `RegExp`:
```diff
- keywords?: string | string[] | Record<string, string | string[]>
+ keywords?: string | string[] | Record<string, string | string[] | RegExp>
```

## Validation

- Build: `npm run build` ✅
- Test: `npm run test` ✅
- Type change is purely additive (no breaking changes)

## Risk & Rollback

- **Risk**: Minimal — purely additive type change
- **Rollback**: Revert single line in `types/index.d.ts`