### PR TITLE
fix(cpp): remove function.dispatch scope from identifiers that start with a keyword (#4394)

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -418,14 +418,13 @@ export default function(hljs) {
   };
 
   const FUNCTION_DISPATCH = {
-    className: 'function.dispatch',
     relevance: 0,
     keywords: {
       // Only for relevance, not highlighting.
       _hint: FUNCTION_HINTS },
     begin: regex.concat(
       /\b/,
-      `(?!${RESERVED_KEYWORDS.join('|')})`,
+      `(?!${RESERVED_KEYWORDS.map(k => k + '\\b').join('|')})`,
       hljs.IDENT_RE,
       regex.lookahead(/(<[^<>]+>|)\s*\(/))
   };
@@ -561,7 +560,7 @@ export default function(hljs) {
     ],
     keywords: CPP_KEYWORDS,
     illegal: '</',
-    classNameAliases: { 'function.dispatch': 'built_in' },
+    classNameAliases: {},
     contains: [].concat(
       EXPRESSION_CONTEXT,
       FUNCTION_DECLARATION,


### PR DESCRIPTION
Fixes #4394

### Changes
- Removed `className: 'function.dispatch'` from `FUNCTION_DISPATCH` so that identifiers that look like function calls are no longer highlighted as `built_in`
- Added word boundary (`\b`) to each keyword in the negative lookahead so prefixes are properly handled
- Cleared the `classNameAliases` for `function.dispatch` accordingly

### Context
Previously, identifiers such as `testing()` were highlighted as `built_in` by `FUNCTION_DISPATCH`, while identifiers starting with a registered keyword (e.g., `for_this()`, `whilexyz()`) were correctly excluded by the negative lookahead. This produced inconsistent highlighting.

With this fix, `FUNCTION_DISPATCH` still exists for relevance scoring via `_hint` keywords, but it no longer applies a visual scope to the matched text, producing consistent unhighlighted identifiers across the board.