### PR TITLE
fix(javascript): add 'self' as a built-in variable (#4339)

### DIFF
--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -154,6 +154,7 @@ export const BUILT_IN_VARIABLES = [
   "console",
   "window",
   "document",
+  "self", // https://developer.mozilla.org/en-US/docs/Web/API/Window/self
   "localStorage",
   "sessionStorage",
   "module",


### PR DESCRIPTION
## Problem

`self` is a standard Web API global available in both window and Worker contexts, equivalent to `window` in browsing contexts. However, the JavaScript grammar does not include `self` in its built-in variable list, so it is not syntax highlighted like other globals.

## Changes

- `src/languages/javascript.js`: Added `'self'` to the `BUILT_IN_VARIABLES` array alongside existing entries like `window`, `globalThis`, and `global`.

## Why

`self` is a standard Web API global (`Window.self`, `WorkerGlobalScope.self`). It should be highlighted consistently with other global objects for proper syntax clarity.

Closes #4339