### PR TITLE
Fix C++ function highlighting for keyword prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Core Grammars:
 - enh(json) add json5 support [Kerry Shetline][]
 - fix(css) `unicode-range` parsing, issue #4253 [Kerry Shetline][]
 - fix(csharp) Support digit separators [te-ing][]
+- fix(cpp) allow function names that start with reserved keyword prefixes [Puneet Dixit][]
 
 Documentation:
 
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[Puneet Dixit]: https://github.com/puneetdixit200
 
 
 ## Version 11.11.1

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -417,6 +417,10 @@ export default function(hljs) {
     _type_hints: TYPE_HINTS
   };
 
+  const RESERVED_KEYWORD_RE = regex.either(
+    ...RESERVED_KEYWORDS.map(keyword => keyword.replace(/\|\d+$/, ''))
+  );
+
   const FUNCTION_DISPATCH = {
     className: 'function.dispatch',
     relevance: 0,
@@ -425,7 +429,7 @@ export default function(hljs) {
       _hint: FUNCTION_HINTS },
     begin: regex.concat(
       /\b/,
-      `(?!${RESERVED_KEYWORDS.join('|')})`,
+      `(?!${RESERVED_KEYWORD_RE}\\b)`,
       hljs.IDENT_RE,
       regex.lookahead(/(<[^<>]+>|)\s*\(/))
   };

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -479,15 +479,18 @@ export default function(hljs) {
     _type_hints: TYPE_HINTS
   };
 
+  const RESERVED_KEYWORD_RE = regex.either(
+    ...RESERVED_KEYWORDS.map(keyword => keyword.replace(/\|\d+$/, ''))
+  );
+
   const FUNCTION_DISPATCH = {
-    className: 'function.dispatch',
-    relevance: 0,
+    scope: 'function.dispatch',
     keywords: {
       // Only for relevance, not highlighting.
       _hint: FUNCTION_HINTS },
     begin: regex.concat(
       /\b/,
-      `(?!${RESERVED_KEYWORDS.join('|')})`,
+      `(?!${RESERVED_KEYWORD_RE}\\b)`,
       hljs.IDENT_RE,
       regex.lookahead(/(<[^<>]+>|)\s*\(/))
   };

--- a/test/markup/cpp/function-like-keywords.expect.txt
+++ b/test/markup/cpp/function-like-keywords.expect.txt
@@ -10,3 +10,15 @@
 <span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
 
 <span class="hljs-keyword">static_assert</span>(<span class="hljs-literal">true</span>);
+
+<span class="hljs-built_in">format</span>();
+
+<span class="hljs-built_in">for_this</span>();
+
+<span class="hljs-built_in">whilexyz</span>();
+
+<span class="hljs-keyword">if</span> (<span class="hljs-built_in">ifsyz</span>()) {}
+
+<span class="hljs-built_in">returnxyz</span>();
+
+<span class="hljs-built_in">thisxyz</span>();

--- a/test/markup/cpp/function-like-keywords.expect.txt
+++ b/test/markup/cpp/function-like-keywords.expect.txt
@@ -10,7 +10,22 @@
 <span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
 
 <span class="hljs-keyword">static_assert</span>(<span class="hljs-literal">true</span>);
+<<<<<<< HEAD
 <span class="hljs-keyword">contract_assert</span>(<span class="hljs-literal">false</span>);
 
 <span class="hljs-keyword">_BitInt</span>(<span class="hljs-number">64</span>) x;
 <span class="hljs-keyword">_Atomic</span>(<span class="hljs-type">int</span>) y;
+=======
+
+<span class="hljs-built_in">format</span>();
+
+<span class="hljs-built_in">for_this</span>();
+
+<span class="hljs-built_in">whilexyz</span>();
+
+<span class="hljs-keyword">if</span> (<span class="hljs-built_in">ifsyz</span>()) {}
+
+<span class="hljs-built_in">returnxyz</span>();
+
+<span class="hljs-built_in">thisxyz</span>();
+>>>>>>> 514eaf963 (Fix C++ function highlighting for keyword prefixes)

--- a/test/markup/cpp/function-like-keywords.expect.txt
+++ b/test/markup/cpp/function-like-keywords.expect.txt
@@ -10,12 +10,10 @@
 <span class="hljs-function"><span class="hljs-type">void</span> <span class="hljs-title">f</span><span class="hljs-params">()</span> </span>= <span class="hljs-keyword">delete</span>(<span class="hljs-string">&quot;reason&quot;</span>);
 
 <span class="hljs-keyword">static_assert</span>(<span class="hljs-literal">true</span>);
-<<<<<<< HEAD
 <span class="hljs-keyword">contract_assert</span>(<span class="hljs-literal">false</span>);
 
 <span class="hljs-keyword">_BitInt</span>(<span class="hljs-number">64</span>) x;
 <span class="hljs-keyword">_Atomic</span>(<span class="hljs-type">int</span>) y;
-=======
 
 <span class="hljs-built_in">format</span>();
 
@@ -28,4 +26,3 @@
 <span class="hljs-built_in">returnxyz</span>();
 
 <span class="hljs-built_in">thisxyz</span>();
->>>>>>> 514eaf963 (Fix C++ function highlighting for keyword prefixes)

--- a/test/markup/cpp/function-like-keywords.txt
+++ b/test/markup/cpp/function-like-keywords.txt
@@ -10,3 +10,15 @@ for (;;) {}
 void f() = delete("reason");
 
 static_assert(true);
+
+format();
+
+for_this();
+
+whilexyz();
+
+if (ifsyz()) {}
+
+returnxyz();
+
+thisxyz();

--- a/test/markup/cpp/function-like-keywords.txt
+++ b/test/markup/cpp/function-like-keywords.txt
@@ -14,3 +14,15 @@ contract_assert(false);
 
 _BitInt(64) x;
 _Atomic(int) y;
+
+format();
+
+for_this();
+
+whilexyz();
+
+if (ifsyz()) {}
+
+returnxyz();
+
+thisxyz();


### PR DESCRIPTION
Fixes #4394

### Changes
- Treat only exact C++ reserved keyword identifiers as excluded from function dispatch highlighting.
- Add C++ markup coverage for function names that start with keywords, including `format`, `for_this`, and `whilexyz`.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [ ] Updated the changelog at `CHANGES.md`