### PR TITLE
Fix dead JSFiddle link in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ assignees: ''
 Please include sample code or step-by-step instructions to reproduce the bug you are seeing.  If you attach a screenshot PLEASE also provide any actually code shown in plaintext as well so that we can easily copy/paste if necessary to help resolve the issue.
 
 A jsfiddle can sometimes be even better.  You can fork an example test case:
-https://jsfiddle.net/ajoshguy/gfzujpyt/
+https://jsfiddle.net/ajoshguy/cjhvre2k/
 -->
 
 


### PR DESCRIPTION
## Summary

Update the bug-report issue template to use the working JSFiddle example already referenced by the contribution and syntax-request templates.

The previous example returns 404, which prevents reporters from forking the suggested reproduction case.

Fixes #4012.

## Validation

- confirmed the previous URL returns 404
- confirmed the replacement URL returns 200
- verified all repository references now use the same example
- `git diff --check` passed
