### PR TITLE
fix(parser): count named capture groups when rewriting backreferences

### DIFF
--- a/src/lib/regex.js
+++ b/src/lib/regex.js
@@ -101,14 +101,17 @@ export function startsWith(re, lexeme) {
   return match && match.index === 0;
 }
 
-// BACKREF_RE matches an open parenthesis or backreference. To avoid
-// an incorrect parse, it additionally matches the following:
-// - [...] elements, where the meaning of parentheses and escapes change
-// - other escape sequences, so we do not misparse escape sequences as
-//   interesting elements
-// - non-matching or lookahead parentheses, which do not capture. These
-//   follow the '(' with a '?'.
-const BACKREF_RE = /\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./;
+// BACKREF_RE matches an open parenthesis or backreference. To avoid an
+// incorrect parse, it also matches the constructs where the meaning of
+// parentheses, escapes, or capture counting changes.
+const BACKREF_RE = new RegExp(either(
+  /\[(?:[^\\\]]|\\.)*\]/, // a character class, inside which ( and \ lose their meaning
+  /\(\?<(?![=!])[^>]+>/, // a named capture group `(?<name>` (not a lookbehind `(?<=` / `(?<!`)
+  /\(\?'[^']+'/, // a named capture group `(?'name'`
+  /\(\??/, // an opening parenthesis, capturing or non-capturing / lookahead
+  /\\([1-9][0-9]*)/, // a backreference like `\1`
+  /\\./ // any other escape sequence
+));
 
 // **INTERNAL** Not intended for outside usage
 // join logically computes regexps.join(separator), but fixes the
@@ -143,7 +146,7 @@ export function _rewriteBackreferences(regexps, { joinWith }) {
         out += '\\' + String(Number(match[1]) + offset);
       } else {
         out += match[0];
-        if (match[0] === '(') {
+        if (match[0] === '(' || /^\(\?[<']/.test(match[0])) {
           numCaptures++;
         }
       }

--- a/test/parser/named-group-backreference.js
+++ b/test/parser/named-group-backreference.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const hljs = require('../../build');
+
+describe('named capture group backreference', () => {
+  before(() => {
+    hljs.registerLanguage('named-backref-test', () => ({
+      contains: [
+        // A named capture group in an earlier joined rule must be counted so
+        // that the backreference in the following rule is renumbered correctly.
+        { begin: /(?<n>@)\w+/ },
+        { match: /(\w)\1/, scope: 'keyword' },
+      ],
+    }));
+  });
+
+  after(() => {
+    hljs.unregisterLanguage('named-backref-test');
+  });
+
+  it('renumbers a backreference that follows a named capture group', () => {
+    const result = hljs.highlight('hello', { language: 'named-backref-test' }).value;
+    result.should.equal('he<span class="hljs-keyword">ll</span>o');
+  });
+});


### PR DESCRIPTION
When several sibling rules of a mode are merged into the mode's single
multi-matcher, every numbered backreference is renumbered based on a running
count of capture groups. `_rewriteBackreferences` counts groups with
`BACKREF_RE`, whose `\(\??` branch skips a named capture group `(?<name>...)`.
So a named group in an earlier joined regex is not counted, the running total
drifts low, and every following `\1` or `\2` backreference resolves to the wrong
group.

For example a grammar with `{begin: /(?<n>@)\w+/}` before `{match: /(\w)\1/}`
highlights every character of `hello` instead of only the doubled `ll`, because
the `\1` is renumbered one short and matches the wrong group.

The fix recognizes `(?<name>` and `(?'name'` in `BACKREF_RE`, ordered before the
generic `(?` branch and guarded against the lookbehind forms `(?<=` and `(?<!`,
and counts them as captures. This matches `countMatchGroups`, which already
counts named groups through the real engine. Non-capturing, lookahead and
lookbehind groups are still not counted.
