### PR TITLE
Add GNU Gettext syntax highlighting for PO and POT files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- enh(gettext) add GNU Gettext PO and POT syntax highlighting [Pablo1Gustavo][]
 - enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
 - fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
@@ -22,6 +23,7 @@ Documentation:
 
 CONTRIBUTORS
 
+[Pablo1Gustavo]: https://github.com/Pablo1Gustavo
 [Hashim Khan]: https://github.com/Hashim1999164
 [arturict]: https://github.com/arturict
 [Dhruv Maniya]: https://github.com/iamdhrv

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -100,6 +100,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Gleam                   | gleam                  | [gleam-highlight.js](https://github.com/gleam-lang/gleam-highlight.js) |
 | Glimmer and EmberJS     | hbs, glimmer, html.hbs, html.handlebars, htmlbars | [highlightjs-glimmer](https://github.com/NullVoxPopuli/highlightjs-glimmer) |
 | GN for Ninja            | gn, gni                | [highlightjs-GN](https://github.com/highlightjs/highlightjs-GN) |
+| GNU Gettext             | gettext, po, pot       |         |
 | Go                      | go, golang             |         |
 | Golo                    | golo, gololang         |         |
 | Gradle                  | gradle                 |         |

--- a/src/languages/gettext.js
+++ b/src/languages/gettext.js
@@ -1,0 +1,77 @@
+/*
+Language: GNU Gettext
+Description: GNU gettext PO and POT translation catalog files
+Website: https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+Category: config
+*/
+
+/** @type LanguageFn */
+export default function(hljs) {
+  const ESCAPE = hljs.inherit(hljs.BACKSLASH_ESCAPE, {
+    scope: 'char.escape'
+  });
+
+  const FORMAT = {
+    scope: 'char.escape',
+    variants: [
+      { match: /[&_][A-Za-z0-9\u00C0-\uFFFF]/ },
+      { match: /<[a-zA-Z="/ ]+>/ },
+      { match: /%(?:\([\w\s]*\))?[-+#0 ]*(?:[1-9]\d*|\*)?(?:\.(?:\d+|\*))?[hlL]?[diouxXeEfFgGcrsab%]/ },
+      { match: /%(?:%|(?:[1-9]\d*\$)?[#0\- +'I]*(?:\*|[1-9]\d*)?(?:\.(?:\*|\d+)?)?(?:hh|h|ll|l|j|t|z|L)?[diouxXDOUeEfFgGaAcCsSpn])/ }
+    ],
+    relevance: 0
+  };
+
+  const STRING = {
+    scope: 'string',
+    begin: /"/,
+    end: /"/,
+    contains: [ ESCAPE, FORMAT ]
+  };
+
+  const DIRECTIVE = {
+    begin: [
+      /^\s*/,
+      /domain\b|msgctxt\b|msgid_plural\b|msgid\b|msgstr\b/
+    ],
+    beginScope: {
+      2: 'keyword'
+    },
+    end: /$/,
+    contains: [ STRING ]
+  };
+
+  const FORMAT_COMMENT = {
+    scope: 'comment',
+    begin: /^#,/,
+    end: /$/,
+    contains: [
+      ESCAPE,
+      {
+        scope: 'doctag',
+        match: /\bfuzzy\b/,
+        relevance: 0
+      }
+    ]
+  };
+
+  const LOCATION_COMMENT = {
+    scope: 'comment',
+    begin: /^#:/,
+    end: /$/,
+    contains: [ ESCAPE ]
+  };
+
+  return {
+    name: 'GNU Gettext',
+    aliases: [ 'po', 'pot' ],
+    disableAutodetect: true,
+    contains: [
+      FORMAT_COMMENT,
+      LOCATION_COMMENT,
+      hljs.COMMENT(/^#/, /$/),
+      DIRECTIVE,
+      STRING
+    ]
+  };
+}

--- a/test/detect/gettext/default.txt
+++ b/test/detect/gettext/default.txt
@@ -1,0 +1,32 @@
+# Example gettext translation catalog
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Example Project 1.0\n"
+"Report-Msgid-Bugs-To: https://example.com/bugs\n"
+"POT-Creation-Date: 2026-08-08 12:00+0000\n"
+"PO-Revision-Date: 2026-08-08 12:00+0000\n"
+"Last-Translator: Example Translator <translator@example.com>\n"
+"Language-Team: Portuguese <translations@example.com>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Shown in the file menu when there are unsaved changes.
+#: src/window.c:42 src/menu.c:17
+#, c-format
+#| msgid "Save document"
+msgctxt "file menu"
+msgid "Save _As &Close <b>%1$s</b> (%d file)"
+msgid_plural "Save _As &Close <b>%1$s</b> (%d files)"
+msgstr[0] "Salvar _como e &fechar <b>%1$s</b> (%d arquivo)"
+msgstr[1] "Salvar _como e &fechar <b>%1$s</b> (%d arquivos)"
+
+#, python-format
+msgid "Hello %(name)s, you have %(count)d new message."
+msgstr "Ola %(name)s, voce tem %(count)d nova mensagem."
+
+#~ msgid "Obsolete message"
+#~ msgstr "Mensagem obsoleta"

--- a/test/markup/gettext/default.expect.txt
+++ b/test/markup/gettext/default.expect.txt
@@ -1,0 +1,57 @@
+<span class="hljs-comment"># Example gettext translation catalog</span>
+<span class="hljs-comment"># Copyright (C) 2026 Example Project</span>
+<span class="hljs-comment"># This file is distributed under the same license as the project.</span>
+<span class="hljs-comment"># Translator: Example Translator &lt;translator@example.com&gt;</span>
+<span class="hljs-comment">#, <span class="hljs-doctag">fuzzy</span></span>
+<span class="hljs-keyword">msgid</span> <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-keyword">msgstr</span> <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-string">&quot;Project-Id-Version: Example Project 1.0<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Report-Msgid-Bugs-To: https://example.com/bugs<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;POT-Creation-Date: 2026-08-08 12:00+0000<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;PO-Revision-Date: 2026-08-08 12:00+0000<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Last-Translator: Example Translator &lt;translator@example.com&gt;<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Language-Team: Portuguese &lt;translations@example.com&gt;<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Language: pt<span class="hljs-char escape_">_B</span>R<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;MIME-Version: 1.0<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Content-Type: text/plain; charset=UTF-8<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Content-Transfer-Encoding: 8bit<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Plural-Forms: nplurals=2; plural=(n != 1);<span class="hljs-char escape_">\n</span>&quot;</span>
+
+<span class="hljs-comment">#. Shown in the file menu when there are unsaved changes.</span>
+<span class="hljs-comment">#: src/window.c:42 src/menu.c:17</span>
+<span class="hljs-comment">#, <span class="hljs-doctag">fuzzy</span>, c-format, no-wrap</span>
+<span class="hljs-comment">#| msgctxt &quot;menu item&quot;</span>
+<span class="hljs-comment">#| msgid &quot;Save document&quot;</span>
+<span class="hljs-keyword">msgctxt</span> <span class="hljs-string">&quot;file menu&quot;</span>
+<span class="hljs-keyword">msgid</span> <span class="hljs-string">&quot;Save <span class="hljs-char escape_">_A</span>s <span class="hljs-char escape_">&amp;C</span>lose <span class="hljs-char escape_">&lt;b&gt;</span><span class="hljs-char escape_">%1$s</span><span class="hljs-char escape_">&lt;/b&gt;</span> (<span class="hljs-char escape_">%d</span> file)&quot;</span>
+<span class="hljs-keyword">msgid_plural</span> <span class="hljs-string">&quot;Save <span class="hljs-char escape_">_A</span>s <span class="hljs-char escape_">&amp;C</span>lose <span class="hljs-char escape_">&lt;b&gt;</span><span class="hljs-char escape_">%1$s</span><span class="hljs-char escape_">&lt;/b&gt;</span> (<span class="hljs-char escape_">%d</span> files)&quot;</span>
+<span class="hljs-keyword">msgstr</span>[0] <span class="hljs-string">&quot;Salvar <span class="hljs-char escape_">_c</span>omo e <span class="hljs-char escape_">&amp;f</span>echar <span class="hljs-char escape_">&lt;b&gt;</span><span class="hljs-char escape_">%1$s</span><span class="hljs-char escape_">&lt;/b&gt;</span> (<span class="hljs-char escape_">%d</span> arquivo)&quot;</span>
+<span class="hljs-keyword">msgstr</span>[1] <span class="hljs-string">&quot;Salvar <span class="hljs-char escape_">_c</span>omo e <span class="hljs-char escape_">&amp;f</span>echar <span class="hljs-char escape_">&lt;b&gt;</span><span class="hljs-char escape_">%1$s</span><span class="hljs-char escape_">&lt;/b&gt;</span> (<span class="hljs-char escape_">%d</span> arquivos)&quot;</span>
+
+<span class="hljs-comment">#. Python mapping placeholders must be retained by translators.</span>
+<span class="hljs-comment">#: src/notifications.py:88</span>
+<span class="hljs-comment">#, python-format</span>
+<span class="hljs-keyword">msgctxt</span> <span class="hljs-string">&quot;notification&quot;</span>
+<span class="hljs-keyword">msgid</span> <span class="hljs-string">&quot;Hello <span class="hljs-char escape_">%(name)s</span>, you have <span class="hljs-char escape_">%(count)d</span> new message.&quot;</span>
+<span class="hljs-keyword">msgid_plural</span> <span class="hljs-string">&quot;Hello <span class="hljs-char escape_">%(name)s</span>, you have <span class="hljs-char escape_">%(count)d</span> new messages.&quot;</span>
+<span class="hljs-keyword">msgstr</span>[0] <span class="hljs-string">&quot;Ola <span class="hljs-char escape_">%(name)s</span>, voce tem <span class="hljs-char escape_">%(count)d</span> nova mensagem.&quot;</span>
+<span class="hljs-keyword">msgstr</span>[1] <span class="hljs-string">&quot;Ola <span class="hljs-char escape_">%(name)s</span>, voce tem <span class="hljs-char escape_">%(count)d</span> novas mensagens.&quot;</span>
+
+<span class="hljs-keyword">msgid</span> <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-string">&quot;A multiline message with an escaped quote: <span class="hljs-char escape_">\&quot;</span><span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;It also contains a tab <span class="hljs-char escape_">\t</span> and a backslash <span class="hljs-char escape_">\\</span>.&quot;</span>
+<span class="hljs-keyword">msgstr</span> <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-string">&quot;Uma mensagem com varias linhas.<span class="hljs-char escape_">\n</span>&quot;</span>
+<span class="hljs-string">&quot;Tambem contem uma tabulacao <span class="hljs-char escape_">\t</span> e uma barra invertida <span class="hljs-char escape_">\\</span>.&quot;</span>
+
+<span class="hljs-comment"># Translator comment with no automatic metadata.</span>
+<span class="hljs-comment">#: src/preferences.ui</span>
+<span class="hljs-comment">#, no-c-format</span>
+<span class="hljs-keyword">msgid</span> <span class="hljs-string">&quot;Preferences&quot;</span>
+<span class="hljs-keyword">msgstr</span> <span class="hljs-string">&quot;Preferencias&quot;</span>
+
+<span class="hljs-comment">#~ #. This translation was removed from the template.</span>
+<span class="hljs-comment">#~ #: src/legacy.c:9</span>
+<span class="hljs-comment">#~ #, c-format</span>
+<span class="hljs-comment">#~ msgid &quot;Obsolete message&quot;</span>
+<span class="hljs-comment">#~ msgstr &quot;Mensagem obsoleta&quot;</span>

--- a/test/markup/gettext/default.txt
+++ b/test/markup/gettext/default.txt
@@ -1,0 +1,57 @@
+# Example gettext translation catalog
+# Copyright (C) 2026 Example Project
+# This file is distributed under the same license as the project.
+# Translator: Example Translator <translator@example.com>
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Example Project 1.0\n"
+"Report-Msgid-Bugs-To: https://example.com/bugs\n"
+"POT-Creation-Date: 2026-08-08 12:00+0000\n"
+"PO-Revision-Date: 2026-08-08 12:00+0000\n"
+"Last-Translator: Example Translator <translator@example.com>\n"
+"Language-Team: Portuguese <translations@example.com>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Shown in the file menu when there are unsaved changes.
+#: src/window.c:42 src/menu.c:17
+#, fuzzy, c-format, no-wrap
+#| msgctxt "menu item"
+#| msgid "Save document"
+msgctxt "file menu"
+msgid "Save _As &Close <b>%1$s</b> (%d file)"
+msgid_plural "Save _As &Close <b>%1$s</b> (%d files)"
+msgstr[0] "Salvar _como e &fechar <b>%1$s</b> (%d arquivo)"
+msgstr[1] "Salvar _como e &fechar <b>%1$s</b> (%d arquivos)"
+
+#. Python mapping placeholders must be retained by translators.
+#: src/notifications.py:88
+#, python-format
+msgctxt "notification"
+msgid "Hello %(name)s, you have %(count)d new message."
+msgid_plural "Hello %(name)s, you have %(count)d new messages."
+msgstr[0] "Ola %(name)s, voce tem %(count)d nova mensagem."
+msgstr[1] "Ola %(name)s, voce tem %(count)d novas mensagens."
+
+msgid ""
+"A multiline message with an escaped quote: \"\n"
+"It also contains a tab \t and a backslash \\."
+msgstr ""
+"Uma mensagem com varias linhas.\n"
+"Tambem contem uma tabulacao \t e uma barra invertida \\."
+
+# Translator comment with no automatic metadata.
+#: src/preferences.ui
+#, no-c-format
+msgid "Preferences"
+msgstr "Preferencias"
+
+#~ #. This translation was removed from the template.
+#~ #: src/legacy.c:9
+#~ #, c-format
+#~ msgid "Obsolete message"
+#~ msgstr "Mensagem obsoleta"


### PR DESCRIPTION
### Changes
- Added GNU Gettext syntax highlighting for `.po` and `.pot` catalogs.
- Highlights PO directives, comments, `fuzzy` flags, plurals, contexts, multiline strings, escapes, placeholders, mnemonics, tags, and obsolete entries.
- Added comprehensive markup and detection examples, plus changelog and supported-language documentation.

Gettext catalogs are widely used for software localization. Native highlighting makes translation files easier to scan and edit safely, especially when preserving plural forms, format placeholders, and message context.

### Checklist
- [x] Added markup tests.
- [x] Updated the changelog at `CHANGES.md`