### PR TITLE
fix(c, cpp): keep raw string delimiters from swallowing quotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Core Grammars:
 - fix(csharp) support digit separators in binary literals and numeric type suffixes, and stop highlighting the leading `_` of an identifier, issue #4258 [Sarath Francis][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - fix(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
+- fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
 
@@ -31,6 +32,7 @@ CONTRIBUTORS
 [Mark Xian]: https://github.com/xianjianlf2
 [Nicolas Le Cam]: https://github.com/KuSh
 [Konstantin Baltsat]: https://github.com/Baltsat
+[David Pavlovschii]: https://github.com/davidpavlovschi
 
 
 ## Version 11.11.3

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -89,9 +89,13 @@ export default function(hljs) {
         end: '\'',
         illegal: '.'
       },
+      // https://en.cppreference.com/w/cpp/language/string_literal
+      // a d-char-sequence never contains parentheses, backslashes or whitespace;
+      // quotes are excluded as well so the closing delimiter cannot swallow the
+      // quote that actually terminates the literal
       hljs.END_SAME_AS_BEGIN({
-        begin: /(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,
-        end: /\)([^()\\ ]{0,16})"/
+        begin: /(?:u8?|U|L)?R"([^()\\\s"]{0,16})\(/,
+        end: /\)([^()\\\s"]{0,16})"/
       })
     ]
   };

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -42,9 +42,13 @@ export default function(hljs) {
         end: '\'',
         illegal: '.'
       },
+      // https://en.cppreference.com/w/cpp/language/string_literal
+      // a d-char-sequence never contains parentheses, backslashes or whitespace;
+      // quotes are excluded as well so the closing delimiter cannot swallow the
+      // quote that actually terminates the literal
       hljs.END_SAME_AS_BEGIN({
-        begin: /(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,
-        end: /\)([^()\\ ]{0,16})"/
+        begin: /(?:u8?|U|L)?R"([^()\\\s"]{0,16})\(/,
+        end: /\)([^()\\\s"]{0,16})"/
       })
     ]
   };

--- a/test/markup/c/raw-string-delimiters.expect.txt
+++ b/test/markup/c/raw-string-delimiters.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-comment">// quotes inside a raw string must not be mistaken for its closing delimiter</span>
+<span class="hljs-type">const</span> <span class="hljs-type">char</span> *empty = <span class="hljs-string">R&quot;(JKhf2n&quot;v; 0&gt;qwv&gt;q &quot; JKhf2n&quot;l0 &quot;v42HHf&amp;g )&quot;</span>;
+<span class="hljs-type">int</span> after_empty_delimiter;
+
+<span class="hljs-comment">// the same, with a named delimiter</span>
+<span class="hljs-type">const</span> <span class="hljs-type">char</span> *named = <span class="hljs-string">R&quot;a(bla)a&quot;</span>;
+<span class="hljs-type">int</span> after_named_delimiter;
+
+<span class="hljs-comment">// a delimiter-looking sequence inside the literal does not end it</span>
+<span class="hljs-type">const</span> <span class="hljs-type">char</span> *json = <span class="hljs-string">R&quot;json({&quot;key&quot;: &quot;})json_no&quot;, &quot;value&quot;: 1})json&quot;</span>;
+<span class="hljs-type">int</span> after_json;

--- a/test/markup/c/raw-string-delimiters.txt
+++ b/test/markup/c/raw-string-delimiters.txt
@@ -1,0 +1,11 @@
+// quotes inside a raw string must not be mistaken for its closing delimiter
+const char *empty = R"(JKhf2n"v; 0>qwv>q " JKhf2n"l0 "v42HHf&g )";
+int after_empty_delimiter;
+
+// the same, with a named delimiter
+const char *named = R"a(bla)a";
+int after_named_delimiter;
+
+// a delimiter-looking sequence inside the literal does not end it
+const char *json = R"json({"key": "})json_no", "value": 1})json";
+int after_json;

--- a/test/markup/cpp/raw-string-delimiters.expect.txt
+++ b/test/markup/cpp/raw-string-delimiters.expect.txt
@@ -1,0 +1,11 @@
+<span class="hljs-comment">// quotes inside a raw string must not be mistaken for its closing delimiter</span>
+<span class="hljs-function">vector&lt;string&gt; <span class="hljs-title">s</span><span class="hljs-params">({<span class="hljs-string">R&quot;(JKhf2n&quot;v; 0&gt;qwv&gt;q &quot; JKhf2n&quot;l0 &quot;v42HHf&amp;g )&quot;</span>,<span class="hljs-string">&quot;4U \&quot;N *+ &quot;</span>})</span></span>;
+<span class="hljs-type">int</span> after_empty_delimiter;
+
+<span class="hljs-comment">// the same, with a named delimiter</span>
+<span class="hljs-keyword">auto</span> v = {<span class="hljs-string">R&quot;a(bla)a&quot;</span>,<span class="hljs-string">&quot;&quot;</span>};
+<span class="hljs-type">int</span> after_named_delimiter;
+
+<span class="hljs-comment">// a delimiter-looking sequence inside the literal does not end it</span>
+<span class="hljs-keyword">auto</span> json = <span class="hljs-string">R&quot;json({&quot;key&quot;: &quot;})json_no&quot;, &quot;value&quot;: 1})json&quot;</span>;
+<span class="hljs-type">int</span> after_json;

--- a/test/markup/cpp/raw-string-delimiters.txt
+++ b/test/markup/cpp/raw-string-delimiters.txt
@@ -1,0 +1,11 @@
+// quotes inside a raw string must not be mistaken for its closing delimiter
+vector<string> s({R"(JKhf2n"v; 0>qwv>q " JKhf2n"l0 "v42HHf&g )","4U \"N *+ "});
+int after_empty_delimiter;
+
+// the same, with a named delimiter
+auto v = {R"a(bla)a",""};
+int after_named_delimiter;
+
+// a delimiter-looking sequence inside the literal does not end it
+auto json = R"json({"key": "})json_no", "value": 1})json";
+int after_json;


### PR DESCRIPTION
## Summary

- exclude quotes from the delimiter captured by the C/C++ raw-string rules, following the workaround proposed in #3585
- stop a false delimiter match from making the raw string consume the rest of the document
- preserve the existing behavior for unterminated raw strings
- add matching C and C++ regression fixtures for empty, named, and delimiter-like content cases

The closing rule currently allows its greedy delimiter capture to consume a quote. `END_SAME_AS_BEGIN` then rejects that longer capture, but cannot retry the correct shorter delimiter at the same position, so highlighting can remain inside the string until EOF.

## Validation

- current head: focused C/C++ markup suite, 21 passing
- current head: `npm run lint-languages` passes
- prior production head: full suite 1,566 passing, 3 pending, 1 pre-existing jsdom setup timeout (the unmodified base reports 1,565/3/1)
- differential fuzzing: 1,683 generated valid cases against a reference C++ raw-string scanner; 810 mismatches on `main`, 0 with this patch
- the existing truncated raw-string fixture still highlights to EOF

## Trade-off

C++ technically permits a quote inside the delimiter itself. As discussed in #3585, this patch deliberately stops recognizing that pathological form as a raw string; it degrades locally to ordinary string highlighting instead of corrupting everything after it.

Fixes #3585.