### PR TITLE
fix(markdown) don't treat a thematic break as the start of bold text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Core Grammars:
 - fix(gherkin) variables can't contain whitespace [Hirse][]
 - enh(gherkin) docstrings can use backticks [Hirse][]
 - fix(dart) add highlighting for class and function names [guuido][]
+- fix(markdown) don't treat a `***` or `___` thematic break as the start of bold text, issue #3719 [Mayank Gupta][]
 
 Documentation:
 
@@ -46,6 +47,7 @@ CONTRIBUTORS
 [Jayesh Bhade]: https://github.com/Jaybhade
 [Hirse]: https://github.com/Hirse
 [guuido]: https://github.com/guuido
+[Mayank Gupta]: https://github.com/Mynk11
 
 
 ## Version 11.11.3

--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -14,10 +14,10 @@ export default function(hljs) {
     subLanguage: 'xml',
     relevance: 0
   };
-  const HORIZONTAL_RULE = {
-    begin: '^[-\\*]{3,}',
-    end: '$'
-  };
+  // https://spec.commonmark.org/0.31.2/#thematic-breaks
+  // three or more `-`, `*` or `_`, all the same character, optionally
+  // separated and followed by spaces or tabs, and nothing else on the line
+  const HORIZONTAL_RULE = { match: /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/ };
   const CODE = {
     className: 'code',
     variants: [
@@ -233,11 +233,13 @@ export default function(hljs) {
       HEADER,
       INLINE_HTML,
       LIST,
+      // must come before BOLD/ITALIC so that a `***` or `___` thematic break
+      // isn't mistaken for the start of bold text
+      HORIZONTAL_RULE,
       BOLD,
       ITALIC,
       BLOCKQUOTE,
       CODE,
-      HORIZONTAL_RULE,
       LINK,
       LINK_REFERENCE,
       ENTITY

--- a/test/markup/markdown/horizontal_rule.expect.txt
+++ b/test/markup/markdown/horizontal_rule.expect.txt
@@ -1,0 +1,21 @@
+Text before the break.
+
+***
+
+Text between breaks.
+
+___
+
+Text between breaks.
+
+  ***
+
+Indented up to three spaces is still a break.
+
+<span class="hljs-strong">**<span class="hljs-emphasis">*This is still bold and italic*</span>**</span>
+
+<span class="hljs-strong">**This is still bold**</span>
+
+<span class="hljs-emphasis">*This is still italic*</span>
+
+Text after the break.

--- a/test/markup/markdown/horizontal_rule.txt
+++ b/test/markup/markdown/horizontal_rule.txt
@@ -1,0 +1,21 @@
+Text before the break.
+
+***
+
+Text between breaks.
+
+___
+
+Text between breaks.
+
+  ***
+
+Indented up to three spaces is still a break.
+
+***This is still bold and italic***
+
+**This is still bold**
+
+*This is still italic*
+
+Text after the break.


### PR DESCRIPTION
Fixes #3719. Picks up where #3909 left off, addressing @joshgoebel's review comments there.

`***` on its own line is a thematic break, but `BOLD` was tried before `HORIZONTAL_RULE` in the top-level `contains`, so it matched `**` and opened a `strong` span that swallowed the rest of the document.

Simply reordering was what stalled the previous attempt, because the old matcher (`^[-\*]{3,}` … `$`) was loose enough to also eat the opening `***` of `***bold italic***`. So this does both: anchors the rule to a full line, then moves it ahead of `BOLD`/`ITALIC`.

```js
const HORIZONTAL_RULE = { match: /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/ };
```

Per [spec 0.31.2](https://spec.commonmark.org/0.31.2/#thematic-breaks): up to three leading spaces, then the same marker three or more times, separated and followed by spaces or tabs, and nothing else on the line.

On the earlier review comments:

- **`_` style rule** — covered; the marker is a capture group with a backreference, so `___` works and mixed runs like `-*-` correctly don't.
- **`\s*$`** — deliberately not used: `\s` matches `\n`, which would let a break swallow following blank lines. `[ \t]*` matches the spec's wording.
- **escaping `*` inside `[]`** — not needed, dropped.

Behaviour is unchanged for `***bold italic***`, `**bold**`, `*italic*`, setext headings (`Heading` / `---`), and list bullets — all covered by the existing `bold_italics` and `list` tests, which still pass.

Out of scope, flagging it so it isn't a surprise: `- - -` still highlights as a bullet because `LIST` precedes `HORIZONTAL_RULE`. The spec says a thematic break wins there, but that's a separate precedence question and I'd rather not fold it into this fix. Happy to follow up.

`npx mocha test` → 1611 passing, 3 pending (was 1610 before the new test). Lint on `src/languages/markdown.js` is unchanged from `main` (one pre-existing `spaced-comment` error on the `ENTITY` comment, untouched here).

### Checklist

- [x] Added markup tests (`test/markup/markdown/horizontal_rule.{txt,expect.txt}`)
- [x] Updated `CHANGES.md`
