### PR TITLE
fix(rust): recognize escaped backslash and quote in char literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 11.12.0
 
+Core Grammars:
+
+- fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
+
 Documentation:
 
 - referenced missing 3rd party ES|QL grammar to SUPPORTED_LANGUAGES [Elastic][]
@@ -9,6 +13,7 @@ CONTRIBUTORS
 
 [Dhruv Maniya]: https://github.com/iamdhrv
 [Elastic]: https://github.com/elastic
+[Sarath Francis]: https://github.com/sarathfrancis90
 
 
 ## Version 11.11.3

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -216,7 +216,7 @@ export default function(hljs) {
             contains: [
               {
                 scope: "char.escape",
-                match: /\\('|\w|x\w{2}|u\w{4}|U\w{8})/
+                match: /\\('|"|\\|\w|x\w{2}|u\w{4}|U\w{8})/
               }
             ]
           }

--- a/test/markup/rust/strings.expect.txt
+++ b/test/markup/rust/strings.expect.txt
@@ -3,8 +3,12 @@
 <span class="hljs-string">&#x27;<span class="hljs-char escape_">\x</span>1A&#x27;</span>;
 <span class="hljs-string">&#x27;<span class="hljs-char escape_">\u</span>12AS&#x27;</span>;
 <span class="hljs-string">&#x27;<span class="hljs-char escape_">\U</span>1234ASDF&#x27;</span>;
+<span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span>;
+<span class="hljs-string">&#x27;<span class="hljs-char escape_">\&#x27;</span>&#x27;</span>;
 <span class="hljs-string">&#x27;😭&#x27;</span>;
 <span class="hljs-string">b&#x27;a&#x27;</span>;
+<span class="hljs-keyword">let</span> <span class="hljs-variable">escaped</span> = <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span>;
+<span class="hljs-built_in">println!</span>(<span class="hljs-string">&quot;after a backslash char literal&quot;</span>);
 
 <span class="hljs-string">&quot;hello&quot;</span>;
 <span class="hljs-string">b&quot;hello&quot;</span>;

--- a/test/markup/rust/strings.txt
+++ b/test/markup/rust/strings.txt
@@ -3,8 +3,12 @@
 '\x1A';
 '\u12AS';
 '\U1234ASDF';
+'\\';
+'\'';
 '😭';
 b'a';
+let escaped = '\\';
+println!("after a backslash char literal");
 
 "hello";
 b"hello";


### PR DESCRIPTION
Resolves #4351

### Changes

The Rust char-literal mode listed the escapes `\'`, `\w`, `\xNN`, `\uNNNN` and `\UNNNNNNNN`, but not the backslash escape `\\` (or `\"`). So a literal like `'\\'` was read as a lone backslash followed by an escaped closing quote — the literal never terminated and everything after it on the line/file was highlighted as a string.

I added `\\` and `"` to the `char.escape` alternation so `'\\'` and `'\"'` are matched as complete escapes and the literal closes correctly. No other Rust cases are affected.

### Checklist
- [x] Added markup tests (extended `test/markup/rust/strings.txt` with `'\\'`, `'\''` and a line of code after a backslash char literal to prove highlighting no longer leaks)
- [x] Updated the changelog at `CHANGES.md`
