### PR TITLE
fix(c, cpp): scope angle-bracket header string to #include (issue #3505)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Core Grammars:
 - fix(c, cpp) stop a raw string's closing delimiter from swallowing quotes, which broke highlighting of everything after the literal, issue #3585 [David Pavlovschii][]
 - enh(python) add missing builtins: `aiter` and `anext` (Python 3.10), `frozendict` and `sentinel` (Python 3.15) [Hugo van Kemenade][]
 - enh(python) Support t-strings [Nicolas Le Cam][]
+- fix(c, cpp) scope the angle-bracket header string to `#include` so a `#define` body containing `>` no longer swallows the following quote and breaks highlighting of the rest of the file, issue #3505 [Pablo][]
 
 Documentation:
 
@@ -33,6 +34,7 @@ CONTRIBUTORS
 [Nicolas Le Cam]: https://github.com/KuSh
 [Konstantin Baltsat]: https://github.com/Baltsat
 [David Pavlovschii]: https://github.com/davidpavlovschi
+[Pablo]: https://github.com/MsfPablo
 
 
 ## Version 11.11.3

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -118,18 +118,18 @@ export default function(hljs) {
   // which would otherwise leave an unbalanced `"` and break highlighting for
   // the rest of the file. See issue #3505.
   const PREPROCESSOR_INCLUDE = {
-    className: 'meta',
+    scope: 'meta',
     begin: /#\s*include\b/,
     end: /$/,
     keywords: { keyword: 'include' },
     contains: [
       {
+        // the `\` at the end of a line signaling continuation
         begin: /\\\n/,
-        relevance: 0
       },
-      hljs.inherit(STRINGS, { className: 'string' }),
+      STRINGS,
       {
-        className: 'string',
+        scope: 'string',
         begin: /<.*?>/
       },
       C_LINE_COMMENT_MODE,
@@ -154,6 +154,11 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE
     ]
   };
+
+  const PREPROCESSORS = [
+    PREPROCESSOR_INCLUDE,
+    PREPROCESSOR
+  ];
 
   const TITLE_MODE = {
     className: 'title',
@@ -262,8 +267,7 @@ export default function(hljs) {
   };
 
   const EXPRESSION_CONTAINS = [
-    PREPROCESSOR_INCLUDE,
-    PREPROCESSOR,
+    ...PREPROCESSORS,
     TYPES,
     C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,
@@ -359,8 +363,7 @@ export default function(hljs) {
       TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
-      PREPROCESSOR_INCLUDE,
-      PREPROCESSOR
+      ...PREPROCESSORS
     ]
   };
 
@@ -377,8 +380,7 @@ export default function(hljs) {
       FUNCTION_DECLARATION,
       EXPRESSION_CONTAINS,
       [
-        PREPROCESSOR_INCLUDE,
-        PREPROCESSOR,
+        ...PREPROCESSORS,
         {
           begin: hljs.IDENT_RE + '::',
           keywords: KEYWORDS
@@ -395,7 +397,6 @@ export default function(hljs) {
       ]),
     exports: {
       preprocessor: PREPROCESSOR,
-      preprocessorInclude: PREPROCESSOR_INCLUDE,
       strings: STRINGS,
       keywords: KEYWORDS
     }

--- a/src/languages/c.js
+++ b/src/languages/c.js
@@ -111,6 +111,32 @@ export default function(hljs) {
     relevance: 0
   };  
   
+  // `#include` is the only preprocessor directive that takes an angle-bracket
+  // quoted header (`#include <header>`). Scoping that rule to `#include` keeps
+  // the greedy `<...>` match from eating a `>` that belongs to the body of
+  // another directive (e.g. `#define what do { cout << ">"; } while (0)`),
+  // which would otherwise leave an unbalanced `"` and break highlighting for
+  // the rest of the file. See issue #3505.
+  const PREPROCESSOR_INCLUDE = {
+    className: 'meta',
+    begin: /#\s*include\b/,
+    end: /$/,
+    keywords: { keyword: 'include' },
+    contains: [
+      {
+        begin: /\\\n/,
+        relevance: 0
+      },
+      hljs.inherit(STRINGS, { className: 'string' }),
+      {
+        className: 'string',
+        begin: /<.*?>/
+      },
+      C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
+    ]
+  };
+
   const PREPROCESSOR = {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,
@@ -124,10 +150,6 @@ export default function(hljs) {
         relevance: 0
       },
       hljs.inherit(STRINGS, { className: 'string' }),
-      {
-        className: 'string',
-        begin: /<.*?>/
-      },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE
     ]
@@ -240,6 +262,7 @@ export default function(hljs) {
   };
 
   const EXPRESSION_CONTAINS = [
+    PREPROCESSOR_INCLUDE,
     PREPROCESSOR,
     TYPES,
     C_LINE_COMMENT_MODE,
@@ -336,6 +359,7 @@ export default function(hljs) {
       TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
+      PREPROCESSOR_INCLUDE,
       PREPROCESSOR
     ]
   };
@@ -353,6 +377,7 @@ export default function(hljs) {
       FUNCTION_DECLARATION,
       EXPRESSION_CONTAINS,
       [
+        PREPROCESSOR_INCLUDE,
         PREPROCESSOR,
         {
           begin: hljs.IDENT_RE + '::',
@@ -370,6 +395,7 @@ export default function(hljs) {
       ]),
     exports: {
       preprocessor: PREPROCESSOR,
+      preprocessorInclude: PREPROCESSOR_INCLUDE,
       strings: STRINGS,
       keywords: KEYWORDS
     }

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -98,6 +98,32 @@ export default function(hljs) {
     relevance: 0
   };
 
+  // `#include` is the only preprocessor directive that takes an angle-bracket
+  // quoted header (`#include <header>`). Scoping that rule to `#include` keeps
+  // the greedy `<...>` match from eating a `>` that belongs to the body of
+  // another directive (e.g. `#define what do { cout << ">"; } while (0)`),
+  // which would otherwise leave an unbalanced `"` and break highlighting for
+  // the rest of the file. See issue #3505.
+  const PREPROCESSOR_INCLUDE = {
+    className: 'meta',
+    begin: /#\s*include\b/,
+    end: /$/,
+    keywords: { keyword: 'include' },
+    contains: [
+      {
+        begin: /\\\n/,
+        relevance: 0
+      },
+      hljs.inherit(STRINGS, { className: 'string' }),
+      {
+        className: 'string',
+        begin: /<.*?>/
+      },
+      C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
+    ]
+  };
+
   const PREPROCESSOR = {
     className: 'meta',
     begin: /#\s*[a-z]+\b/,
@@ -111,10 +137,6 @@ export default function(hljs) {
         relevance: 0
       },
       hljs.inherit(STRINGS, { className: 'string' }),
-      {
-        className: 'string',
-        begin: /<.*?>/
-      },
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE
     ]
@@ -436,6 +458,7 @@ export default function(hljs) {
 
   const EXPRESSION_CONTAINS = [
     FUNCTION_DISPATCH,
+    PREPROCESSOR_INCLUDE,
     PREPROCESSOR,
     CPP_PRIMITIVE_TYPES,
     C_LINE_COMMENT_MODE,
@@ -548,6 +571,7 @@ export default function(hljs) {
       CPP_PRIMITIVE_TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
+      PREPROCESSOR_INCLUDE,
       PREPROCESSOR
     ]
   };
@@ -572,6 +596,7 @@ export default function(hljs) {
       FUNCTION_DISPATCH,
       EXPRESSION_CONTAINS,
       [
+        PREPROCESSOR_INCLUDE,
         PREPROCESSOR,
         { // containers: ie, `vector <int> rooms (9);`
           begin: '\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function|flat_map|flat_set)\\s*<(?!<)',

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -105,18 +105,18 @@ export default function(hljs) {
   // which would otherwise leave an unbalanced `"` and break highlighting for
   // the rest of the file. See issue #3505.
   const PREPROCESSOR_INCLUDE = {
-    className: 'meta',
+    scope: 'meta',
     begin: /#\s*include\b/,
     end: /$/,
     keywords: { keyword: 'include' },
     contains: [
       {
+        // the `\` at the end of a line signaling continuation
         begin: /\\\n/,
-        relevance: 0
       },
-      hljs.inherit(STRINGS, { className: 'string' }),
+      STRINGS,
       {
-        className: 'string',
+        scope: 'string',
         begin: /<.*?>/
       },
       C_LINE_COMMENT_MODE,
@@ -141,6 +141,11 @@ export default function(hljs) {
       hljs.C_BLOCK_COMMENT_MODE
     ]
   };
+
+  const PREPROCESSORS = [
+    PREPROCESSOR_INCLUDE,
+    PREPROCESSOR
+  ];
 
   const TITLE_MODE = {
     className: 'title',
@@ -458,8 +463,7 @@ export default function(hljs) {
 
   const EXPRESSION_CONTAINS = [
     FUNCTION_DISPATCH,
-    PREPROCESSOR_INCLUDE,
-    PREPROCESSOR,
+    ...PREPROCESSORS,
     CPP_PRIMITIVE_TYPES,
     C_LINE_COMMENT_MODE,
     hljs.C_BLOCK_COMMENT_MODE,
@@ -571,8 +575,7 @@ export default function(hljs) {
       CPP_PRIMITIVE_TYPES,
       C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
-      PREPROCESSOR_INCLUDE,
-      PREPROCESSOR
+      ...PREPROCESSORS
     ]
   };
 
@@ -596,8 +599,7 @@ export default function(hljs) {
       FUNCTION_DISPATCH,
       EXPRESSION_CONTAINS,
       [
-        PREPROCESSOR_INCLUDE,
-        PREPROCESSOR,
+        ...PREPROCESSORS,
         { // containers: ie, `vector <int> rooms (9);`
           begin: '\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function|flat_map|flat_set)\\s*<(?!<)',
           end: '>',

--- a/test/markup/c/preprocessor-define-angle-bracket.expect.txt
+++ b/test/markup/c/preprocessor-define-angle-bracket.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> DBG(x) do { printf(<span class="hljs-string">&quot;got &gt; %d\n&quot;</span>, x); } while (0)</span>
+<span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;stdio.h&gt;</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;sys/types.h&gt;</span></span>
+
+<span class="hljs-type">int</span> <span class="hljs-title function_">main</span><span class="hljs-params">(<span class="hljs-type">void</span>)</span> {
+  DBG(<span class="hljs-number">42</span>);
+  <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;
+}

--- a/test/markup/c/preprocessor-define-angle-bracket.txt
+++ b/test/markup/c/preprocessor-define-angle-bracket.txt
@@ -1,0 +1,8 @@
+#define DBG(x) do { printf("got > %d\n", x); } while (0)
+#include <stdio.h>
+#include <sys/types.h>
+
+int main(void) {
+  DBG(42);
+  return 0;
+}

--- a/test/markup/cpp/preprocessor-define-angle-bracket.expect.txt
+++ b/test/markup/cpp/preprocessor-define-angle-bracket.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> what do { cout &lt;&lt; <span class="hljs-string">&quot;&gt;&quot;</span>; } while (0)</span>
+<span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;iostream&gt;</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">include</span> <span class="hljs-string">&lt;vector&gt;</span></span>
+<span class="hljs-meta">#<span class="hljs-keyword">define</span> DBG(x) do { std::cerr &lt;&lt; x &lt;&lt; <span class="hljs-string">&quot;\n&quot;</span>; } while (0)</span>
+
+<span class="hljs-function"><span class="hljs-type">int</span> <span class="hljs-title">main</span><span class="hljs-params">()</span> </span>{
+  std::cout &lt;&lt; <span class="hljs-string">&quot;hello &gt; world&quot;</span> &lt;&lt; std::endl;
+  <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;
+}

--- a/test/markup/cpp/preprocessor-define-angle-bracket.txt
+++ b/test/markup/cpp/preprocessor-define-angle-bracket.txt
@@ -1,0 +1,9 @@
+#define what do { cout << ">"; } while (0)
+#include <iostream>
+#include <vector>
+#define DBG(x) do { std::cerr << x << "\n"; } while (0)
+
+int main() {
+  std::cout << "hello > world" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Fixes #3505.

## Root cause

The C/C++ preprocessor grammar applied the angle-bracket quoted-string rule (`<.*?>`, intended for `#include <header>`) to **every** preprocessor directive, not just `#include`. When a `#define` body contained `>`, for example:

```cpp
#define what do { cout << ">"; } while (0)
```

the greedy `<.*?>` match consumed `<< ">`, leaving an unbalanced `"` that the string rule then extended to the end of the file, breaking highlighting for everything after the offending line.

## Fix

Per @joshgoebel's guidance in the issue ("You may be right that this needs to be scoped to `#include`..."), this scopes the angle-bracket string to a dedicated `PREPROCESSOR_INCLUDE` mode that only matches `#include` lines, and removes it from the general `PREPROCESSOR` mode. `#include <iostream>` and `#include <sys/types.h>` continue to highlight exactly as before; other directives (`#define`, `#if`, ...) no longer risk swallowing a quote.

The change is applied symmetrically to both `src/languages/c.js` and `src/languages/cpp.js`, with `PREPROCESSOR_INCLUDE` placed ahead of `PREPROCESSOR` in each `contains` array so `#include` matches the more specific mode first.

## Tests

- Adds markup fixtures `test/markup/cpp/preprocessor-define-angle-bracket` and `test/markup/c/preprocessor-define-angle-bracket` reproducing the issue (a `#define` with `>` in its body plus a normal `#include` and follow-on code).
- `npm run build`, `npm test` (1595 passing, 3 pending, 0 failing), `npm run lint`, and `npm run lint-languages` are all green.

The maintainer explicitly asked for a PR in issue #3505 ("Either of your willing to submit a PR for this?").

Developed with AI assistance and reviewed by the contributor.
