### PR TITLE
docs(php): explain the difference between php and php-template

### DIFF
--- a/src/languages/php-template.js
+++ b/src/languages/php-template.js
@@ -3,6 +3,9 @@ Language: PHP Template
 Requires: xml.js, php.js
 Author: Josh Goebel <hello@joshgoebel.com>
 Website: https://www.php.net
+Description: Use this for HTML (or other markup) with embedded PHP, i.e. code
+             that includes the `<?php ... ?>` (or `<?= ... ?>`) tags. For
+             plain PHP code without the surrounding tags, use `php` instead.
 Category: common
 */
 

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -3,6 +3,10 @@ Language: PHP
 Author: Victor Karamzin <Victor.Karamzin@enterra-inc.com>
 Contributors: Evgeny Stepanischev <imbolk@gmail.com>, Ivan Sagalaev <maniac@softwaremaniacs.org>
 Website: https://www.php.net
+Description: Use this for plain PHP code, i.e. code that does not include the
+             surrounding `<?php ... ?>` tags. If your snippet mixes PHP with
+             HTML markup and the opening/closing tags, use `php-template`
+             instead.
 Category: common
 */
 


### PR DESCRIPTION
## Summary

Both the `php` and `php-template` language definitions only linked to https://www.php.net in their header comments, with nothing explaining when to use one over the other. Fixes #3765.

## Change

Added a `Description` field to each header (following the existing convention used by other language definitions):

- `php`: plain PHP code/snippets, i.e. without the surrounding `<?php ... ?>` tags
- `php-template`: markup (HTML, etc.) with embedded PHP that requires the opening/closing tags (`<?php ... ?>` or `<?= ... ?>`)

This matches the distinction a maintainer confirmed in the issue thread:

> - PHP templates are detected as php-template
> - Raw php code (snippets) are detected as php

## Testing

- `npm run lint-languages` — passes
- `npm run build && npm test` — full suite passes (1570 passing)