### PR TITLE
fix(css): support six-digit unicode ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Core Grammars:
 - fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [MarkXian][]
 - fix(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
+- fix(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
 

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -11,7 +11,7 @@ export const MODES = (hljs) => {
     },
     UNICODE_RANGE: {
       scope: 'number',
-      begin: /\b[Uu]\+[0-9A-Fa-f][0-9A-Fa-f?]{0,4}(-[0-9A-Fa-f][0-9A-Fa-f]{0,4})?/
+      begin: /\b[Uu]\+[0-9A-Fa-f][0-9A-Fa-f?]{0,5}(-[0-9A-Fa-f][0-9A-Fa-f]{0,5})?/
     },
     FUNCTION_DISPATCH: {
       className: "built_in",

--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -55,6 +55,7 @@
   <span class="hljs-attribute">font-feature-settings</span>: <span class="hljs-string">&quot;liga&quot;</span> <span class="hljs-number">0</span>;
   <span class="hljs-attribute">font-variation-settings</span>: <span class="hljs-string">&quot;xhgt&quot;</span> <span class="hljs-number">0.7</span>;
   <span class="hljs-attribute">unicode-range</span>: <span class="hljs-number">U+0025-00FF</span>, <span class="hljs-number">U+4??</span>;
+  <span class="hljs-attribute">unicode-range</span>: <span class="hljs-number">U+10FFFF</span>, <span class="hljs-number">U+0-10FFFF</span>, <span class="hljs-number">U+0?????</span>;
   <span class="hljs-comment">/* it&#x27;s not 100% clear how url and format should be highlighted universally */</span>
   <span class="hljs-comment">/* src: url(&quot;/fonts/OpenSans-Regular-webfont.woff2&quot;) format(&quot;woff2&quot;),
        url(&quot;/fonts/OpenSans-Regular-webfont.woff&quot;) format(&quot;woff&quot;); */</span>

--- a/test/markup/css/css_consistency.txt
+++ b/test/markup/css/css_consistency.txt
@@ -55,6 +55,7 @@ a[href*="example"] {}
   font-feature-settings: "liga" 0;
   font-variation-settings: "xhgt" 0.7;
   unicode-range: U+0025-00FF, U+4??;
+  unicode-range: U+10FFFF, U+0-10FFFF, U+0?????;
   /* it's not 100% clear how url and format should be highlighted universally */
   /* src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
        url("/fonts/OpenSans-Regular-webfont.woff") format("woff"); */


### PR DESCRIPTION
Follow-up to #4253 and #4254. This also supersedes the author-closed #4406 by adding the requested markup coverage and changelog entry.

### Changes

- accept the CSS Fonts limit of one to six hexadecimal digits in `unicode-range`
- cover `U+10FFFF`, `U+0-10FFFF`, and `U+0?????` in the shared CSS markup fixture
- document the fix in `CHANGES.md`

The CSS Fonts specification defines the initial range as `U+0-10FFFF` and permits one to six hexadecimal digits:
https://drafts.csswg.org/css-fonts/#unicode-range-desc

Before this patch, current `main` highlighted only `U+10FFF` in `U+10FFFF`, leaving the final `F` unclassified. The branch highlights each full token.

### Validation

- `npm run build`
- `npm run test-markup` — 550 passing
- `npm run lint-languages`
- `npm test` — 1,583 passing, 3 pending
- `git diff --check`

This change was AI-assisted; I reproduced the behavior on current `main`, inspected the exact diff, and ran the checks above locally.

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`
