### PR TITLE
fix(bash): keep heredoc continuations highlighted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ New Grammars:
 
 Core Grammars:
 
+- fix(bash) keep heredoc continuation commands outside the string span, issue #4377 [puneetdixit200][]
 - fix(javascript) correctly highlight 'for await' again [wolfgang42][]
 - enh(csp) add missing directives / keywords from MDN (7 more) [Max Liashuk][]
 - enh(ada) add new `parallel` keyword, allow `[]` for Ada 2022 [Max Reznik][]
@@ -55,6 +56,7 @@ CONTRIBUTORS
 [te-ing]: https://github.com/te-ing
 [Anthony Martin]: https://github.com/anthony-c-martin
 [NriotHrreion]: https://github.com/NriotHrreion
+[puneetdixit200]: https://github.com/puneetdixit200
 
 
 ## Version 11.11.1

--- a/src/languages/bash.js
+++ b/src/languages/bash.js
@@ -50,16 +50,6 @@ export default function(hljs) {
       }
     }
   );
-  const HERE_DOC = {
-    begin: /<<-?\s*(?=\w+)/,
-    starts: { contains: [
-      hljs.END_SAME_AS_BEGIN({
-        begin: /(\w+)/,
-        end: /(\w+)/,
-        className: 'string'
-      })
-    ] }
-  };
   const QUOTE_STRING = {
     className: 'string',
     begin: /"/,
@@ -368,6 +358,52 @@ export default function(hljs) {
     "whoami",
     "yes"
   ];
+  const BASH_KEYWORDS = {
+    $pattern: /\b[a-z][a-z0-9._-]+\b/,
+    keyword: KEYWORDS,
+    literal: LITERALS,
+    built_in: [
+      ...SHELL_BUILT_INS,
+      ...BASH_BUILT_INS,
+      // Shell modifiers
+      "set",
+      "shopt",
+      ...ZSH_BUILT_INS,
+      ...GNU_CORE_UTILS
+    ]
+  };
+  let heredocDelimiter = "";
+  const HERE_DOC_BODY = {
+    className: 'string',
+    begin: /\n/,
+    end: /^\t*(\w+)$/m,
+    endsParent: true,
+    'on:end': (m, resp) => {
+      if (m[1] !== heredocDelimiter) resp.ignoreMatch();
+    }
+  };
+  const HERE_DOC = {
+    begin: /<<-?\s*(\w+)/,
+    'on:begin': (m) => { heredocDelimiter = m[1]; },
+    end: /\n/,
+    returnEnd: true,
+    keywords: BASH_KEYWORDS,
+    contains: [
+      ARITHMETIC,
+      COMMENT,
+      PATH_MODE,
+      QUOTE_STRING,
+      ESCAPED_QUOTE,
+      APOS_STRING,
+      ESCAPED_APOS,
+      VAR
+    ],
+    starts: {
+      contains: [
+        HERE_DOC_BODY
+      ]
+    }
+  };
 
   return {
     name: 'Bash',
@@ -375,20 +411,7 @@ export default function(hljs) {
       'sh',
       'zsh'
     ],
-    keywords: {
-      $pattern: /\b[a-z][a-z0-9._-]+\b/,
-      keyword: KEYWORDS,
-      literal: LITERALS,
-      built_in: [
-        ...SHELL_BUILT_INS,
-        ...BASH_BUILT_INS,
-        // Shell modifiers
-        "set",
-        "shopt",
-        ...ZSH_BUILT_INS,
-        ...GNU_CORE_UTILS
-      ]
-    },
+    keywords: BASH_KEYWORDS,
     contains: [
       KNOWN_SHEBANG, // to catch known shells and boost relevancy
       hljs.SHEBANG(), // to catch unknown shells but still highlight the shebang

--- a/test/markup/bash/heredoc-continuation.expect.txt
+++ b/test/markup/bash/heredoc-continuation.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-built_in">echo</span> <span class="hljs-string">&quot;ok&quot;</span> &lt;&lt;-EOF | <span class="hljs-built_in">cat</span><span class="hljs-string">
+	Hello
+EOF</span>

--- a/test/markup/bash/heredoc-continuation.txt
+++ b/test/markup/bash/heredoc-continuation.txt
@@ -1,0 +1,3 @@
+echo "ok" <<-EOF | cat
+	Hello
+EOF

--- a/test/markup/bash/strings.expect.txt
+++ b/test/markup/bash/strings.expect.txt
@@ -2,7 +2,7 @@ SCRIPT_DIR=<span class="hljs-string">&quot;<span class="hljs-subst">$( cd <span 
 TLS_DIR=<span class="hljs-string">&quot;<span class="hljs-variable">$SCRIPT_DIR</span>/../src/main/resources/tls&quot;</span>
 ROOT_DIR=<span class="hljs-string">&quot;<span class="hljs-variable">$SCRIPT_DIR</span>/..&quot;</span>
 
-jshell -s - &lt;&lt; <span class="hljs-string">EOF
+jshell -s - &lt;&lt; EOF<span class="hljs-string">
 System.out.printf(&quot;Procs: %s%n&quot;, getdata())
 EOF</span>
 


### PR DESCRIPTION
Fixes #4377.

## Summary
- Keep Bash heredoc continuation commands on the command line instead of folding them into the heredoc string.
- Start the heredoc string span on the following line and end it at the matching delimiter.
- Add a Bash markup regression for `<<-EOF | cat`.
- Update the existing Bash heredoc expectation and changelog entry.

## Tests
- Red before fix: the reported sample highlighted `EOF | cat` inside the heredoc string span, so `cat` was not highlighted as a command.
- `ONLY_LANGUAGES=bash npm run test-markup`
- `npx eslint --no-eslintrc -c .eslintrc.lang.js src/languages/bash.js`
- `npm run build`
- `git diff --check`

Note: I also ran the full `npm run test-markup`; it reached 537 passing tests and then hit the existing 2s Mocha timeout on `http/default`, unrelated to the Bash fixture. The Bash markup suite passed in both focused runs.
