### PR TITLE
fix(c, cpp): bound the type token run in function declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Core Grammars:
 - fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
+- fix(c, cpp) bound the run of type tokens in front of a function name, which made highlighting a long line of plain words take quadratic time (ReDoS), issue #4362 [Jayesh Bhade][]
 
 Documentation:
 
@@ -33,6 +34,7 @@ CONTRIBUTORS
 [Nicolas Le Cam]: https://github.com/KuSh
 [Konstantin Baltsat]: https://github.com/Baltsat
 [David Pavlovschii]: https://github.com/davidpavlovschi
+[Jayesh Bhade]: https://github.com/Jaybhade
 
 
 ## Version 11.11.3

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -140,6 +140,13 @@ export default function(hljs) {
   };
 
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
+  // How many type tokens (`static`, `const`, `unsigned`, `long`, ...) may
+  // appear in front of a function name.  This has to be bounded: with an
+  // unbounded quantifier the group consumes an arbitrarily long run of words,
+  // and when no function title follows it the engine retries the title at
+  // every token boundary of that run - quadratic in the length of the run, so
+  // quadratic in the size of the document.  See #4362.
+  const MAX_FUNCTION_TYPE_TOKENS = 12;
 
   const C_KEYWORDS = [
     "asm",
@@ -280,7 +287,7 @@ export default function(hljs) {
   };
 
   const FUNCTION_DECLARATION = {
-    begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
+    begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+){1,' + MAX_FUNCTION_TYPE_TOKENS + '}' + FUNCTION_TITLE,
     returnBegin: true,
     end: /[{;=]/,
     excludeEnd: true,

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -140,12 +140,10 @@ export default function(hljs) {
   };
 
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
-  // How many type tokens (`static`, `const`, `unsigned`, `long`, ...) may
-  // appear in front of a function name.  This has to be bounded: with an
-  // unbounded quantifier the group consumes an arbitrarily long run of words,
-  // and when no function title follows it the engine retries the title at
-  // every token boundary of that run - quadratic in the length of the run, so
-  // quadratic in the size of the document.  See #4362.
+  // Bounded on purpose: an unbounded quantifier here consumes an arbitrarily
+  // long run of words, and when no function title follows it the engine retries
+  // the title at every token boundary of that run - quadratic in the size of
+  // the document.  See #4362.
   const MAX_FUNCTION_TYPE_TOKENS = 12;
 
   const C_KEYWORDS = [

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -127,12 +127,10 @@ export default function(hljs) {
   };
 
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
-  // How many type tokens (`static`, `const`, `unsigned`, `long`, ...) may
-  // appear in front of a function name.  This has to be bounded: with an
-  // unbounded quantifier the group consumes an arbitrarily long run of words,
-  // and when no function title follows it the engine retries the title at
-  // every token boundary of that run - quadratic in the length of the run, so
-  // quadratic in the size of the document.  See #4362.
+  // Bounded on purpose: an unbounded quantifier here consumes an arbitrarily
+  // long run of words, and when no function title follows it the engine retries
+  // the title at every token boundary of that run - quadratic in the size of
+  // the document.  See #4362.
   const MAX_FUNCTION_TYPE_TOKENS = 12;
 
   // https://en.cppreference.com/w/cpp/keyword

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -127,6 +127,13 @@ export default function(hljs) {
   };
 
   const FUNCTION_TITLE = regex.optional(NAMESPACE_RE) + hljs.IDENT_RE + '\\s*\\(';
+  // How many type tokens (`static`, `const`, `unsigned`, `long`, ...) may
+  // appear in front of a function name.  This has to be bounded: with an
+  // unbounded quantifier the group consumes an arbitrarily long run of words,
+  // and when no function title follows it the engine retries the title at
+  // every token boundary of that run - quadratic in the length of the run, so
+  // quadratic in the size of the document.  See #4362.
+  const MAX_FUNCTION_TYPE_TOKENS = 12;
 
   // https://en.cppreference.com/w/cpp/keyword
   const RESERVED_KEYWORDS = [
@@ -477,7 +484,7 @@ export default function(hljs) {
 
   const FUNCTION_DECLARATION = {
     className: 'function',
-    begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE,
+    begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+){1,' + MAX_FUNCTION_TYPE_TOKENS + '}' + FUNCTION_TITLE,
     returnBegin: true,
     end: /[{;=]/,
     excludeEnd: true,

--- a/test/parser/function-declaration-backtracking.js
+++ b/test/parser/function-declaration-backtracking.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const hljs = require('../../build');
+hljs.debugMode(); // tests run in debug mode so errors are raised
+
+// The C/C++ `FUNCTION_DECLARATION` matcher looks for a run of type tokens
+// followed by a function name.  That run used to be unbounded, so a long line
+// of plain words (which never reaches a function name) made the regex engine
+// retry the function name at every token boundary of the run: quadratic in the
+// size of the input.  32 KB took ~30s, 64 KB took ~2 minutes.  See #4362.
+describe("function declaration backtracking", function() {
+  const LANGUAGES = [
+    'c',
+    'cpp',
+    'arduino' // inherits from cpp
+  ];
+
+  // 32 KB of words that never form a function declaration.  Highlighting this
+  // is a few tens of milliseconds once the run is bounded; the budget is
+  // deliberately loose so slow CI machines don't make this flaky, while still
+  // being orders of magnitude below the quadratic behavior.
+  const attack = 'a '.repeat(16 * 1024);
+  const BUDGET_MS = 1000;
+
+  LANGUAGES.forEach((language) => {
+    it(`should highlight ${language} in linear time`, function() {
+      this.timeout(30000);
+
+      const start = process.hrtime.bigint();
+      hljs.highlight(attack, {
+        language,
+        ignoreIllegals: true
+      });
+      const elapsed = Number(process.hrtime.bigint() - start) / 1e6;
+
+      elapsed.should.be.below(BUDGET_MS,
+        `highlighting ${attack.length} bytes took ${elapsed.toFixed(0)}ms `
+        + `(budget ${BUDGET_MS}ms) - the type token run is likely unbounded again`);
+    });
+  });
+
+  // ...and the declarations we do care about are still recognized, including
+  // ones with a healthy pile of qualifiers in front of the name.
+  it("should still find the function title after many type tokens", function() {
+    const declaration = 'static const volatile unsigned long long int * const * restrict fn(void);';
+
+    const result = hljs.highlight(declaration, { language: 'c' });
+    result.value.should.containEql('<span class="hljs-title function_">fn</span>');
+  });
+});

--- a/test/parser/function-declaration-backtracking.js
+++ b/test/parser/function-declaration-backtracking.js
@@ -3,11 +3,10 @@
 const hljs = require('../../build');
 hljs.debugMode(); // tests run in debug mode so errors are raised
 
-// The C/C++ `FUNCTION_DECLARATION` matcher looks for a run of type tokens
-// followed by a function name.  That run used to be unbounded, so a long line
-// of plain words (which never reaches a function name) made the regex engine
-// retry the function name at every token boundary of the run: quadratic in the
-// size of the input.  32 KB took ~30s, 64 KB took ~2 minutes.  See #4362.
+// While the run of type tokens in `FUNCTION_DECLARATION` was unbounded, a long
+// line of plain words took quadratic time to highlight: the engine retried the
+// function name at every token boundary of the run, at every start offset.
+// 32 KB of it took ~19s.  See #4362.
 describe("function declaration backtracking", function() {
   const LANGUAGES = [
     'c',
@@ -15,10 +14,8 @@ describe("function declaration backtracking", function() {
     'arduino' // inherits from cpp
   ];
 
-  // 32 KB of words that never form a function declaration.  Highlighting this
-  // is a few tens of milliseconds once the run is bounded; the budget is
-  // deliberately loose so slow CI machines don't make this flaky, while still
-  // being orders of magnitude below the quadratic behavior.
+  // 32 KB of words that never form a function declaration.  The budget is
+  // loose so a slow machine can't make this flaky; the bug overshot it by 18x.
   const attack = 'a '.repeat(16 * 1024);
   const BUDGET_MS = 1000;
 
@@ -39,8 +36,6 @@ describe("function declaration backtracking", function() {
     });
   });
 
-  // ...and the declarations we do care about are still recognized, including
-  // ones with a healthy pile of qualifiers in front of the name.
   it("should still find the function title after many type tokens", function() {
     const declaration = 'static const volatile unsigned long long int * const * restrict fn(void);';
 

--- a/test/parser/index.js
+++ b/test/parser/index.js
@@ -9,4 +9,5 @@ describe('hljs', function() {
   require('./should-not-destroyData');
   require('./compiler-extensions');
   require('./max_keyword_hits');
+  require('./function-declaration-backtracking');
 });


### PR DESCRIPTION
Fixes #4362

### Changes

`FUNCTION_DECLARATION` in `c.js` / `cpp.js` (and so `arduino`) matches a run of type tokens followed by a function name:

```js
begin: '(' + FUNCTION_TYPE_RE + '[\\*&\\s]+)+' + FUNCTION_TITLE
```

The outer quantifier is unbounded, so on text that never reaches a function name the group first consumes the whole run of words, and the engine then retries `FUNCTION_TITLE` at every token boundary of that run before giving up. The scan repeats that at every start offset, so the cost grows with the square of the document size.

Worth noting the ambiguity is *not* between `[\*&\s]+` and the outer `+`, as the issue guesses — `FUNCTION_TYPE_RE` can't start with whitespace, so each token/separator split is forced and shortening `[\*&\s]+` always leaves the next iteration on a separator, where it fails immediately. The quadratic term is purely `O(start offsets) × O(iterations to backtrack)`, which is why the fix has to bound the iteration count: for any `(A)+B`, a backtracking engine retries `B` once per iteration when `B` fails, so limiting how far the group can reach is the only way to make the work per start offset constant.

Bounding it to 12 tokens leaves plenty of headroom — `static const volatile unsigned long long int * const * restrict fn(void)` is 11 — and puts highlighting back to linear time.

### Why not `[\*&\s]*`

On the suggestion in the thread ([comment](https://github.com/highlightjs/highlight.js/issues/4362#issuecomment-4888544735)) to relax the inner `+` to `*`: that one makes things considerably worse. With `*`, `FUNCTION_TYPE_RE` can repeat with no separator in between, and `(ident)+` is ambiguous for any run of word characters — so it turns polynomial backtracking into exponential. `'a'.repeat(n)`, no function name in sight:

| identifier length | 20 | 22 | 24 | 26 | 28 |
|---|---|---|---|---|---|
| time | 62ms | 254ms | 1.1s | 3.6s | 13.3s |

That's ~4× per 2 characters, so a 40-character identifier is already hours. It's also rejected by our own regex suite — with `*` in place, `ONLY_LANG=c npx mocha test/regex` fails both checks:

```
1) c should not cause exponential backtracking:
   The quantifier `((decltype\(auto\)|...)[\*&\s]*)+` ambiguous for all words "AA".repeat(n) for any n>1.
2) c should not cause polynomial backtracking:
   By repeating any character that matches /[A-Z_]/i, an attack string can be created.
```

The current `+` version passes those checks, which is presumably why this survived: the exponential test only looks at `A` vs `A{2,}` disjointness, and the polynomial test only compares adjacent single-character quantifiers, so neither can see the `(A sep)+ B` shape this issue is about.

### Verification

`hljs.highlight('a '.repeat(n), { language, ignoreIllegals: true })`, node 22, same machine:

| `c` | 4 KB | 8 KB | 16 KB | 32 KB | 64 KB | 128 KB | 256 KB |
|---|---|---|---|---|---|---|---|
| before | 368ms | 1538ms | 5631ms | 18545ms | (~4× per doubling) | | |
| after | 11ms | 17ms | 29ms | 75ms | 116ms | 173ms | 278ms |

`cpp` and `arduino` behave the same; `arduino` was the worst before, at 22.6s for 32 KB.

**Highlighting is unchanged.** I hashed the rendered HTML of a corpus before and after — all 230 C headers and 192 libc++ headers in the macOS SDK, plus every `c`/`cpp`/`arduino` fixture under `test/`, each run through all three grammars (2442 outputs, 18.5 MiB) — and all 2442 hashes are identical. As a side effect that corpus now highlights in 8.5s instead of 22.8s, since real headers contain plenty of comment prose that was hitting the backtracking path.

`npm test` is green (1597 passing), `npm run lint` and `npm run lint-languages` clean.

### Not fixed here

A single long identifier (`'a'.repeat(n)`, no spaces) is also quadratic, but that one isn't specific to this grammar — `javascript` and `java` show the same curve, and it comes from `\w*` being re-scanned at every start offset rather than from this quantifier. Unchanged by this PR; happy to open a separate issue if that's useful.

### Checklist

- [x] Added markup tests, or they don't apply here because... a markup test can't express this — the rendered output is deliberately identical (see the 2442-hash differential above). Instead `test/parser/function-declaration-backtracking.js` asserts a 32 KB adversarial payload highlights well inside a loose 1s budget for all three languages, and that a declaration with 11 type tokens still gets its title highlighted. Reverting just the grammar change fails the three timing assertions (18.4s / 16.9s / 16.6s against the 1s budget) while the title assertion keeps passing.
- [x] Updated the changelog at `CHANGES.md`
