### PR TITLE
enh(javascript/typescript) native JSX grammar (#1625)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 Core Grammars:
 
+- enh(javascript, typescript) native JSX grammar (no XML sublanguage): comments in tags and `{/* */}`, issue #1625 [Josh Goebel][]
 - enh(dns) highlight registered CAA property tags, issue #4475 [Joey Huang][]
 - enh(dos) add `batch` as an alias, issue #4395 [Hashim Khan][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -24,68 +24,130 @@ export default function(hljs) {
   };
 
   const IDENT_RE = ECMAScript.IDENT_RE;
-  const FRAGMENT = {
-    begin: '<>',
-    end: '</>'
+  // JSX tag names: Component, div, ns:tag, member.tag, dashes
+  const JSX_TAG_NAME_RE = /[A-Za-z_$][\w$.:-]*/;
+  /**
+   * Scan forward from `<` to find this tag's terminator (`>` or `/>`),
+   * skipping strings, comments, and `{...}` expressions so `=>` etc. do not
+   * false-trigger.
+   * @param {string} input
+   * @param {number} from index of `<`
+   * @returns {{end: number, selfClosing: boolean} | null}
+   */
+  const scanJsxTagEnd = (input, from) => {
+    let i = from + 1; // after <
+    // skip / of closing tag
+    if (input[i] === '/') i++;
+    let depth = 0;
+    let quote = /** @type {string | null} */ (null);
+    while (i < input.length) {
+      const c = input[i];
+      if (quote) {
+        if (c === '\\') {
+          i += 2;
+          continue;
+        }
+        if (c === quote) quote = null;
+        i++;
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        quote = c;
+        i++;
+        continue;
+      }
+      if (c === '{') {
+        depth++;
+        i++;
+        continue;
+      }
+      if (c === '}') {
+        if (depth > 0) depth--;
+        i++;
+        continue;
+      }
+      if (depth > 0) {
+        i++;
+        continue;
+      }
+      // line comment inside tag
+      if (c === '/' && input[i + 1] === '/') {
+        const nl = input.indexOf('\n', i);
+        i = nl === -1 ? input.length : nl;
+        continue;
+      }
+      // block comment inside tag
+      if (c === '/' && input[i + 1] === '*') {
+        const end = input.indexOf('*/', i + 2);
+        i = end === -1 ? input.length : end + 2;
+        continue;
+      }
+      if (c === '<' ) {
+        // nested `<` is not valid here for our purposes
+        return null;
+      }
+      if (c === '>') {
+        return { end: i, selfClosing: false };
+      }
+      if (c === '/' && input[i + 1] === '>') {
+        return { end: i + 1, selfClosing: true };
+      }
+      i++;
+    }
+    return null;
   };
-  // to avoid some special cases inside isTrulyOpeningTag
-  const XML_SELF_CLOSING = /<[A-Za-z0-9\\._:-]+\s*\/>/;
-  const XML_TAG = {
-    begin: /<[A-Za-z0-9\\._:-]+/,
-    end: /\/[A-Za-z0-9\\._:-]+>|\/>/,
-    /**
-     * @param {RegExpMatchArray} match
-     * @param {CallbackResponse} response
-     */
-    isTrulyOpeningTag: (match, response) => {
-      const afterMatchIndex = match[0].length + match.index;
-      const nextChar = match.input[afterMatchIndex];
-      if (
-        // HTML should not include another raw `<` inside a tag
-        // nested type?
-        // `<Array<Array<number>>`, etc.
-        nextChar === "<" ||
-        // the , gives away that this is not HTML
-        // `<T, A extends keyof T, V>`
-        nextChar === ","
-        ) {
+
+  /**
+   * Discriminate JSX tags from TypeScript generics / comparisons.
+   * `match` is the leading `<` only (name is a child mode).
+   * @param {RegExpMatchArray} match
+   * @param {CallbackResponse} response
+   */
+  const isTrulyOpeningTag = (match, response) => {
+    const afterLt = match.input.slice(match.index + match[0].length);
+    const nameMatch = afterLt.match(/^[A-Za-z_$][\w$.:-]*/);
+    if (!nameMatch) {
+      response.ignoreMatch();
+      return;
+    }
+    const afterNameIndex = match.index + match[0].length + nameMatch[0].length;
+    const nextChar = match.input[afterNameIndex];
+    if (
+      // nested type: `<Array<Array<number>>`
+      nextChar === "<" ||
+      // type params: `<T, A extends keyof T, V>`
+      nextChar === ","
+    ) {
+      response.ignoreMatch();
+      return;
+    }
+
+    // `<something>` — need a matching close tag later
+    if (nextChar === ">") {
+      // hasClosingTag expects match[0] like `<Name`
+      const fakeMatch = {
+        0: match.input.slice(match.index, afterNameIndex),
+        input: match.input,
+        index: match.index
+      };
+      if (!hasClosingTag(/** @type {any} */ (fakeMatch), { after: afterNameIndex })) {
         response.ignoreMatch();
-        return;
       }
+      return;
+    }
 
-      // `<something>`
-      // Quite possibly a tag, lets look for a matching closing tag...
-      if (nextChar === ">") {
-        // if we cannot find a matching closing tag, then we
-        // will ignore it
-        if (!hasClosingTag(match, { after: afterMatchIndex })) {
-          response.ignoreMatch();
-        }
-      }
+    const afterName = match.input.substring(afterNameIndex);
 
-      // `<blah />` (self-closing)
-      // handled by simpleSelfClosing rule
+    // `<T = any>(key?: string) => ...`
+    if (afterName.match(/^\s*=/)) {
+      response.ignoreMatch();
+      return;
+    }
 
-      let m;
-      const afterMatch = match.input.substring(afterMatchIndex);
-
-      // some more template typing stuff
-      //  <T = any>(key?: string) => Modify<
-      if ((m = afterMatch.match(/^\s*=/))) {
-        response.ignoreMatch();
-        return;
-      }
-
-      // `<From extends string>`
-      // technically this could be HTML, but it smells like a type
-      // NOTE: This is ugh, but added specifically for https://github.com/highlightjs/highlight.js/issues/3276
-      if ((m = afterMatch.match(/^\s+extends\s+/))) {
-        if (m.index === 0) {
-          response.ignoreMatch();
-          // eslint-disable-next-line no-useless-return
-          return;
-        }
-      }
+    // `<From extends string>` (https://github.com/highlightjs/highlight.js/issues/3276)
+    const extendsMatch = afterName.match(/^\s+extends\s+/);
+    if (extendsMatch && extendsMatch.index === 0) {
+      response.ignoreMatch();
     }
   };
   const KEYWORDS = {
@@ -451,6 +513,185 @@ export default function(hljs) {
     ]
   };
 
+  // Native JSX (not xml sublanguage): tags, attrs, // and /* */ inside open
+  // tags, and {...} expressions that re-enter JS (including nested JSX).
+  //
+  // Pairing model: open tag mode `starts` a children mode; the children mode
+  // ends via endsParent on the matching close tag. Nested elements are full
+  // child modes (not bare open/close), so </child> cannot terminate <parent>.
+  const JSX_ELEMENT = { variants: [] };
+
+  const JSX_EXPRESSION = {
+    begin: /\{/,
+    end: /\}/,
+    keywords: KEYWORDS,
+    contains: [
+      COMMENT,
+      hljs.APOS_STRING_MODE,
+      hljs.QUOTE_STRING_MODE,
+      TEMPLATE_STRING,
+      { match: /\$\d+/ },
+      NUMBER,
+      {
+        className: 'function',
+        begin: FUNC_LEAD_IN_RE,
+        returnBegin: true,
+        end: '\\s*=>',
+        contains: [
+          {
+            className: 'params',
+            variants: [
+              {
+                begin: hljs.UNDERSCORE_IDENT_RE,
+                relevance: 0
+              },
+              {
+                className: null,
+                begin: /\(\s*\)/,
+                skip: true
+              },
+              {
+                begin: /(\s*)\(/,
+                end: /\)/,
+                excludeBegin: true,
+                excludeEnd: true,
+                keywords: KEYWORDS,
+                contains: PARAMS_CONTAINS
+              }
+            ]
+          }
+        ]
+      },
+      PROPERTY_ACCESS,
+      FUNCTION_CALL,
+      CLASS_REFERENCE,
+      UPPER_CASE_CONSTANT,
+      JSX_ELEMENT,
+      // nested braces (objects, blocks)
+      "self"
+    ]
+  };
+
+  const JSX_TAG_INTERNALS = {
+    endsWithParent: true,
+    illegal: /</,
+    relevance: 0,
+    contains: [
+      COMMENT,
+      {
+        className: 'attr',
+        begin: JSX_TAG_NAME_RE,
+        relevance: 0
+      },
+      {
+        begin: /=\s*/,
+        relevance: 0,
+        endsWithParent: true,
+        contains: [
+          {
+            className: 'string',
+            endsParent: true,
+            variants: [
+              { begin: /"/, end: /"/ },
+              { begin: /'/, end: /'/ }
+            ]
+          },
+          JSX_EXPRESSION
+        ]
+      }
+    ]
+  };
+
+  const JSX_CLOSE_TAG = {
+    className: 'tag',
+    begin: regex.concat(
+      /<\//,
+      regex.lookahead(regex.concat(JSX_TAG_NAME_RE, />/))
+    ),
+    end: />/,
+    endsParent: true,
+    contains: [
+      {
+        className: 'name',
+        begin: JSX_TAG_NAME_RE,
+        relevance: 0
+      }
+    ]
+  };
+
+  /**
+   * @param {boolean} selfClosing
+   * @param {boolean} paired after `>` continue into children until close tag
+   */
+  const jsxOpenTag = (selfClosing, paired) => {
+    /** @type {Mode} */
+    const mode = {
+      className: 'tag',
+      begin: regex.concat(
+        /</,
+        regex.lookahead(JSX_TAG_NAME_RE)
+      ),
+      end: selfClosing ? /\/>/ : />/,
+      contains: [
+        {
+          className: 'name',
+          begin: JSX_TAG_NAME_RE,
+          relevance: 0,
+          starts: JSX_TAG_INTERNALS
+        }
+      ],
+      'on:begin': (match, response) => {
+        isTrulyOpeningTag(match, response);
+        if (response.isMatchIgnored) return;
+        const scanned = scanJsxTagEnd(match.input, match.index);
+        if (!scanned) {
+          response.ignoreMatch();
+          return;
+        }
+        if (selfClosing && !scanned.selfClosing) response.ignoreMatch();
+        if (paired && scanned.selfClosing) response.ignoreMatch();
+      }
+    };
+    if (paired) {
+      mode.starts = {
+        end: hljs.MATCH_NOTHING_RE,
+        contains: [
+          JSX_EXPRESSION,
+          JSX_ELEMENT,
+          JSX_CLOSE_TAG
+        ]
+      };
+    }
+    return mode;
+  };
+
+  const JSX_SELF_CLOSING_TAG = jsxOpenTag(true, false);
+  const JSX_PAIRED_TAG = jsxOpenTag(false, true);
+
+  JSX_ELEMENT.variants = [
+    {
+      // <> children </>
+      className: 'tag',
+      begin: /<>/,
+      starts: {
+        end: hljs.MATCH_NOTHING_RE,
+        contains: [
+          JSX_EXPRESSION,
+          JSX_ELEMENT,
+          {
+            className: 'tag',
+            begin: /<\/>/,
+            endsParent: true
+          }
+        ]
+      }
+    },
+    JSX_SELF_CLOSING_TAG,
+    JSX_PAIRED_TAG
+  ];
+
+  const JSX = JSX_ELEMENT;
+
   return {
     name: 'JavaScript',
     aliases: ['js', 'jsx', 'mjs', 'cjs'],
@@ -530,28 +771,7 @@ export default function(hljs) {
             match: /\s+/,
             relevance: 0
           },
-          { // JSX
-            variants: [
-              { begin: FRAGMENT.begin, end: FRAGMENT.end },
-              { match: XML_SELF_CLOSING },
-              {
-                begin: XML_TAG.begin,
-                // we carefully check the opening tag to see if it truly
-                // is a tag and not a false positive
-                'on:begin': XML_TAG.isTrulyOpeningTag,
-                end: XML_TAG.end
-              }
-            ],
-            subLanguage: 'xml',
-            contains: [
-              {
-                begin: XML_TAG.begin,
-                end: XML_TAG.end,
-                skip: true,
-                contains: ['self']
-              }
-            ]
-          }
+          JSX
         ],
       },
       FUNCTION_DEFINITION,

--- a/test/markup/javascript/arrow-function.expect.txt
+++ b/test/markup/javascript/arrow-function.expect.txt
@@ -1,7 +1,7 @@
 <span class="hljs-keyword">var</span> <span class="hljs-title function_">f</span> = x =&gt; x;
 <span class="hljs-title function_">f</span>(<span class="hljs-function"><span class="hljs-params">x</span> =&gt;</span> x + <span class="hljs-function">(<span class="hljs-params">y=<span class="hljs-number">2</span>, z=<span class="hljs-literal">undefined</span>, ...rest</span>) =&gt;</span> y);
 <span class="hljs-function">() =&gt;</span> <span class="hljs-literal">null</span>;
-<span class="hljs-keyword">const</span> <span class="hljs-title function_">FC</span> = props =&gt; <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>functional component<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span></span>;
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">FC</span> = props =&gt; <span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>functional component<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>;
 
 <span class="hljs-keyword">const</span> <span class="hljs-title function_">good</span> = (<span class="hljs-params"></span>) =&gt; <span class="hljs-number">0</span>;
 <span class="hljs-keyword">const</span> <span class="hljs-title function_">good</span> = (<span class="hljs-params">x</span>) =&gt; <span class="hljs-number">0</span>;

--- a/test/markup/javascript/jsx-comments.expect.txt
+++ b/test/markup/javascript/jsx-comments.expect.txt
@@ -1,0 +1,50 @@
+<span class="hljs-comment">// attribute values: {/* */} is a JS comment expression</span>
+<span class="hljs-keyword">return</span> (
+  <span class="hljs-tag">&lt;<span class="hljs-name">ClassicBasic</span>
+    <span class="hljs-attr">value</span>={<span class="hljs-comment">/* ... */</span>}
+    onChange={<span class="hljs-comment">/* ... */</span>}
+    editorState={<span class="hljs-variable language_">this</span>.<span class="hljs-property">state</span>.<span class="hljs-property">editorState</span>}
+    onStateChange={<span class="hljs-function"><span class="hljs-params">editorState</span> =&gt;</span> <span class="hljs-variable language_">this</span>.<span class="hljs-title function_">setState</span>({ editorState })}
+  /&gt;</span>
+);
+
+<span class="hljs-comment">// line and block comments between attributes (inside the opening tag)</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">button</span>
+  <span class="hljs-comment">// prevent editor losing focus</span>
+  <span class="hljs-attr">onMouseDown</span>={<span class="hljs-function"><span class="hljs-params">e</span> =&gt;</span> e.<span class="hljs-title function_">preventDefault</span>()}
+  /* also a block comment between attrs */
+  onClick={<span class="hljs-function">() =&gt;</span> {
+    <span class="hljs-variable language_">this</span>.<span class="hljs-title function_">setState</span>(<span class="hljs-function"><span class="hljs-params">s</span> =&gt;</span> <span class="hljs-title function_">update</span>(s, <span class="hljs-string">&#x27;editorState.bold.value&#x27;</span>, <span class="hljs-function"><span class="hljs-params">value</span> =&gt;</span> !value));
+  }}
+&gt;</span>
+  Toggle bold
+<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>;
+
+<span class="hljs-comment">// multi-line block comment between attributes</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Comp</span>
+  <span class="hljs-comment">/* multi
+     line */</span>
+  <span class="hljs-attr">foo</span>={<span class="hljs-number">1</span>}
+  bar={<span class="hljs-string">&quot;ok&quot;</span>}
+/&gt;</span>;
+
+<span class="hljs-comment">// {/* */} as a child expression (not text)</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
+  {<span class="hljs-comment">/* block comment in children */</span>}
+  <span class="hljs-tag">&lt;<span class="hljs-name">span</span> /&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>;
+
+<span class="hljs-comment">// children text that looks like // is NOT a comment</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
+  // this is text content
+  <span class="hljs-tag">&lt;<span class="hljs-name">X</span> /&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>;
+
+<span class="hljs-comment">// self-closing with mixed attrs and comments</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">img</span>
+  <span class="hljs-attr">src</span>={url}
+  // lazy load
+  loading=<span class="hljs-string">&quot;lazy&quot;</span>
+  <span class="hljs-comment">/* width hint */</span>
+  <span class="hljs-attr">width</span>={<span class="hljs-comment">/* px */</span> <span class="hljs-number">100</span>}
+/&gt;</span>;

--- a/test/markup/javascript/jsx-comments.txt
+++ b/test/markup/javascript/jsx-comments.txt
@@ -1,0 +1,50 @@
+// attribute values: {/* */} is a JS comment expression
+return (
+  <ClassicBasic
+    value={/* ... */}
+    onChange={/* ... */}
+    editorState={this.state.editorState}
+    onStateChange={editorState => this.setState({ editorState })}
+  />
+);
+
+// line and block comments between attributes (inside the opening tag)
+<button
+  // prevent editor losing focus
+  onMouseDown={e => e.preventDefault()}
+  /* also a block comment between attrs */
+  onClick={() => {
+    this.setState(s => update(s, 'editorState.bold.value', value => !value));
+  }}
+>
+  Toggle bold
+</button>;
+
+// multi-line block comment between attributes
+<Comp
+  /* multi
+     line */
+  foo={1}
+  bar={"ok"}
+/>;
+
+// {/* */} as a child expression (not text)
+<div>
+  {/* block comment in children */}
+  <span />
+</div>;
+
+// children text that looks like // is NOT a comment
+<div>
+  // this is text content
+  <X />
+</div>;
+
+// self-closing with mixed attrs and comments
+<img
+  src={url}
+  // lazy load
+  loading="lazy"
+  /* width hint */
+  width={/* px */ 100}
+/>;

--- a/test/markup/javascript/jsx-fragment.expect.txt
+++ b/test/markup/javascript/jsx-fragment.expect.txt
@@ -1,10 +1,10 @@
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Columns</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_ inherited__">React.Component</span> {
   <span class="hljs-title function_">render</span>(<span class="hljs-params"></span>) {
     <span class="hljs-keyword">return</span> (
-      <span class="language-xml"><span class="hljs-tag">&lt;&gt;</span>
+      <span class="hljs-tag">&lt;&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-name">td</span>&gt;</span>Hello<span class="hljs-tag">&lt;/<span class="hljs-name">td</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-name">td</span>&gt;</span>World<span class="hljs-tag">&lt;/<span class="hljs-name">td</span>&gt;</span>
-      <span class="hljs-tag">&lt;/&gt;</span></span>
+      <span class="hljs-tag">&lt;/&gt;</span>
     );
   }
 }

--- a/test/markup/javascript/jsx.expect.txt
+++ b/test/markup/javascript/jsx.expect.txt
@@ -1,25 +1,25 @@
-<span class="hljs-keyword">var</span> jsx = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">node</span>/&gt;</span></span>;
-<span class="hljs-keyword">var</span> jsx = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">node</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">child</span>/&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span></span>;
-<span class="hljs-keyword">var</span> jsx = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">node</span>&gt;</span>...<span class="hljs-tag">&lt;<span class="hljs-name">child</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">child</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span></span>;
-<span class="hljs-keyword">var</span> jsx = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">span</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">br</span> /&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">span</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></span>;
-<span class="hljs-keyword">var</span> jsx = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">pre-node</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">child</span> /&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">pre-node</span>&gt;</span></span>;
+<span class="hljs-keyword">var</span> jsx = <span class="hljs-tag">&lt;<span class="hljs-name">node</span>/&gt;</span>;
+<span class="hljs-keyword">var</span> jsx = <span class="hljs-tag">&lt;<span class="hljs-name">node</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">child</span>/&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span>;
+<span class="hljs-keyword">var</span> jsx = <span class="hljs-tag">&lt;<span class="hljs-name">node</span>&gt;</span>...<span class="hljs-tag">&lt;<span class="hljs-name">child</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">child</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span>;
+<span class="hljs-keyword">var</span> jsx = <span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">span</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">br</span> /&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">span</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>;
+<span class="hljs-keyword">var</span> jsx = <span class="hljs-tag">&lt;<span class="hljs-name">pre-node</span>&gt;</span><span class="hljs-tag">&lt;<span class="hljs-name">child</span> /&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">pre-node</span>&gt;</span>;
 
 <span class="hljs-keyword">var</span> x = <span class="hljs-number">5</span>;
 
-<span class="hljs-keyword">return</span> (<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">node</span> <span class="hljs-attr">attr</span>=<span class="hljs-string">&quot;value&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span></span>);
+<span class="hljs-keyword">return</span> (<span class="hljs-tag">&lt;<span class="hljs-name">node</span> <span class="hljs-attr">attr</span>=<span class="hljs-string">&quot;value&quot;</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">node</span>&gt;</span>);
 
-<span class="hljs-keyword">const</span> <span class="hljs-title function_">n</span> = (<span class="hljs-params"></span>) =&gt; <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">X</span> /&gt;</span></span>
-<span class="hljs-keyword">const</span> <span class="hljs-title function_">m</span> = (<span class="hljs-params"></span>) =&gt; <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">X</span> <span class="hljs-attr">x</span>=<span class="hljs-string">&quot;&quot;</span> /&gt;</span></span>
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">n</span> = (<span class="hljs-params"></span>) =&gt; <span class="hljs-tag">&lt;<span class="hljs-name">X</span> /&gt;</span>
+<span class="hljs-keyword">const</span> <span class="hljs-title function_">m</span> = (<span class="hljs-params"></span>) =&gt; <span class="hljs-tag">&lt;<span class="hljs-name">X</span> <span class="hljs-attr">x</span>=<span class="hljs-string">&quot;&quot;</span> /&gt;</span>
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">App</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_ inherited__">Component</span> {
   <span class="hljs-title function_">render</span>(<span class="hljs-params"></span>) {
     <span class="hljs-keyword">return</span> (
-      <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">BrowserRouter</span>&gt;</span>
+      <span class="hljs-tag">&lt;<span class="hljs-name">BrowserRouter</span>&gt;</span>
         <span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
-          <span class="hljs-tag">&lt;<span class="hljs-name">Route</span> <span class="hljs-attr">path</span>=<span class="hljs-string">&quot;/about&quot;</span> <span class="hljs-attr">component</span>=<span class="hljs-string">{About}</span> /&gt;</span>
-          <span class="hljs-tag">&lt;<span class="hljs-name">Route</span> <span class="hljs-attr">path</span>=<span class="hljs-string">&quot;/contact&quot;</span> <span class="hljs-attr">component</span>=<span class="hljs-string">{Contact}</span> /&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-name">Route</span> <span class="hljs-attr">path</span>=<span class="hljs-string">&quot;/about&quot;</span> <span class="hljs-attr">component</span>={<span class="hljs-title class_">About</span>} /&gt;</span>
+          <span class="hljs-tag">&lt;<span class="hljs-name">Route</span> <span class="hljs-attr">path</span>=<span class="hljs-string">&quot;/contact&quot;</span> <span class="hljs-attr">component</span>={<span class="hljs-title class_">Contact</span>} /&gt;</span>
         <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
-      <span class="hljs-tag">&lt;/<span class="hljs-name">BrowserRouter</span>&gt;</span></span>
+      <span class="hljs-tag">&lt;/<span class="hljs-name">BrowserRouter</span>&gt;</span>
     );
   }
 }

--- a/test/markup/typescript/jsx-comments.expect.txt
+++ b/test/markup/typescript/jsx-comments.expect.txt
@@ -1,0 +1,50 @@
+<span class="hljs-comment">// attribute values: {/* */} is a JS comment expression</span>
+<span class="hljs-keyword">return</span> (
+  <span class="hljs-tag">&lt;<span class="hljs-name">ClassicBasic</span>
+    <span class="hljs-attr">value</span>={<span class="hljs-comment">/* ... */</span>}
+    onChange={<span class="hljs-comment">/* ... */</span>}
+    editorState={<span class="hljs-variable language_">this</span>.<span class="hljs-property">state</span>.<span class="hljs-property">editorState</span>}
+    onStateChange={<span class="hljs-function"><span class="hljs-params">editorState</span> =&gt;</span> <span class="hljs-variable language_">this</span>.<span class="hljs-title function_">setState</span>({ editorState })}
+  /&gt;</span>
+);
+
+<span class="hljs-comment">// line and block comments between attributes (inside the opening tag)</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">button</span>
+  <span class="hljs-comment">// prevent editor losing focus</span>
+  <span class="hljs-attr">onMouseDown</span>={<span class="hljs-function"><span class="hljs-params">e</span> =&gt;</span> e.<span class="hljs-title function_">preventDefault</span>()}
+  /* also a block comment between attrs */
+  onClick={<span class="hljs-function">() =&gt;</span> {
+    <span class="hljs-variable language_">this</span>.<span class="hljs-title function_">setState</span>(<span class="hljs-function"><span class="hljs-params">s</span> =&gt;</span> <span class="hljs-title function_">update</span>(s, <span class="hljs-string">&#x27;editorState.bold.value&#x27;</span>, <span class="hljs-function"><span class="hljs-params">value</span> =&gt;</span> !value));
+  }}
+&gt;</span>
+  Toggle bold
+<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>;
+
+<span class="hljs-comment">// multi-line block comment between attributes</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">Comp</span>
+  <span class="hljs-comment">/* multi
+     line */</span>
+  <span class="hljs-attr">foo</span>={<span class="hljs-number">1</span>}
+  bar={<span class="hljs-string">&quot;ok&quot;</span>}
+/&gt;</span>;
+
+<span class="hljs-comment">// {/* */} as a child expression (not text)</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
+  {<span class="hljs-comment">/* block comment in children */</span>}
+  <span class="hljs-tag">&lt;<span class="hljs-name">span</span> /&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>;
+
+<span class="hljs-comment">// children text that looks like // is NOT a comment</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>
+  // this is text content
+  <span class="hljs-tag">&lt;<span class="hljs-name">X</span> /&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>;
+
+<span class="hljs-comment">// self-closing with mixed attrs and comments</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">img</span>
+  <span class="hljs-attr">src</span>={url}
+  // lazy load
+  loading=<span class="hljs-string">&quot;lazy&quot;</span>
+  <span class="hljs-comment">/* width hint */</span>
+  <span class="hljs-attr">width</span>={<span class="hljs-comment">/* px */</span> <span class="hljs-number">100</span>}
+/&gt;</span>;

--- a/test/markup/typescript/jsx-comments.txt
+++ b/test/markup/typescript/jsx-comments.txt
@@ -1,0 +1,50 @@
+// attribute values: {/* */} is a JS comment expression
+return (
+  <ClassicBasic
+    value={/* ... */}
+    onChange={/* ... */}
+    editorState={this.state.editorState}
+    onStateChange={editorState => this.setState({ editorState })}
+  />
+);
+
+// line and block comments between attributes (inside the opening tag)
+<button
+  // prevent editor losing focus
+  onMouseDown={e => e.preventDefault()}
+  /* also a block comment between attrs */
+  onClick={() => {
+    this.setState(s => update(s, 'editorState.bold.value', value => !value));
+  }}
+>
+  Toggle bold
+</button>;
+
+// multi-line block comment between attributes
+<Comp
+  /* multi
+     line */
+  foo={1}
+  bar={"ok"}
+/>;
+
+// {/* */} as a child expression (not text)
+<div>
+  {/* block comment in children */}
+  <span />
+</div>;
+
+// children text that looks like // is NOT a comment
+<div>
+  // this is text content
+  <X />
+</div>;
+
+// self-closing with mixed attrs and comments
+<img
+  src={url}
+  // lazy load
+  loading="lazy"
+  /* width hint */
+  width={/* px */ 100}
+/>;

--- a/test/markup/typescript/jsx.expect.txt
+++ b/test/markup/typescript/jsx.expect.txt
@@ -3,7 +3,7 @@
         <span class="hljs-keyword">let</span> a : <span class="hljs-title class_">Array</span>&lt;<span class="hljs-title class_">Array</span>&lt;<span class="hljs-built_in">number</span>&gt;&gt; = [[<span class="hljs-number">1</span>,<span class="hljs-number">2</span>]];
         <span class="hljs-keyword">let</span> b = <span class="hljs-keyword">new</span> <span class="hljs-title class_">Map</span>&lt;<span class="hljs-built_in">string</span>,<span class="hljs-built_in">number</span>&gt;();
         <span class="hljs-keyword">return</span> (
-            <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> /&gt;</span></span>
+            <span class="hljs-tag">&lt;<span class="hljs-name">div</span> /&gt;</span>
         );
     }
 }


### PR DESCRIPTION
## Summary

Native JSX in JavaScript/TypeScript (no XML sublanguage), so attribute-position and expression comments highlight correctly.

**Fixes #1625**

**Fixes #2324** (nested JSX inside `{…}` expressions)

### Why not XML?

JSX is not HTML/XML:

- `//` and `/* */` are legal **between attributes** inside an opening tag
- Attribute values are often `{jsExpr}`, not only strings
- `{/* comment */}` is a JS expression (attrs and children)
- Nested JSX lives inside those expressions (`onClick={() => <Foo />}`)

`subLanguage: 'xml'` cannot own any of that. Earlier ideas (depth counters, skip-balanced nested tags + XML) paper over the wrong model. This PR builds JSX into the JS grammar instead.

### Design

All of this lives in `src/languages/javascript.js` (TypeScript inherits it).

#### 1. Element shape (not depth counting)

```
<OpenTag attrs>     → mode class "tag", then starts children
  children…         → expressions + nested JSX_ELEMENT + close
</CloseTag>         → endsParent finishes children mode
```

Self-closing is a **separate variant** (`end: /\/>/`, no `starts`). Nested elements are full `JSX_ELEMENT` children, not bare open/close rules in the parent—so `</child>` cannot tear down `<parent>`.

Fragments: `<>…</>` with the same children/`endsParent` pattern.

#### 2. Tag internals

Inside an open tag (after the name):

- `COMMENT` (`//`, `/* */`, JSDoc variant via existing `COMMENT`)
- `attr` names
- `=` values: quoted strings **or** `JSX_EXPRESSION` (`{…}`)

#### 3. Expressions

`JSX_EXPRESSION` is a JS subset (comments, strings, templates, numbers, arrows/params, property access, calls, class refs, nested `{` via `"self"`, and nested `JSX_ELEMENT`). Enough for typical attribute/children expressions without re-running the entire language.

#### 4. JSX vs TypeScript generics

`isTrulyOpeningTag` (same spirit as before) ignores:

- `<Array<…`, `<T, U>`
- `<T = …`
- `<From extends …` (#3276)
- bare `<Something>` with no matching close later (`hasClosingTag`)

#### 5. Self-closing vs paired (important)

A naïve `[^>]*` / “first `>` wins” check breaks on arrows in attrs:

```jsx
<X onC={e => e} />
```

The `>` in `=>` is not the tag end. **`scanJsxTagEnd`** walks from `<` and skips strings, `{…}` depth, and line/block comments, then decides `>` vs `/>`. `on:begin` uses that so the self-closing and paired variants don’t steal each other.

If the wrong variant wins, paired mode can `starts` children after a false `>` and swallow the rest of the buffer (comments stop highlighting, etc.). The scanner is load-bearing.

### Markup / CSS impact

- JSX is no longer wrapped in `language-xml`
- Tokens still use familiar scopes: `tag`, `name`, `attr`, `string`, `comment`, plus normal JS scopes inside `{…}`
- Themes that only styled JSX via `.language-xml …` may need a glance; most theme `tag`/`attr` rules apply either way
- Updated expects: `jsx`, `jsx-fragment`, `arrow-function`, plus new `jsx-comments` (JS + TS)

### Tests

| File | Intent |
|------|--------|
| `test/markup/javascript/jsx-comments.*` | #1625 cases: attr `{/* */}`, `//`/`/* */` between attrs, multi-line block comments, child `{/* */}`, `//` as **text** not comment, mixed self-closing |
| `test/markup/typescript/jsx-comments.*` | Same under `typescript` |
| Existing `jsx` / `jsx-fragment` / `arrow-function` | Refreshed for native markup |

### Known limits / follow-ups

- Close tags are not name-checked against the opener (`</wrong>` can still end children). Nested same-name tags are OK because each element has its own children mode.
- Expression highlighting is a **subset** of full JS (by design).
- JSX still only enters from the existing “value” container (`return` / `RE_STARTERS_RE`, etc.), same as before.
- `html\`…\`` templates still use `subLanguage: 'xml'` (real markup, not JSX).
- No `hljs-unset` / reset class for expressions inside tags (raised in #1625); expressions use normal JS token colors inside the tag scope—theme-dependent.

### Intentionally not done

- No XML sublanguage “fix” for JSX comments
- No global JSX depth counter
- No separate `jsx` language id (still `javascript` / `typescript` aliases `jsx` / `tsx`)

## Test plan

- [x] `npm run build`
- [x] `ONLY_LANGUAGES="javascript typescript" npx mocha test/markup` — 39 passing
- [ ] Spot-check a dark + light theme on sample from #1625 (attrs + `//` + `{/* */}`)
- [x] Confirm TS generics fixtures still look right (`jsx.txt` non-JSX sections)

