### PR TITLE
fix(css): extend unicode-range regex to support 6-digit hex values

### DIFF
--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -11,7 +11,7 @@ export const MODES = (hljs) => {
     },
     UNICODE_RANGE: {
       scope: 'number',
-      begin: /\b[Uu]\+[0-9A-Fa-f][0-9A-Fa-f?]{0,4}(-[0-9A-Fa-f][0-9A-Fa-f]{0,4})?/
+      begin: /\b[Uu]\+[0-9A-Fa-f][0-9A-Fa-f?]{0,5}(-[0-9A-Fa-f][0-9A-Fa-f]{0,5})?/
     },
     FUNCTION_DISPATCH: {
       className: "built_in",


### PR DESCRIPTION
### Changes

Extended the UNICODE_RANGE regex in `css-shared.js` to support hex values up to 6 digits (e.g., `U+10FFFF`, `U+0-10FFFF`). The previous regex limited hexadecimal digits to 5 positions, causing values like `U+10FFFF` to be truncated to `U+10FFF`.

Changed `{0,4}` to `{0,5}` in both the prefix and suffix of the unicode range pattern to comply with the CSS spec which supports 1–6 digit hex values.

### Related Issue

Closes #4253

### Testing

Verified the fix with:
- `U+0-10FFFF` (full Unicode range)
- `U+000-5FF`, `U+1e00-1fff`, `U+2000-2300` (existing cases still work)
- `U+4?????` (wildcards with up to 6 ?)
- Multiple comma-separated ranges

### Checklist
- [x] Added markup tests, or they don't apply here because this is a regex-only change
- [ ] Updated the changelog at `CHANGES.md`