### PR TITLE
docs: add Cedar to supported languages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,11 @@
 Documentation:
 
 - referenced missing 3rd party ES|QL grammar to SUPPORTED_LANGUAGES [Elastic][]
+- added 3rd party Cedar grammar to SUPPORTED_LANGUAGES [Dhruv Maniya][]
 
 CONTRIBUTORS
 
+[Dhruv Maniya]: https://github.com/iamdhrv
 [Elastic]: https://github.com/elastic
 
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -48,6 +48,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Cache Object Script     | cos, cls               |         |
 | Candid                  | candid, did            | [highlightjs-motoko](https://github.com/rvanasa/highlightjs-motoko) |
 | Cap’n Proto             | capnproto, capnp       |         |
+| Cedar                   | cedar, cedarschema     | [highlightjs-cedar](https://github.com/cedar-policy/highlightjs-cedar) |
 | Chaos                   | chaos, kaos            | [highlightjs-chaos](https://github.com/chaos-lang/highlightjs-chaos) |
 | Chapel                  | chapel, chpl           | [highlightjs-chapel](https://github.com/chapel-lang/highlightjs-chapel) |
 | Cisco CLI               | cisco                  | [highlightjs-cisco-cli](https://github.com/BMatheas/highlightjs-cisco-cli) |


### PR DESCRIPTION
<!-- Please link to a related issue below. -->
Refs #4164

### Changes
- Add the Cedar third-party grammar package to `SUPPORTED_LANGUAGES.md`.
- Include both registered identifiers from the Cedar package: `cedar` and `cedarschema`.
- Add a matching `CHANGES.md` documentation entry.

### Checklist
- [x] Added markup tests, or they don't apply here because this only updates the supported-language documentation table and changelog.
- [x] Updated the changelog at `CHANGES.md`
