### PR TITLE
fix(crystal): stop treating integer division // as a regex literal

### DIFF
--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -159,6 +159,16 @@ export default function(hljs) {
         // a regex here would also make this variant swallow the rest of
         // the line (or file) whenever `//` appears at the start of a
         // statement, since there would be no closing delimiter to match.
+        //
+        // INTEGER_DIVISION (above, given priority over this REGEXP mode)
+        // already handles the common case where `//` starts matching at the
+        // same position as this mode, e.g. mid-expression like
+        // `something // 4`. But this outer REGEXP mode's `begin` can also
+        // start matching one character earlier, at a preceding newline
+        // (via its `\n` alternative), when `//`/`//=` is the first thing on
+        // a line; in that case INTEGER_DIVISION never gets a chance to
+        // compete, so this lookahead is what stops `//` from being
+        // misclassified as a regexp there too.
         begin: '/(?!\\/)',
         end: '/[a-z]*'
       }

--- a/src/languages/crystal.js
+++ b/src/languages/crystal.js
@@ -154,16 +154,13 @@ export default function(hljs) {
           hljs.BACKSLASH_ESCAPE,
           SUBST
         ],
-        variants: [
-          {
-            begin: '//[a-z]*',
-            relevance: 0
-          },
-          {
-            begin: '/(?!\\/)',
-            end: '/[a-z]*'
-          }
-        ]
+        // Unlike Ruby, Crystal has no "empty regex" (`//`) literal syntax,
+        // since `//` is already used for integer division. Treating it as
+        // a regex here would also make this variant swallow the rest of
+        // the line (or file) whenever `//` appears at the start of a
+        // statement, since there would be no closing delimiter to match.
+        begin: '/(?!\\/)',
+        end: '/[a-z]*'
       }
     ],
     relevance: 0
@@ -208,11 +205,21 @@ export default function(hljs) {
     end: '\\]',
     contains: [ hljs.inherit(hljs.QUOTE_STRING_MODE, { className: 'string' }) ]
   };
+  // Unlike Ruby, Crystal uses `//` (and `//=`) as the integer division
+  // operator. Without this mode taking precedence, the REGEXP heuristic
+  // below (borrowed from Ruby, where `//` doesn't have a special meaning)
+  // would mistake it for the start of an (empty) regex literal and swallow
+  // the remainder of the line, or even the file.
+  const INTEGER_DIVISION = {
+    begin: /\/\/=?/,
+    relevance: 0
+  };
   const CRYSTAL_DEFAULT_CONTAINS = [
     EXPANSION,
     STRING,
     Q_STRING,
     REGEXP2,
+    INTEGER_DIVISION,
     REGEXP,
     ATTRIBUTE,
     VARIABLE,

--- a/test/markup/crystal/integer-division.expect.txt
+++ b/test/markup/crystal/integer-division.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-function"><span class="hljs-keyword">def</span> <span class="hljs-title">something</span></span>()
+    something // <span class="hljs-number">4</span>
+<span class="hljs-keyword">end</span>

--- a/test/markup/crystal/integer-division.txt
+++ b/test/markup/crystal/integer-division.txt
@@ -1,0 +1,3 @@
+def something()
+    something // 4
+end

--- a/test/markup/crystal/operators.expect.txt
+++ b/test/markup/crystal/operators.expect.txt
@@ -16,8 +16,8 @@
 &gt;=
 &lt;=&gt;
 ===
-<span class="hljs-regexp">//</span>
-<span class="hljs-regexp">//</span>=
+//
+//=
 &amp;+
 &amp;-
 &amp;*


### PR DESCRIPTION
Fixes #3730

## Summary of Changes

Crystal uses `//` (and `//=`) as its integer division operator, but the REGEXP detection heuristic in `src/languages/crystal.js` was borrowed from Ruby, where `//` has no special meaning and is instead treated as an empty regex literal.

This caused two related problems:

- Mid-expression, e.g. `something // 4`, the first `/` was consumed as a generic "regex starter" operator, leaving the second `/` to open an unterminated regex that swallowed the rest of the line (as reported in the issue), or even the rest of the file.
- At the start of a line/statement, e.g. `//` or `//=` on their own, the "empty regex" variant (`//[a-z]*`) matched `//` directly, again misclassifying the division operator as a regexp span. This was actually already baked into the `operators.expect.txt` test fixture as the (buggy) expected output.

This PR:

- Adds a dedicated `INTEGER_DIVISION` mode matching `//` and `//=`, given priority over the regex heuristic in the `contains` list, so it wins whenever the two would otherwise tie for the same starting position.
- Drops the ambiguous "empty regex" variant from the regexp heuristic, since Crystal doesn't actually support that syntax, and it's what let `//` seep through at the start of a line even where `INTEGER_DIVISION` wasn't a tied first alternative.
- Updates `test/markup/crystal/operators.expect.txt` to reflect the corrected (unstyled) output for `//` and `//=`.
- Adds a new `test/markup/crystal/integer-division.txt` regression test reproducing the exact snippet from the issue.

Regex literal detection after keywords and operators (`if /foo/`, `+/foo/`, etc., already covered by `test/markup/crystal/regexes.txt`) continues to work as before.

## Testing instructions

Ran the full test suite (`npx mocha`), all 1574 tests pass, plus `npx eslint --no-eslintrc -c .eslintrc.lang.js src/languages/crystal.js` with no warnings.

Manually verified before/after with the reproduction from the issue:

```crystal
def something()
    something // 4
end
```

Before: everything from the second `/` onward (`/ 4\nend`) was wrapped in `hljs-regexp`.
After: `//` is left unstyled (as an operator) and `4` is correctly highlighted as a number.