### PR TITLE
refactor: inline deepFreeze and drop deep-freeze-es6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "commander": "^14.0.3",
         "css": "^3.0.0",
         "css-color-names": "^1.0.1",
-        "deep-freeze-es6": "^3.0.2",
         "del": "^8.0.0",
         "dependency-resolver": "^2.0.1",
         "eslint": "^8.57.0",
@@ -2064,15 +2063,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/deep-freeze-es6": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/deep-freeze-es6/-/deep-freeze-es6-3.0.2.tgz",
-      "integrity": "sha512-snvTmNKjkzR1ywDMWN+jJtjEwqTPF0Nq0g1/puSkkaxgL71gJ0rJpsPF+WOqMRaVLWogtwb73lHthfSaqP8nIQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.12.0"
       }
     },
     "node_modules/deep-is": {
@@ -7388,12 +7378,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true
-    },
-    "deep-freeze-es6": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/deep-freeze-es6/-/deep-freeze-es6-3.0.2.tgz",
-      "integrity": "sha512-snvTmNKjkzR1ywDMWN+jJtjEwqTPF0Nq0g1/puSkkaxgL71gJ0rJpsPF+WOqMRaVLWogtwb73lHthfSaqP8nIQ==",
       "dev": true
     },
     "deep-is": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "commander": "^14.0.3",
     "css": "^3.0.0",
     "css-color-names": "^1.0.1",
-    "deep-freeze-es6": "^3.0.2",
     "del": "^8.0.0",
     "dependency-resolver": "^2.0.1",
     "eslint": "^8.57.0",

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -3,8 +3,6 @@ Syntax highlighting with language autodetection.
 https://highlightjs.org/
 */
 
-// @ts-ignore
-import deepFreeze from 'deep-freeze-es6';
 import Response from './lib/response.js';
 import TokenTreeEmitter from './lib/token_tree.js';
 import * as regex from './lib/regex.js';
@@ -1030,7 +1028,7 @@ const HLJS = function(hljs) {
     // @ts-ignore
     if (typeof MODES[key] === "object") {
       // @ts-ignore
-      deepFreeze(MODES[key]);
+      utils.deepFreeze(MODES[key]);
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -34,3 +34,20 @@ export function inherit(original, ...objects) {
   return /** @type {T} */ (result);
 }
 
+/**
+ * @template T
+ * @param {T} obj
+ * @returns {T}
+ */
+export function deepFreeze(obj) {
+  if (obj === null || typeof obj !== "object" || Object.isFrozen(obj)) {
+    return obj;
+  }
+  Object.freeze(obj);
+  for (const name of Object.getOwnPropertyNames(obj)) {
+    // @ts-ignore
+    deepFreeze(obj[name]);
+  }
+  return obj;
+}
+


### PR DESCRIPTION
## Summary

- Inline a minimal recursive `Object.freeze` helper in `src/lib/utils.js` (same walk as before: objects, arrays, regexes — what `MODES` actually contains).
- Remove the `deep-freeze-es6` devDependency.
- Supersedes / replaces #4470 (bump to v5), which required Node `>=22.18` and didn’t match our CI matrix.

## Test plan

- [x] `node tools/build.js -t node`
- [x] Smoke: `hljs.C_LINE_COMMENT_MODE` is frozen after load
- [ ] CI green