### PR TITLE
Add Xojo to supported languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -276,6 +276,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | x86 Assembly            | x86asm                 |         |
 | x86 Assembly (AT&T)     | x86asmatt              | [highlightjs-x86asmatt](https://github.com/gondow/highlightjs-x86asmatt)  |
 | XL                      | xl, tao                |         |
+| Xojo                    | xojo                   | [highlight.js-xojo](https://github.com/patricksalo/highlight.js-xojo) |
 | XQuery                  | xquery, xpath, xq, xqm |         |
 | YAML                    | yml, yaml              |         |
 | ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -276,7 +276,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | x86 Assembly            | x86asm                 |         |
 | x86 Assembly (AT&T)     | x86asmatt              | [highlightjs-x86asmatt](https://github.com/gondow/highlightjs-x86asmatt)  |
 | XL                      | xl, tao                |         |
-| Xojo                    | xojo                   | [highlight.js-xojo](https://github.com/patricksalo/highlight.js-xojo) |
+| Xojo                    | xojo                   | [highlightjs-xojo](https://github.com/patricksalo/highlight.js-xojo) |
 | XQuery                  | xquery, xpath, xq, xqm |         |
 | YAML                    | yml, yaml              |         |
 | ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -276,7 +276,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | x86 Assembly            | x86asm                 |         |
 | x86 Assembly (AT&T)     | x86asmatt              | [highlightjs-x86asmatt](https://github.com/gondow/highlightjs-x86asmatt)  |
 | XL                      | xl, tao                |         |
-| Xojo                    | xojo                   | [highlightjs-xojo](https://github.com/patricksalo/highlight.js-xojo) |
+| Xojo                    | xojo                   | [highlightjs-xojo](https://github.com/patricksalo/highlightjs-xojo) |
 | XQuery                  | xquery, xpath, xq, xqm |         |
 | YAML                    | yml, yaml              |         |
 | ZenScript               | zenscript, zs          |[highlightjs-zenscript](https://github.com/highlightjs/highlightjs-zenscript) |


### PR DESCRIPTION
Adds Xojo to SUPPORTED_LANGUAGES.md.

This follows the current guidance to list third-party/community-supported languages here rather than integrating them directly into the main highlight.js repository.