### PR TITLE
Fix C++ auto-detection for trailing return types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- fix(cpp) recognize trailing return types in function declarations, issue #3673 [Aysajan Eziz][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
 - fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
 - fix(cmake) only highlight standalone numbers, not digits that begin an identifier (e.g. `3rdparty`), issue #4170 [MarkXian][]
@@ -14,6 +15,7 @@ Documentation:
 
 CONTRIBUTORS
 
+[Aysajan Eziz]: https://github.com/AysajanE
 [arturict]: https://github.com/arturict
 [Dhruv Maniya]: https://github.com/iamdhrv
 [Elastic]: https://github.com/elastic

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -478,7 +478,7 @@ export default function(hljs) {
     end: /[{;=]/,
     excludeEnd: true,
     keywords: CPP_KEYWORDS,
-    illegal: /[^\w\s\*&:<>.]/,
+    illegal: /(?!->)[^\w\s\*&:<>.]/,
     contains: [
       { // to prevent it from being confused as the function title
         begin: DECLTYPE_AUTO_RE,

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -54,4 +54,20 @@ describe('.highlight()', () => {
       '<span class="hljs-type">int</span> z)</span>;'
     );
   });
+  it('should detect C++ functions with a trailing return type', () => {
+    const code = 'auto main() -> int {\n  auto i = 42; // test\n  return i;\n}';
+    const result = hljs.highlightAuto(code, [ 'cpp' ]);
+
+    should(result.language).equal(
+      'cpp',
+      'C++ trailing return type was not auto-detected'
+    );
+    result.illegal.should.equal(false);
+  });
+  it('should keep standalone hyphens illegal in C++ function declarations', () => {
+    const code = 'auto main() - int { return 0; }';
+    const result = hljs.highlight(code, { language: 'cpp', ignoreIllegals: false });
+
+    result.illegal.should.equal(true);
+  });
 });


### PR DESCRIPTION
Resolves #3673

### Changes

- allow the C++ function-declaration mode to accept a trailing-return arrow without accepting standalone hyphens
- add positive and negative API regression tests for the narrowed grammar behavior
- update the current changelog

### Checklist

- [x] Markup tests do not apply because this is an auto-detection regression; API regression tests cover both the reported behavior and the preserved illegal-hyphen behavior.
- [x] Updated the changelog at `CHANGES.md`

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1054:start -->
### Verification

[Northset proof-of-pass receipt M-1054](https://northset-oss.github.io/verification-pilot/receipts/M-1054/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1054:end -->
