### PR TITLE
CI: Add node 24.x to ci and remove 21.x

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # All 'LTS' and 'Current' versions (https://nodejs.org/en/about/previous-releases)
-        node-version: [18.x, 20.x, 21.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:

--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # All 'LTS' and 'Current' versions (https://nodejs.org/en/about/previous-releases)
-        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:

--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # All 'LTS' and 'Current' versions (https://nodejs.org/en/about/previous-releases)
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
         build-how: ["node", "browser", "browser -n", "cdn :common"]
 
     steps:


### PR DESCRIPTION
24.x is a lts release. 21.x was just a normal release, never a lts so can be dropped.