### PR TITLE
fix(javascript): prevent XML_TAG from matching TS type assertion with array syntax

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -47,7 +47,10 @@ export default function(hljs) {
         nextChar === "<" ||
         // the , gives away that this is not HTML
         // `<T, A extends keyof T, V>`
-        nextChar === ","
+        nextChar === "," ||
+        // the [ gives away that this is a type assertion, not HTML
+        // `<string[]>` in TypeScript type assertions
+        nextChar === "["
         ) {
         response.ignoreMatch();
         return;


### PR DESCRIPTION
## Problem

When TypeScript code uses angle bracket type assertions with array syntax (e.g. `<string[]>value`), the XML_TAG pattern in the JavaScript grammar incorrectly matches `<string` as a potential HTML tag start. Since the character immediately after `<string` is `[` (not `>` or a space/attribute), the existing checks don't catch it, causing the highlighter to enter XML sublanguage mode and break all subsequent highlighting.

## Root cause

The `isTrulyOpeningTag` function only checks for `,` and `<` as signals that the `<` is a TypeScript generic, not HTML. It did not account for `[`, which is the telltale sign of a TypeScript array type assertion (`<Type[]>`).

## Changes

- `src/languages/javascript.js`: Added `nextChar === "["` to the `isTrulyOpeningTag` ignore check. The `[` character cannot appear immediately after an HTML tag name, so this is a safe indicator of a TypeScript type assertion rather than an HTML tag.

## Why

This follows the same defensive pattern already in place for `,` and `<` — a single additional character check suffices because `[` cannot start a valid HTML/XML tag name.

## Test

```typescript
const myVar = <string[]>this.service.invoke();
```

Before: everything after `<string` loses highlighting.
After: the type assertion is correctly ignored.

Closes #4301