### PR TITLE
fix(ruby): don't treat scope resolution :: as symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Core Grammars:
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - fix(css) support six-digit `unicode-range` values [Konstantin Baltsat][]
 - fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
+- fix(ruby) don't treat the scope resolution operator `::` as a symbol, issue #4294 [Hashim Khan][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
 - fix(c, cpp) scope the angle-bracket header string to `#include` so a `#define` body containing `>` no longer swallows the following quote and breaks highlighting of the rest of the file, issue #3505 [Pablo][]

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -325,8 +325,10 @@ export default function(hljs) {
     CLASS_REFERENCE,
     METHOD_DEFINITION,
     {
-      // swallow namespace qualifiers before symbols
-      begin: hljs.IDENT_RE + '::' },
+      // swallow the scope resolution operator so `::` is not read as a symbol
+      begin: '::',
+      relevance: 0
+    },
     {
       className: 'symbol',
       begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:',

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -326,8 +326,7 @@ export default function(hljs) {
     METHOD_DEFINITION,
     {
       // swallow the scope resolution operator so `::` is not read as a symbol
-      begin: '::',
-      relevance: 0
+      begin: '::'
     },
     {
       className: 'symbol',

--- a/test/markup/ruby/symbols.expect.txt
+++ b/test/markup/ruby/symbols.expect.txt
@@ -1,0 +1,10 @@
+<span class="hljs-symbol">:symbol</span>
+<span class="hljs-symbol">:<span class="hljs-string">&quot;quoted symbol&quot;</span></span>
+{ <span class="hljs-symbol">name:</span> <span class="hljs-string">&quot;ruby&quot;</span>, <span class="hljs-symbol">version:</span> <span class="hljs-number">3</span> }
+obj.send(<span class="hljs-symbol">:to_s</span>)
+
+<span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>
+<span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::baz(<span class="hljs-number">1</span>)
+<span class="hljs-title class_">ClassName</span>::method
+<span class="hljs-title class_">Math</span>::<span class="hljs-variable constant_">PI</span>
+::<span class="hljs-title class_">TopLevel</span>.new

--- a/test/markup/ruby/symbols.txt
+++ b/test/markup/ruby/symbols.txt
@@ -1,0 +1,10 @@
+:symbol
+:"quoted symbol"
+{ name: "ruby", version: 3 }
+obj.send(:to_s)
+
+Foo::Bar
+Foo::Bar::baz(1)
+ClassName::method
+Math::PI
+::TopLevel.new


### PR DESCRIPTION
Fixes #4294

### Problem

In Ruby, `ClassName::method` was highlighted as a class name followed by two symbols:

```
<span class="hljs-title class_">ClassName</span><span class="hljs-symbol">:</span><span class="hljs-symbol">:method</span>
```

The grammar already had a rule meant to swallow namespace qualifiers (`begin: hljs.IDENT_RE + '::'`), but it never fired. The CamelCase `CLASS_REFERENCE` rule is listed earlier and matches at the same offset, so it consumed `ClassName` on its own and left `::method` for the symbol rule, which matches any colon not followed by whitespace.

### Fix

Match the `::` operator on its own instead of `identifier::`, so it is swallowed no matter what rule handled the text before it. The issue suggested a negative lookbehind on the symbol rule, but the codebase still avoids lookbehind for browser support reasons (see the TODO notes in `swift.js` and `javascript.js`), and it would also leave the first colon highlighted as a symbol.

After:

```
<span class="hljs-title class_">ClassName</span>::method
<span class="hljs-title class_">Foo</span>::<span class="hljs-title class_">Bar</span>::baz(<span class="hljs-number">1</span>)
<span class="hljs-title class_">Math</span>::<span class="hljs-variable constant_">PI</span>
::<span class="hljs-title class_">TopLevel</span>.new
```

Regular symbols (`:symbol`, `:"quoted"`, `key:` in hashes, `obj.send(:to_s)`) are unaffected.

### Test plan

- Added `test/markup/ruby/symbols.txt` / `symbols.expect.txt` covering plain symbols, hash keys, quoted symbols, and scope resolution including nested namespaces and a leading `::`.
- `npm run build && npm test`: 1594 passing, 0 failing.
- Ran `highlightAuto` over every fixture in `test/detect` before and after the change; the detected language and relevance are identical for all 198 files, so auto detection is unaffected.
