### PR TITLE
feat: add 'batch' alias for DOS syntax highlighting

### DIFF
--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -132,7 +132,8 @@ export default function(hljs) {
     name: 'Batch file (DOS)',
     aliases: [
       'bat',
-      'cmd'
+      'cmd',
+      'batch'
     ],
     case_insensitive: true,
     illegal: /\/\*/,


### PR DESCRIPTION
Fixes #4395

Why
`batch` is the official name of the file format (batch file), but it cannot be used as an alias for DOS highlighting. The alias `bat` already exists (a shortening of `batch`), so `batch` is a natural addition for users who write `language-batch` in their code blocks.

Changes
Added `"batch"` to the aliases array in the DOS language definition.

Updated component: `src/languages/dos.js`

Testing
The `batch` alias now resolves to DOS syntax highlighting, consistent with the existing `bat` and `cmd` aliases.

Surface area
- Languages / DOS
- Enhancement