### PR TITLE
fix(rust): backslash char literal breaks subsequent highlighting

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -213,7 +213,7 @@ export default function(hljs) {
             contains: [
               {
                 scope: "char.escape",
-                match: /\\('|\w|x\w{2}|u\w{4}|U\w{8})/
+                match: /\\(\\|'|"|\w|x\w{2}|u\w{4}|U\w{8})/
               }
             ]
           }


### PR DESCRIPTION
## Description

Fixes #4351

In Rust, the char literal `'\\'` (a backslash character) was not correctly parsed by highlight.js. The escape regex `/\\('|\w|x\w{2}|u\w{4}|U\w{8})/` had no dedicated alternative for matching the `\\` sequence (two backslashes = escaped backslash).

### Root Cause

When highlight.js encountered `'\\'`:
1. The first backslash triggered escape matching
2. The escape regex tried `\w` against the second backslash — `\w` does not match `\`, so it failed
3. The second backslash + the closing quote character were then consumed as `\'` (escaped single quote)
4. The char literal remained unterminated, breaking all subsequent highlighting

### The Fix

Added `\\` as a prioritized alternative before `'` and `\w` in the escape group:

`/\\(\\|'|"|\w|x\w{2}|u\w{4}|U\w{8})/`

This ensures that `\\` is correctly matched as an escaped backslash, not split into `\` + `\'`.

### Test

```rust
if text.contains('\\') || text.contains('/') {
    println!("found a slash");
}
```

**Before**: Everything after the first char literal was highlighted as string content
**After**: Both char literals and the rest of the code are correctly highlighted

### Verification

- All 1570 tests pass (0 failures)
- Tested various Rust escape sequences: `\n`, `\t`, `\0`, `\x41`, `\u0065`, `\'`
- Tested strings with backslashes (unaffected)
