### PR TITLE
enh(dos): add batch as language alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
 - fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
 - fix(cmake) only highlight standalone numbers, not digits that begin an identifier (e.g. `3rdparty`), issue #4170 [MarkXian][]
@@ -17,6 +18,7 @@ Documentation:
 
 CONTRIBUTORS
 
+[Hashim Khan]: https://github.com/Hashim1999164
 [arturict]: https://github.com/arturict
 [Dhruv Maniya]: https://github.com/iamdhrv
 [Elastic]: https://github.com/elastic

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -75,7 +75,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | DNS Zone file           | dns, zone, bind        |         |
 | Dockerfile              | dockerfile, docker     |         |
 | Djot                    | djot, dj               |[highlightjs-djot](https://github.com/php-collective/highlightjs-djot) |
-| DOS                     | dos, bat, cmd          |         |
+| DOS                     | dos, bat, batch, cmd   |         |
 | dsconfig                | dsconfig               |         |
 | DTS (Device Tree)       | dts                    |         |
 | Dust                    | dust, dst              |         |

--- a/src/languages/dos.js
+++ b/src/languages/dos.js
@@ -132,6 +132,7 @@ export default function(hljs) {
     name: 'Batch file (DOS)',
     aliases: [
       'bat',
+      'batch',
       'cmd'
     ],
     case_insensitive: true,


### PR DESCRIPTION
## Summary
- Add `batch` as an alias for the existing DOS / batch file grammar (alongside `bat` and `cmd`).
- Update `SUPPORTED_LANGUAGES.md` and `CHANGES.md`.

Fixes #4395

## Test plan
- [ ] Confirm `hljs.getLanguage('batch')` resolves to the DOS grammar
- [ ] Confirm `bat` and `cmd` aliases still work
- [ ] Spot-check highlighting on a small `.bat` sample with `language-batch`