### PR TITLE
Add equinox.css with syntax highlighting styles

### DIFF
--- a/src/styles/equinox.css
+++ b/src/styles/equinox.css
@@ -1,0 +1,13 @@
+.hljs{filter: saturate(2)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+.hljs-comment,.hljs-doctag,.hljs-quote{color:color-mix(in srgb, currentColor, green)}
+.hljs-formula,.hljs-keyword{color:color-mix(in srgb, currentColor, purple)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:color-mix(in srgb, currentColor, pink)}
+.hljs-literal{color:color-mix(in srgb, currentColor, cyan)}
+.hljs-number{color:color-mix(in srgb, currentColor, lime)}
+.hljs-addition,.hljs-attribute,.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:color-mix(in srgb, currentColor, orange)}
+.hljs-attr,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:color-mix(in srgb, currentColor, blue)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:color-mix(in srgb, currentColor, olive)}
+.hljs-built_in,.hljs-class .hljs-title,.hljs-title.class_{color:color-mix(in srgb, currentColor, yellow)}


### PR DESCRIPTION
Add a new "Equinox" theme which aim to be
- usable in both light and dark mode with the same CSS (hence the name)
- loosely based on Monaco coloring scheme
- unopinionated (no background, border, shadow) for a smooth integration

<!--- Provide a general summary of your changes in the Title above -->

<!-- Please link to a related issue below. -->
Resolves #4390

### Changes
Added new CSS that can hilight in both dark and light mode
`<meta name="color-scheme" content="light">`
<img width="655" height="259" alt="image" src="https://github.com/user-attachments/assets/6e230c76-d3b5-46a6-a249-9f741dc9507d" />
`<meta name="color-scheme" content="dark">`
<img width="594" height="241" alt="image" src="https://github.com/user-attachments/assets/6fe24ac2-af67-427d-ac98-630f47b2c6cf" />

### Checklist
- [ ] No markup tests added
- [ ] I can updated `CHANGES.md` but it was untouched for 9 months so ...
