### PR TITLE
fix(yaml) empty lines should not terminate block scalars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Core Grammars:
 - fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
+- fix(yaml) stop empty lines from ending a block scalar (`|`/`>`), which caused the rest of the string to be re-parsed as YAML, issue #4090 [pikammmmm][]
 
 Documentation:
 
@@ -33,6 +34,7 @@ CONTRIBUTORS
 [Nicolas Le Cam]: https://github.com/KuSh
 [Konstantin Baltsat]: https://github.com/Baltsat
 [David Pavlovschii]: https://github.com/davidpavlovschi
+[pikammmmm]: https://github.com/pikammmmm
 
 
 ## Version 11.11.3

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -133,29 +133,20 @@ export default function(hljs) {
       relevance: 10
     },
     { // multi line string
-      // Blocks start with a | or > followed by a newline
-      //
-      // Indentation of subsequent lines must be the same to
-      // be considered part of the block
-      //
-      // Empty lines (and lines containing only spaces) do not end the block
-      // when another indented line follows. Trailing blanks stay outside
-      // so the next key is still a key.
-      //
-      // WHY: extra blank-line groups are non-capturing so \2 stays the
-      // indent group `( +)`. If they captured, indent would be \3 and
-      // \2 could match empty, so the block would swallow following keys.
+      // WHY: blank-line pieces stay non-capturing so \2 is the indent
+      // group `( +)`. Capturing them would make indent \3 and \2 empty,
+      // so the block would swallow following keys.
       scope: 'string',
       begin: regex.concat(
-        /[\|>]/,
-        /([1-9]?[+-])?/,
-        /[ ]*\n/,
-        regex.anyNumberOfTimes(/[ ]*\n/),
-        /( +)/,
-        /[^ ][^\n]*\n/,
-        regex.anyNumberOfTimes(
-          regex.concat(regex.anyNumberOfTimes(/[ ]*\n/), /\2[^\n]+\n?/)
-        )
+        /[\|>]/, // | or > indicator
+        /([1-9]?[+-])?/, // optional chomp / indent indicator
+        /(?:[ ]*\n)+/, // header newline plus leading blank lines
+        /( +)/, // indent of the first content line (\2)
+        /[^ ][^\n]*\n/, // first non-blank content line
+        regex.anyNumberOfTimes(regex.concat(
+          regex.anyNumberOfTimes(/[ ]*\n/), // blank lines between content
+          /\2[^\n]+\n?/ // same indent; final newline optional
+        ))
       )
     },
     { // Ruby/Rails erb

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -136,8 +136,12 @@ export default function(hljs) {
       //
       // Indentation of subsequent lines must be the same to
       // be considered part of the block
+      //
+      // Empty lines (and lines containing only spaces) do not end the block,
+      // they are part of its content - but only when another indented line
+      // follows, so that blank lines trailing the block are left alone.
       className: 'string',
-      begin: '[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*'
+      begin: '[\\|>]([1-9]?[+-])?[ ]*\\n(?:[ ]*\\n)*( +)[^ ][^\\n]*\\n((?:[ ]*\\n)*\\2[^\\n]+\\n?)*'
     },
     { // Ruby/Rails erb
       begin: '<%[%=-]?',

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -8,6 +8,7 @@ Website: https://yaml.org
 Category: common, config
 */
 export default function(hljs) {
+  const regex = hljs.regex;
   const LITERALS = 'true false yes no null';
 
   // YAML spec allows non-reserved URI characters in tags.
@@ -136,8 +137,26 @@ export default function(hljs) {
       //
       // Indentation of subsequent lines must be the same to
       // be considered part of the block
-      className: 'string',
-      begin: '[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*'
+      //
+      // Empty lines (and lines containing only spaces) do not end the block
+      // when another indented line follows. Trailing blanks stay outside
+      // so the next key is still a key.
+      //
+      // WHY: extra blank-line groups are non-capturing so \2 stays the
+      // indent group `( +)`. If they captured, indent would be \3 and
+      // \2 could match empty, so the block would swallow following keys.
+      scope: 'string',
+      begin: regex.concat(
+        /[\|>]/,
+        /([1-9]?[+-])?/,
+        /[ ]*\n/,
+        regex.anyNumberOfTimes(/[ ]*\n/),
+        /( +)/,
+        /[^ ][^\n]*\n/,
+        regex.anyNumberOfTimes(
+          regex.concat(regex.anyNumberOfTimes(/[ ]*\n/), /\2[^\n]+\n?/)
+        )
+      )
     },
     { // Ruby/Rails erb
       begin: '<%[%=-]?',

--- a/test/markup/yaml/block_empty_lines.expect.txt
+++ b/test/markup/yaml/block_empty_lines.expect.txt
@@ -1,0 +1,26 @@
+<span class="hljs-attr">nested:</span>
+  <span class="hljs-attr">literal:</span> <span class="hljs-string">|
+    still: a string
+
+    not: anymore
+</span><span class="hljs-attr">folded:</span> <span class="hljs-string">&gt;
+  first line
+
+  second line
+</span><span class="hljs-attr">leading-blank:</span> <span class="hljs-string">|
+
+  alpha
+  beta
+</span><span class="hljs-attr">blank-has-spaces:</span> <span class="hljs-string">|
+  alpha
+  
+  beta
+</span><span class="hljs-attr">multiple-blanks:</span> <span class="hljs-string">|
+  alpha
+
+
+  beta
+</span><span class="hljs-attr">trailing-blank:</span> <span class="hljs-string">|
+  alpha
+</span>
+<span class="hljs-attr">next_key:</span> <span class="hljs-string">after</span>

--- a/test/markup/yaml/block_empty_lines.txt
+++ b/test/markup/yaml/block_empty_lines.txt
@@ -1,0 +1,26 @@
+nested:
+  literal: |
+    still: a string
+
+    not: anymore
+folded: >
+  first line
+
+  second line
+leading-blank: |
+
+  alpha
+  beta
+blank-has-spaces: |
+  alpha
+  
+  beta
+multiple-blanks: |
+  alpha
+
+
+  beta
+trailing-blank: |
+  alpha
+
+next_key: after


### PR DESCRIPTION
Fixes #4090.

## The problem

A YAML block scalar stops being highlighted at the first empty line, and — worse — the remainder of the block is then re-parsed as YAML, so string content turns into keys.

Using the sample from the issue:

```yaml
foo:
  bar: |
    still: a string

    not: anymore
```

`not: anymore` is plain text inside the string, but it is emitted as `hljs-attr` (a key). On a real-world file (`chroma`'s `.github/ISSUE_TEMPLATE/bug_report.yaml`) the paragraph after the blank line is broken up into individual words, each wrapped in its own `hljs-string` span.

## Cause

The multi-line string mode has only a `begin` regex and no `end`, so the entire highlighted span is whatever `begin` matches. Continuation lines had to match:

```
\2[^\n]+
```

that is, the block indent followed by **at least one more character**. An empty line has nothing after the indent, so it can never match and the block ends there.

This is observable: a "blank" line containing *more* spaces than the block indent works today, while a truly empty line, a shorter one, or one exactly as wide as the indent all terminate the block early.

## The change

Empty lines (and lines containing only spaces) are now accepted as block content, both immediately after the header and between content lines:

```diff
-begin: '[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*'
+begin: '[\\|>]([1-9]?[+-])?[ ]*\\n(?:[ ]*\\n)*( +)[^ ][^\\n]*\\n((?:[ ]*\\n)*\\2[^\\n]+\\n?)*'
```

Two things were deliberate:

- **Blank lines are only consumed when another indented line follows.** A blank line that separates the block from the next key is left outside the span, so that key still highlights as a key. The new fixture asserts this negative case explicitly (`trailing-blank`).
- **Both added groups are non-capturing**, so the `\2` backreference still refers to the indent. The capture count is unchanged at 3.

Because both additions are optional (`*`), the new pattern is a strict superset of the old one — it can only ever extend a match, never shrink or relocate one.

## Testing

New fixture `test/markup/yaml/block_empty_lines.txt` covers the issue's own sample, a folded `>` scalar, a blank line right after the header, a spaces-only blank line, consecutive blank lines, and the trailing-blank guard described above.

- Full suite with the change: **1594 passing, 0 failing**
- Full suite with the change reverted: **1593 passing, 1 failing** — the sole failure is the new fixture, confirming it actually covers the bug
- Differential check over 400 real-world `.yaml`/`.yml` files on disk, old build vs new: the underlying text is byte-identical in every file (markup-only changes), 37 files differ, and in all 37 the string coverage grew — no file lost coverage and no file gained a spurious key

## Known limitations (pre-existing, not addressed here)

These were already broken before this change and are unchanged by it:

- **CRLF line endings** — `[ ]*\n` cannot cross the `\r`, so block scalars in CRLF files remain broken.
- **Blank lines containing a tab** still terminate the block.

Both would need separate work; I kept this patch to the empty-line case in the issue.
