### PR TITLE
fix(cpp): highlight digit separators in defines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Core Grammars:
 
 - enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
+- fix(c, cpp) recognize digit separators in preprocessor definitions, issue #4443 [Dhruv Maniya][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
 - fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
 - fix(cmake) only highlight standalone numbers, not digits that begin an identifier (e.g. `3rdparty`), issue #4170 [MarkXian][]

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -119,6 +119,7 @@ export default function(hljs) {
         begin: /\\\n/,
         relevance: 0
       },
+      NUMBERS,
       hljs.inherit(STRINGS, { className: 'string' }),
       {
         className: 'string',

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -106,27 +106,54 @@ export default function(hljs) {
   ],
     relevance: 0
   };  
+
+  const CONTINUED_PREPROCESSOR_NUMBER = {
+    className: 'number',
+    begin: /[+-]?\b[0-9](?:'?[0-9])*(?:'\\\n[0-9](?:'?[0-9])*)+/,
+    relevance: 0
+  };
+
+  const UNHIGHLIGHTED_PREPROCESSOR_NUMBER = {
+    begin: /[+-]?\b[0-9](?:'?[0-9])*/,
+    relevance: 0
+  };
+
+  const PREPROCESSOR_CONTAINS = [
+    {
+      begin: /\\\n/,
+      relevance: 0
+    },
+    hljs.inherit(STRINGS, { className: 'string' }),
+    {
+      className: 'string',
+      begin: /<.*?>/
+    },
+    C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE
+  ];
   
   const PREPROCESSOR = {
     className: 'meta',
-    begin: /#\s*[a-z]+\b/,
     end: /$/,
     keywords: { keyword:
         'if else elif endif define undef warning error line '
         + 'pragma _Pragma ifdef ifndef elifdef elifndef include' },
-    contains: [
+    variants: [
       {
-        begin: /\\\n/,
-        relevance: 0
+        begin: /#\s*define\b/,
+        contains: [
+          CONTINUED_PREPROCESSOR_NUMBER,
+          NUMBERS,
+          ...PREPROCESSOR_CONTAINS
+        ]
       },
-      NUMBERS,
-      hljs.inherit(STRINGS, { className: 'string' }),
       {
-        className: 'string',
-        begin: /<.*?>/
-      },
-      C_LINE_COMMENT_MODE,
-      hljs.C_BLOCK_COMMENT_MODE
+        begin: /#\s*[a-z]+\b/,
+        contains: [
+          UNHIGHLIGHTED_PREPROCESSOR_NUMBER,
+          ...PREPROCESSOR_CONTAINS
+        ]
+      }
     ]
   };
 

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -106,6 +106,7 @@ export default function(hljs) {
         begin: /\\\n/,
         relevance: 0
       },
+      NUMBERS,
       hljs.inherit(STRINGS, { className: 'string' }),
       {
         className: 'string',

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -94,26 +94,53 @@ export default function(hljs) {
     relevance: 0
   };
 
+  const CONTINUED_PREPROCESSOR_NUMBER = {
+    className: 'number',
+    begin: /[+-]?\b[0-9](?:'?[0-9])*(?:'\\\n[0-9](?:'?[0-9])*)+/,
+    relevance: 0
+  };
+
+  const UNHIGHLIGHTED_PREPROCESSOR_NUMBER = {
+    begin: /[+-]?\b[0-9](?:'?[0-9])*/,
+    relevance: 0
+  };
+
+  const PREPROCESSOR_CONTAINS = [
+    {
+      begin: /\\\n/,
+      relevance: 0
+    },
+    hljs.inherit(STRINGS, { className: 'string' }),
+    {
+      className: 'string',
+      begin: /<.*?>/
+    },
+    C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE
+  ];
+
   const PREPROCESSOR = {
     className: 'meta',
-    begin: /#\s*[a-z]+\b/,
     end: /$/,
     keywords: { keyword:
         'if else elif endif define undef warning error line '
         + 'pragma _Pragma ifdef ifndef include' },
-    contains: [
+    variants: [
       {
-        begin: /\\\n/,
-        relevance: 0
+        begin: /#\s*define\b/,
+        contains: [
+          CONTINUED_PREPROCESSOR_NUMBER,
+          NUMBERS,
+          ...PREPROCESSOR_CONTAINS
+        ]
       },
-      NUMBERS,
-      hljs.inherit(STRINGS, { className: 'string' }),
       {
-        className: 'string',
-        begin: /<.*?>/
-      },
-      C_LINE_COMMENT_MODE,
-      hljs.C_BLOCK_COMMENT_MODE
+        begin: /#\s*[a-z]+\b/,
+        contains: [
+          UNHIGHLIGHTED_PREPROCESSOR_NUMBER,
+          ...PREPROCESSOR_CONTAINS
+        ]
+      }
     ]
   };
 

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -42,5 +42,7 @@
 <span class="hljs-number">6ULL</span> <span class="hljs-number">6Ull</span> <span class="hljs-number">6uLL</span> <span class="hljs-number">6ull</span>
 <span class="hljs-number">7LLU</span> <span class="hljs-number">7LLu</span> <span class="hljs-number">7llU</span> <span class="hljs-number">7llu</span>
 
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> C23_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;000</span></span>
+
 <span class="hljs-comment">// Character array.</span>
 <span class="hljs-type">char</span> word[] = { <span class="hljs-string">&#x27;3&#x27;</span>, <span class="hljs-string">&#x27;\0&#x27;</span> };

--- a/test/markup/c/number-literals.expect.txt
+++ b/test/markup/c/number-literals.expect.txt
@@ -43,6 +43,10 @@
 <span class="hljs-number">7LLU</span> <span class="hljs-number">7LLu</span> <span class="hljs-number">7llU</span> <span class="hljs-number">7llu</span>
 
 <span class="hljs-meta">#<span class="hljs-keyword">define</span> C23_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;000</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> CONTINUED_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;\
+000</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">if</span> 1&#x27;000 &gt; 0</span>
+<span class="hljs-meta">#<span class="hljs-keyword">endif</span></span>
 
 <span class="hljs-comment">// Character array.</span>
 <span class="hljs-type">char</span> word[] = { <span class="hljs-string">&#x27;3&#x27;</span>, <span class="hljs-string">&#x27;\0&#x27;</span> };

--- a/test/markup/c/number-literals.txt
+++ b/test/markup/c/number-literals.txt
@@ -42,5 +42,7 @@
 6ULL 6Ull 6uLL 6ull
 7LLU 7LLu 7llU 7llu
 
+#define C23_DIGIT_SEPARATOR 10'000
+
 // Character array.
 char word[] = { '3', '\0' };

--- a/test/markup/c/number-literals.txt
+++ b/test/markup/c/number-literals.txt
@@ -43,6 +43,10 @@
 7LLU 7LLu 7llU 7llu
 
 #define C23_DIGIT_SEPARATOR 10'000
+#define CONTINUED_DIGIT_SEPARATOR 10'\
+000
+#if 1'000 > 0
+#endif
 
 // Character array.
 char word[] = { '3', '\0' };

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -1,5 +1,6 @@
 <span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;iostream&gt;</span></span>
-<span class="hljs-meta">#<span class="hljs-keyword">define</span> foo 1&lt;&lt;16</span>
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> foo <span class="hljs-number">1</span>&lt;&lt;<span class="hljs-number">16</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> CPP14_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;000</span></span>
 
 <span class="hljs-meta">#<span class="hljs-keyword">ifdef</span> DEBUG</span>
 <span class="hljs-function">TYPE1 <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-type">void</span>)</span>

--- a/test/markup/cpp/preprocessor.expect.txt
+++ b/test/markup/cpp/preprocessor.expect.txt
@@ -1,6 +1,10 @@
 <span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;iostream&gt;</span></span>
 <span class="hljs-meta">#<span class="hljs-keyword">define</span> foo <span class="hljs-number">1</span>&lt;&lt;<span class="hljs-number">16</span></span>
 <span class="hljs-meta">#<span class="hljs-keyword">define</span> CPP14_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;000</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> CONTINUED_DIGIT_SEPARATOR <span class="hljs-number">10&#x27;\
+000</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">if</span> 1&#x27;000 &gt; 0</span>
+<span class="hljs-meta">#<span class="hljs-keyword">endif</span></span>
 
 <span class="hljs-meta">#<span class="hljs-keyword">ifdef</span> DEBUG</span>
 <span class="hljs-function">TYPE1 <span class="hljs-title">foo</span><span class="hljs-params">(<span class="hljs-type">void</span>)</span>

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -1,5 +1,6 @@
 #include <iostream>
 #define foo 1<<16
+#define CPP14_DIGIT_SEPARATOR 10'000
 
 #ifdef DEBUG
 TYPE1 foo(void)

--- a/test/markup/cpp/preprocessor.txt
+++ b/test/markup/cpp/preprocessor.txt
@@ -1,6 +1,10 @@
 #include <iostream>
 #define foo 1<<16
 #define CPP14_DIGIT_SEPARATOR 10'000
+#define CONTINUED_DIGIT_SEPARATOR 10'\
+000
+#if 1'000 > 0
+#endif
 
 #ifdef DEBUG
 TYPE1 foo(void)


### PR DESCRIPTION
### Changes

- run the existing C/C++ number modes before string modes inside preprocessor directives
- add markup regressions for apostrophe digit separators in `#define` values
- add the required changelog entry

This prevents literals such as `100'000` in a macro definition from treating the apostrophe as the start of a string while preserving normal preprocessor string handling.

Resolves #4443

### Validation

- `npm run build`
- `ONLY_LANGUAGES="c cpp" npm run test-markup` (`18 passed`)
- `npm test` (`1578 passed`, `3 pending`)
- ESLint on the changed C and C++ grammar files
- `git diff --check`

### Checklist

- [x] Added markup tests for both affected languages
- [x] Updated the changelog at `CHANGES.md`

Development note: implemented with Codex assistance and validated locally with the full Node.js test suite.
