### PR TITLE
fix(haskell): highlight where in GADT declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Core Grammars:
 - fix(cpp) require a word boundary before numeric literals so digits inside identifiers aren't highlighted as numbers, issue #4231 [Mark Xian][]
 - fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [MarkXian][]
 - fix(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
+- fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
 
@@ -28,6 +29,7 @@ CONTRIBUTORS
 [Sarath Francis]: https://github.com/sarathfrancis90
 [Mark Xian]: https://github.com/xianjianlf2
 [Nicolas Le Cam]: https://github.com/KuSh
+[Konstantin Baltsat]: https://github.com/Baltsat
 
 
 ## Version 11.11.3

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -141,7 +141,7 @@ export default function(hljs) {
         className: 'class',
         begin: '\\b(data|(new)?type)\\b',
         end: '$',
-        keywords: 'data family type newtype deriving',
+        keywords: 'data family type newtype deriving where',
         contains: [
           PRAGMA,
           CONSTRUCTOR,

--- a/test/markup/haskell/gadt.expect.txt
+++ b/test/markup/haskell/gadt.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-class"><span class="hljs-keyword">data</span> <span class="hljs-type">Expr</span> a <span class="hljs-keyword">where</span></span>
+  <span class="hljs-type">Lit</span> :: <span class="hljs-type">Int</span> -&gt; <span class="hljs-type">Expr</span> <span class="hljs-type">Int</span>
+
+<span class="hljs-class"><span class="hljs-keyword">newtype</span> <span class="hljs-type">Identity</span> a <span class="hljs-keyword">where</span></span>
+  <span class="hljs-type">Identity</span> :: a -&gt; <span class="hljs-type">Identity</span> a
+
+<span class="hljs-class"><span class="hljs-keyword">type</span> <span class="hljs-keyword">family</span> <span class="hljs-type">Element</span> c <span class="hljs-keyword">where</span></span>
+  <span class="hljs-type">Element</span> [a] = a

--- a/test/markup/haskell/gadt.txt
+++ b/test/markup/haskell/gadt.txt
@@ -1,0 +1,8 @@
+data Expr a where
+  Lit :: Int -> Expr Int
+
+newtype Identity a where
+  Identity :: a -> Identity a
+
+type family Element c where
+  Element [a] = a


### PR DESCRIPTION
Resolves #3753.

### Changes

- highlight `where` inside Haskell `data`, `newtype`, and closed type-family declarations
- add markup coverage for all three valid forms
- update `CHANGES.md`

This follows up on #3754, which was closed for inactivity. It also answers the open syntax question there: GHC documents `where` for both [`data` and `newtype` GADT-style declarations](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/gadt_syntax.html) and for [closed type families](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/type_families.html#closed-type-families).

### Verification

- regression fixture fails before the grammar change and passes after it
- `npm run build`
- `ONLY_LANGUAGES=haskell npm run test-markup` — 7 passing
- `npm run test` — 1583 passing, 3 pending
- `npm run lint-languages`
- `npm run lint` — 0 errors; one existing ignored-vendor warning

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
