### PR TITLE
fix(groovy) support underscores in numeric literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## Version 11.11.3
+
+Core Grammars:
+
+- fix(groovy) support underscores in numeric literals [greymoth-jp][]
+
+CONTRIBUTORS
+
+[greymoth-jp]: https://github.com/greymoth-jp
+
+
 ## Version 11.11.2
 
 Parser Engine:

--- a/src/languages/groovy.js
+++ b/src/languages/groovy.js
@@ -6,6 +6,8 @@
  Category: system
  */
 
+import { NUMERIC } from "./lib/java.js";
+
 function variants(variants, obj = {}) {
   obj.variants = variants;
   return obj;
@@ -41,10 +43,9 @@ export default function(hljs) {
     begin: /~?\/[^\/\n]+\//,
     contains: [ hljs.BACKSLASH_ESCAPE ]
   };
-  const NUMBER = variants([
-    hljs.BINARY_NUMBER_MODE,
-    hljs.C_NUMBER_MODE
-  ]);
+  // Groovy uses the same numeric literal grammar as Java, including
+  // underscores as digit separators (e.g. 1_000, 0xFF_EC, 0b1010_0101).
+  const NUMBER = NUMERIC;
   const STRING = variants([
     {
       begin: /"""/,

--- a/test/markup/groovy/numbers.expect.txt
+++ b/test/markup/groovy/numbers.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">def</span> million = <span class="hljs-number">1_000_000</span>
+<span class="hljs-keyword">def</span> hex = <span class="hljs-number">0xCAFE_BABE</span>
+<span class="hljs-keyword">def</span> binary = <span class="hljs-number">0b0010_0101</span>
+<span class="hljs-keyword">def</span> fraction = <span class="hljs-number">3.141_592</span>
+<span class="hljs-keyword">def</span> big = <span class="hljs-number">100_000L</span>
+<span class="hljs-keyword">def</span> plain = <span class="hljs-number">1234</span>

--- a/test/markup/groovy/numbers.txt
+++ b/test/markup/groovy/numbers.txt
@@ -1,0 +1,6 @@
+def million = 1_000_000
+def hex = 0xCAFE_BABE
+def binary = 0b0010_0101
+def fraction = 3.141_592
+def big = 100_000L
+def plain = 1234


### PR DESCRIPTION
### Changes

Groovy uses the same numeric literal grammar as Java, which allows underscores as digit separators (`1_000`, `0xFF_EC`, `0b1010_0101`, `3.141_592`). The grammar was using the generic `C_NUMBER_MODE` / `BINARY_NUMBER_MODE`, neither of which accepts `_`, so anything past the first separator dropped out of the number.

Before:

- `1_000_000` -> `<number>1</number>_000_000`
- `0xFF_EC_DE_5E` -> `<number>0xFF</number>_EC_DE_5E`
- `0b1010_0101` -> `<number>0b1010</number>_0101`

After:

- `1_000_000` -> `<number>1_000_000</number>`
- `0xFF_EC_DE_5E` -> `<number>0xFF_EC_DE_5E</number>`
- `0b1010_0101` -> `<number>0b1010_0101</number>`

`kotlin.js` already handles this by importing the shared Java `NUMERIC` mode (with the note "the number mode of kotlin is the same as java 8"). Groovy is in the same spot, so this switches it to `NUMERIC` too. Same idea as #4280, which added digit separator support to C#.

### Checklist

- [x] Added markup tests (`test/markup/groovy/numbers`)
- [x] Updated the changelog at `CHANGES.md`
