### PR TITLE
fix(javascript): highlight self as a built-in global

### DIFF
--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -154,6 +154,7 @@ export const BUILT_IN_VARIABLES = [
   "console",
   "window",
   "document",
+  "self",
   "localStorage",
   "sessionStorage",
   "module",

--- a/test/markup/javascript/built-in-variables.expect.txt
+++ b/test/markup/javascript/built-in-variables.expect.txt
@@ -1,0 +1,3 @@
+<span class="hljs-variable language_">window</span>
+<span class="hljs-variable language_">document</span>
+<span class="hljs-variable language_">self</span>

--- a/test/markup/javascript/built-in-variables.txt
+++ b/test/markup/javascript/built-in-variables.txt
@@ -1,0 +1,3 @@
+window
+document
+self


### PR DESCRIPTION
## Summary
- Adds `self` to `BUILT_IN_VARIABLES` in `ecmascript.js` so it is highlighted with the same `variable.language` class as `window` and `document`
- Adds a markup test covering `window`, `document`, and `self`

Fixes #4339

## Test plan
- [x] `npm run build`
- [x] `ONLY_LANGUAGES=javascript npm run test-markup` (24 passing)