### PR TITLE
fix(java): support qualified generic type arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Core Grammars:
 - fix(cpp) require a word boundary before numeric literals so digits inside identifiers aren't highlighted as numbers, issue #4231 [Mark Xian][]
 - fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [MarkXian][]
 - fix(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
+- fix(java) recognize fully qualified names in generic type arguments, issue #3677 [Konstantin Baltsat][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - fix(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -38,7 +38,7 @@ export default function(hljs) {
 
   // A simple Java type: a type name, optionally followed by type arguments and/or array brackets
   // '<@@@>' is replaced with the pattern for optional type arguments by recurRegex below.
-  const SIMPLE_TYPE_RE = JAVA_IDENT_RE + '<@@@>' + ARRAY_BRACKETS_OPTIONAL_RE;
+  const SIMPLE_TYPE_RE = JAVA_IDENT_RE + '(?:\\.' + JAVA_IDENT_RE + ')*<@@@>' + ARRAY_BRACKETS_OPTIONAL_RE;
 
   // A bounded (? extends Number) or unbounded (?) wildcard type
   const WILDCARD_TYPE_RE = '\\?(?:\\s+(?:extends|super)\\s+' + SIMPLE_TYPE_RE + ')?';

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -36,9 +36,9 @@ export default function(hljs) {
   // Optional 1..n pairs of square brackets identifying an array type
   const ARRAY_BRACKETS_OPTIONAL_RE = '(?:(?:\\s*\\[\\s*])+)?';
 
-  // A simple Java type: a type name, optionally followed by type arguments and/or array brackets
+  // A simple Java type: a type name (optionally package-qualified), optionally followed by type arguments and/or array brackets
   // '<@@@>' is replaced with the pattern for optional type arguments by recurRegex below.
-  const SIMPLE_TYPE_RE = JAVA_IDENT_RE + '<@@@>' + ARRAY_BRACKETS_OPTIONAL_RE;
+  const SIMPLE_TYPE_RE = JAVA_IDENT_RE + '(?:\\.' + JAVA_IDENT_RE + ')*<@@@>' + ARRAY_BRACKETS_OPTIONAL_RE;
 
   // A bounded (? extends Number) or unbounded (?) wildcard type
   const WILDCARD_TYPE_RE = '\\?(?:\\s+(?:extends|super)\\s+' + SIMPLE_TYPE_RE + ')?';

--- a/test/markup/java/generics.expect.txt
+++ b/test/markup/java/generics.expect.txt
@@ -12,3 +12,8 @@
   <span class="hljs-type">void</span> <span class="hljs-title function_">put</span><span class="hljs-params">(K key, V value)</span>;
   <span class="hljs-type">V</span> <span class="hljs-title function_">get</span><span class="hljs-params">(K key)</span>;
 }
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">FooBar</span> {
+  <span class="hljs-type">List</span>&lt;String&gt; <span class="hljs-title function_">foo</span><span class="hljs-params">()</span>;
+  <span class="hljs-type">List</span>&lt;java.lang.String&gt; <span class="hljs-title function_">bar</span><span class="hljs-params">()</span>;
+}

--- a/test/markup/java/generics.expect.txt
+++ b/test/markup/java/generics.expect.txt
@@ -12,3 +12,10 @@
   <span class="hljs-type">void</span> <span class="hljs-title function_">put</span><span class="hljs-params">(K key, V value)</span>;
   <span class="hljs-type">V</span> <span class="hljs-title function_">get</span><span class="hljs-params">(K key)</span>;
 }
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">FooBar</span> {
+  <span class="hljs-type">List</span>&lt;String&gt; <span class="hljs-title function_">foo</span><span class="hljs-params">()</span>;
+  <span class="hljs-type">List</span>&lt;java.lang.String&gt; <span class="hljs-title function_">bar</span><span class="hljs-params">()</span>;
+  <span class="hljs-type">Map</span>&lt;java.lang.String, java.util.List&lt;String&gt;&gt; <span class="hljs-title function_">nested</span><span class="hljs-params">()</span>;
+  <span class="hljs-type">List</span>&lt;? extends java.lang.Number&gt; <span class="hljs-title function_">bounded</span><span class="hljs-params">()</span>;
+}

--- a/test/markup/java/generics.txt
+++ b/test/markup/java/generics.txt
@@ -12,3 +12,8 @@ public interface Map<K, V> {
   void put(K key, V value);
   V get(K key);
 }
+
+interface FooBar {
+  List<String> foo();
+  List<java.lang.String> bar();
+}

--- a/test/markup/java/generics.txt
+++ b/test/markup/java/generics.txt
@@ -12,3 +12,10 @@ public interface Map<K, V> {
   void put(K key, V value);
   V get(K key);
 }
+
+interface FooBar {
+  List<String> foo();
+  List<java.lang.String> bar();
+  Map<java.lang.String, java.util.List<String>> nested();
+  List<? extends java.lang.Number> bounded();
+}


### PR DESCRIPTION
### Changes

The Java grammar accepted only one identifier inside a generic type argument, so a declaration such as `List<java.lang.String> bar()` was not recognized as a method.

This change:

- permits dot-separated qualified names inside Java generic type arguments;
- adds the exact `List<java.lang.String>` regression to the existing Java generics fixture; and
- records the fix in `CHANGES.md`.

The behavior introduced by #4346 remains covered: all 11 Java markup fixtures pass, and top-level qualified declarations are unchanged.

Fixes #3677

### Verification

- `npm run build`
- `ONLY_LANGUAGES=java npm run test-markup` — 11 passing
- Java language ESLint — passed
- `npm run lint-languages` — passed
- `npm run lint` — passed with one existing ignored-vendor warning
- `npm test` — 1,583 passing, 3 pending
- `git diff --check` — passed
- Red→green: the added fixture failed on unpatched main with 10 passing and 1 failing, then passed after the grammar change.
- Revert proof: reverting only `src/languages/java.js` reproduced the focused failure; restoring it returned all 11 Java fixtures to green.

A fresh `npm ci` was unavailable because registry DNS failed in the isolated Linux environment. Verification reused the exact unchanged lockfile dependency tree plus the official lock-resolved Rollup Linux package; `npm ls --all` reported 782 nodes and no problems.

### Checklist

- [x] Added markup tests
- [x] Updated `CHANGES.md`

### Assistance disclosure

This patch and its verification were prepared with OpenAI Codex assistance. The final diff and test outputs were reviewed before publication.