### PR TITLE
enh(dns): highlight CAA property tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- enh(dns) highlight registered CAA property tags, issue #4475 [Joey Huang][]
 - enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
 - fix(rust) recognize `\\` and `\"` char-literal escapes so highlighting doesn't leak, issue #4351 [Sarath Francis][]
@@ -28,6 +29,7 @@ Documentation:
 
 CONTRIBUTORS
 
+[Joey Huang]: https://github.com/oiahoon
 [Hashim Khan]: https://github.com/Hashim1999164
 [arturict]: https://github.com/arturict
 [Dhruv Maniya]: https://github.com/iamdhrv

--- a/src/languages/dns.js
+++ b/src/languages/dns.js
@@ -67,6 +67,8 @@ export default function(hljs) {
     contains: [ ESCAPE ]
   };
 
+  const CAA_PROPERTY_TAG = /\b(?:issuewild|issue|iodef|contactemail|contactphone|issuevmc|issuemail)\b/;
+
   return {
     name: 'DNS Zone',
     aliases: [
@@ -77,6 +79,20 @@ export default function(hljs) {
     keywords: KEYWORDS,
     contains: [
       hljs.COMMENT(';', '$', { relevance: 0 }),
+      {
+        match: [
+          /\bCAA\b/,
+          /[ \t]+/,
+          /\d+/,
+          /[ \t]+/,
+          CAA_PROPERTY_TAG
+        ],
+        scope: {
+          1: 'keyword',
+          3: 'number',
+          5: 'attr'
+        }
+      },
       STRING,
       {
         match: [

--- a/test/markup/dns/caa.expect.txt
+++ b/test/markup/dns/caa.expect.txt
@@ -1,0 +1,13 @@
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">issue</span>  <span class="hljs-string">&quot;letsencrypt.org&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">issuewild</span>  <span class="hljs-string">&quot;;&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">128</span>  <span class="hljs-attr">iodef</span>  <span class="hljs-string">&quot;mailto:security@example.com&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">contactemail</span>  <span class="hljs-string">&quot;admin@example.com&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">contactphone</span>  <span class="hljs-string">&quot;+1-555-555-0100&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">issuevmc</span>  <span class="hljs-string">&quot;example-ca.test&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">issuemail</span>  <span class="hljs-string">&quot;;&quot;</span>
+@  <span class="hljs-type">in</span>  <span class="hljs-keyword">caa</span>  <span class="hljs-number">0</span>  <span class="hljs-attr">ISSUE</span>  <span class="hljs-string">&quot;example-ca.test&quot;</span>
+issue  <span class="hljs-type">IN</span>  <span class="hljs-keyword">TXT</span>  <span class="hljs-string">&quot;not a CAA property tag&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  <span class="hljs-number">0</span>  custom  <span class="hljs-string">&quot;example-ca.test&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>  issue  <span class="hljs-string">&quot;missing flag&quot;</span>
+@  <span class="hljs-type">IN</span>  <span class="hljs-keyword">CAA</span>
+<span class="hljs-number">0</span>  issue  <span class="hljs-string">&quot;different record&quot;</span>

--- a/test/markup/dns/caa.txt
+++ b/test/markup/dns/caa.txt
@@ -1,0 +1,13 @@
+@  IN  CAA  0  issue  "letsencrypt.org"
+@  IN  CAA  0  issuewild  ";"
+@  IN  CAA  128  iodef  "mailto:security@example.com"
+@  IN  CAA  0  contactemail  "admin@example.com"
+@  IN  CAA  0  contactphone  "+1-555-555-0100"
+@  IN  CAA  0  issuevmc  "example-ca.test"
+@  IN  CAA  0  issuemail  ";"
+@  in  caa  0  ISSUE  "example-ca.test"
+issue  IN  TXT  "not a CAA property tag"
+@  IN  CAA  0  custom  "example-ca.test"
+@  IN  CAA  issue  "missing flag"
+@  IN  CAA
+0  issue  "different record"


### PR DESCRIPTION
### Changes

- Highlight registered non-reserved CAA property tags with the `attr` scope.
- Restrict matching to the `CAA <flag> <tag>` sequence on one record so the same words remain plain elsewhere.
- Add DNS markup coverage for registered tags, case-insensitive input, unknown tags, missing flags, and cross-record boundaries.

Resolves #4475.

### Verification

- `npm run build`
- `ONLY_LANGUAGES=dns npm run test-markup` — 4 passing
- `npm test` — 1,609 passing, 3 pending
- `npm run lint-languages`
- `npm run lint` — zero errors; one existing ignored-vendor warning
- `git diff --check`

### Checklist

- [x] Added markup tests
- [x] Updated the changelog at `CHANGES.md`