### PR TITLE
fix: noHighlightRe now wins over languageDetectRe

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -97,6 +97,14 @@ const HLJS = function(hljs) {
 
     classes += block.parentNode ? block.parentNode.className : '';
 
+    // noHighlightRe takes precedence over languageDetectRe so that an explicit
+    // exclusion (e.g. `no-highlight` or `nohighlight`) always wins, even when it
+    // appears alongside a matching `language-*` / `lang-*` class.
+    const noHighlight = classes
+      .split(/\s+/)
+      .find((_class) => shouldNotHighlight(_class));
+    if (noHighlight) return 'no-highlight';
+
     // language-* takes precedence over non-prefixed class names.
     const match = options.languageDetectRe.exec(classes);
     if (match) {
@@ -110,7 +118,7 @@ const HLJS = function(hljs) {
 
     return classes
       .split(/\s+/)
-      .find((_class) => shouldNotHighlight(_class) || getLanguage(_class));
+      .find((_class) => getLanguage(_class));
   }
 
   /**

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -60,6 +60,9 @@ $colorGreenDark: #393;
 <!-- unsupported prefixed language and supported unprefixed language -->
 <pre><code class="python language-foo">for x in [1, 2, 3]: count(x)</code></pre>
 
+<!-- no-highlight should win over a matching language-* class -->
+<pre><code class="no-highlight language-js">var x = '&lt;p&gt;this should &lt;b&gt;not&lt;/b&gt; be highlighted as &lt;em&gt;JavaScript&lt;/em&gt;';</code></pre>
+
 </div>
 
 <!-- sub-languages -->

--- a/test/special/noHighlight.js
+++ b/test/special/noHighlight.js
@@ -56,4 +56,11 @@ describe('no highlighting', () => {
     actual.should.equal(expected);
   });
 
+  it('should keep block unchanged when no-highlight wins over a matching language-* class', () => {
+    const expected = "var x = '&lt;p&gt;this should &lt;b&gt;not&lt;/b&gt; be highlighted as &lt;em&gt;JavaScript&lt;/em&gt;';",
+          actual   = this.blocks[6];
+
+    actual.should.equal(expected);
+  });
+
 });


### PR DESCRIPTION
Closes #3700\n\nWhen a code block carries both a matching `language-*` / `lang-*` class and an explicit `no-highlight` / `nohighlight` class, the exclusion now takes precedence over language detection.\n\nChanges:\n- `blockLanguage` checks `shouldNotHighlight` before running `languageDetectRe`.\n- Added a test fixture + case covering the mixed-class scenario.\n\nVerified with:\n\n```\nnpm run build\nnpm test\nnpm run lint\n```\n\nNote: this change was prepared with assistance from Claude (Anthropic).