### PR TITLE
fix(go) highlight the name of a method with a receiver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Core Grammars:
 - fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
+- fix(go) highlight the name of a method with a receiver, e.g. `func (c *exec.Cmd) Run()`, issue #4196 [Ali Asgher][]
 
 Documentation:
 
@@ -33,6 +34,7 @@ CONTRIBUTORS
 [Nicolas Le Cam]: https://github.com/KuSh
 [Konstantin Baltsat]: https://github.com/Baltsat
 [David Pavlovschii]: https://github.com/davidpavlovschi
+[Ali Asgher]: https://github.com/alliasgher
 
 
 ## Version 11.11.3

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -8,6 +8,7 @@ Category: common, system
 */
 
 export default function(hljs) {
+  const regex = hljs.regex;
   const LITERALS = [
     "true",
     "false",
@@ -86,6 +87,22 @@ export default function(hljs) {
     literal: LITERALS,
     built_in: BUILT_INS
   };
+  const PARAMS = {
+    scope: 'params',
+    begin: /\(/,
+    end: /\)/,
+    endsParent: true,
+    keywords: KEYWORDS,
+    illegal: /["']/
+  };
+  // a method's receiver, ie the `(c *exec.Cmd)` of `func (c *exec.Cmd) Run()` -
+  // it must not end the function mode, otherwise the method name that follows
+  // it is never seen; only a parenthesized group directly followed by
+  // `name(` qualifies, so a plain function's argument list is unaffected
+  const RECEIVER = hljs.inherit(PARAMS, {
+    begin: regex.concat(/\(/, regex.lookahead(/[^)]+\)\s*(?!func\b)[a-zA-Z_]\w*\s*\(/)),
+    endsParent: false
+  });
   return {
     name: 'Go',
     aliases: [ 'golang' ],
@@ -142,15 +159,9 @@ export default function(hljs) {
         end: '\\s*(\\{|$)',
         excludeEnd: true,
         contains: [
+          RECEIVER,
           hljs.TITLE_MODE,
-          {
-            className: 'params',
-            begin: /\(/,
-            end: /\)/,
-            endsParent: true,
-            keywords: KEYWORDS,
-            illegal: /["']/
-          }
+          PARAMS
         ]
       }
     ]

--- a/src/languages/go.js
+++ b/src/languages/go.js
@@ -8,6 +8,7 @@ Category: common, system
 */
 
 export default function(hljs) {
+  const regex = hljs.regex;
   const LITERALS = [
     "true",
     "false",
@@ -86,6 +87,22 @@ export default function(hljs) {
     literal: LITERALS,
     built_in: BUILT_INS
   };
+  const PARAMS = {
+    className: 'params',
+    begin: /\(/,
+    end: /\)/,
+    endsParent: true,
+    keywords: KEYWORDS,
+    illegal: /["']/
+  };
+  // a method's receiver, ie the `(c *exec.Cmd)` of `func (c *exec.Cmd) Run()` -
+  // it must not end the function mode, otherwise the method name that follows
+  // it is never seen; only a parenthesized group directly followed by
+  // `name(` qualifies, so a plain function's argument list is unaffected
+  const RECEIVER = hljs.inherit(PARAMS, {
+    begin: regex.concat(/\(/, regex.lookahead(/[^)]+\)\s*(?!func\b)[a-zA-Z_]\w*\s*\(/)),
+    endsParent: false
+  });
   return {
     name: 'Go',
     aliases: [ 'golang' ],
@@ -142,15 +159,9 @@ export default function(hljs) {
         end: '\\s*(\\{|$)',
         excludeEnd: true,
         contains: [
+          RECEIVER,
           hljs.TITLE_MODE,
-          {
-            className: 'params',
-            begin: /\(/,
-            end: /\)/,
-            endsParent: true,
-            keywords: KEYWORDS,
-            illegal: /["']/
-          }
+          PARAMS
         ]
       }
     ]

--- a/test/markup/go/methods.expect.txt
+++ b/test/markup/go/methods.expect.txt
@@ -1,0 +1,15 @@
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-params">(c *exec.Cmd)</span> <span class="hljs-title">Run</span><span class="hljs-params">()</span></span> <span class="hljs-type">error</span>
+
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-params">(m sync.Mutex)</span> <span class="hljs-title">Lock</span><span class="hljs-params">()</span></span>
+
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-params">(*sync.Mutex)</span> <span class="hljs-title">Unlock</span><span class="hljs-params">()</span></span>
+
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-params">(s *Stack[T])</span> <span class="hljs-title">Push</span><span class="hljs-params">(v T)</span></span> {
+  s.items = <span class="hljs-built_in">append</span>(s.items, v)
+}
+
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-params">(mt MyType)</span> <span class="hljs-title">MyFunc</span><span class="hljs-params">(<span class="hljs-type">int</span>, <span class="hljs-type">float32</span>)</span></span> (<span class="hljs-type">int</span>, io.Reader, <span class="hljs-type">error</span>) {
+  <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>, <span class="hljs-literal">nil</span>, <span class="hljs-literal">nil</span>
+}
+
+<span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">middleware</span><span class="hljs-params">(h Handler)</span></span> <span class="hljs-function"><span class="hljs-keyword">func</span><span class="hljs-params">(<span class="hljs-type">int32</span>)</span></span> <span class="hljs-type">int32</span>

--- a/test/markup/go/methods.txt
+++ b/test/markup/go/methods.txt
@@ -1,0 +1,15 @@
+func (c *exec.Cmd) Run() error
+
+func (m sync.Mutex) Lock()
+
+func (*sync.Mutex) Unlock()
+
+func (s *Stack[T]) Push(v T) {
+  s.items = append(s.items, v)
+}
+
+func (mt MyType) MyFunc(int, float32) (int, io.Reader, error) {
+  return 0, nil, nil
+}
+
+func middleware(h Handler) func(int32) int32


### PR DESCRIPTION
Fixes #4196.

**Describe the issue**

`func (c *exec.Cmd) Run() error` gets no `hljs-title` on `Run`, while a plain `func deferFunc(err *error)` highlights fine.

The function mode contains a `params` sub-mode with `endsParent: true`, so the **first** parenthesised group ends the whole function mode. For a method, that first group is the receiver, so the mode terminates at the receiver's `)` and `TITLE_MODE` never gets as far as the method name.

**The fix**

A separate receiver mode, placed before `TITLE_MODE`, which does not end its parent:

```js
const RECEIVER = hljs.inherit(PARAMS, {
  begin: regex.concat(/\(/, regex.lookahead(/[^)]+\)\s*(?!func\b)[a-zA-Z_]\w*\s*\(/)),
  endsParent: false
});
```

I kept the grammar deliberately narrow rather than loosening `func` generally, since widening it risks auto-detection. The lookahead only fires for a non-empty parenthesised group that is directly followed by an identifier and another open paren, which is the method-declaration shape. A plain function's argument list is not followed by `name(`, so it never matches and behaves exactly as before.

The `(?!func\b)` is there for `func middleware(h Handler) func(int32) int32`: a return type *can* be followed by `(`, and without the guard that argument list would be misread as a receiver.

**Testing**

New markup test `test/markup/go/methods.txt` covering a pointer receiver, a value receiver, an anonymous receiver `(*sync.Mutex)`, a generic receiver `(s *Stack[T])`, multiple return values, and the `func`-typed return above as a negative case. It fails on `main` and passes with this change.

Full suite: `1594 passing`, and no existing `test/markup/go/*.expect.txt` changed, which is the check that plain functions are untouched. `npm run lint` and `npm run lint-languages` are clean.

Two limitations I did not try to fix, both pre-existing and equally true of plain functions today:
- a method's own parameter list is now inside the `params` mode, so a string in a parameter default/array-length expression loses `hljs-string` — this makes methods consistent with plain functions rather than introducing a new inconsistency
- methods with non-ASCII names are still not highlighted, since `TITLE_MODE` is ASCII-only

**Checklist**

- [x] Added markup tests
- [x] Updated the changelog at CHANGES.md