### PR TITLE
fix(python): stop unterminated single-line strings at EOL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@ Core Grammars:
 - enh(python) add missing builtins: `aiter` and `anext` (3.10), `frozendict` and `sentinel` (3.15) [Hugo van Kemenade][]
 - enh(python) correctly highlight `lazy import` syntax from PEP 810 [Peter Bierma][]
 - enh(python) support t-strings [Nicolas Le Cam][]
+- fix(python) don't let unterminated single-line strings swallow the next line, issue #4331 [Xusnitdinov Azizbek][]
 - fix(ruby) don't treat the scope resolution operator `::` as a symbol, issue #4294 [Hashim Khan][]
 - enh(rust) add `safe` keyword [Frances Wingerter][]
 - enh(rust) include the `raw` borrow operator in keywords [Shiva Kiran Koninty][]
@@ -105,6 +106,7 @@ CONTRIBUTORS
 [patricksalo]: https://github.com/patricksalo
 [Styx0x6]: https://github.com/styx0x6
 [Mark Xian]: https://github.com/xianjianlf2
+[Xusnitdinov Azizbek]: https://github.com/xusnitdinov
 [Jayesh Bhade]: https://github.com/Jaybhade
 [Pablo]: https://github.com/MsfPablo
 [David Pavlovschii]: https://github.com/davidpavlovschi

--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -218,27 +218,29 @@ export default function(hljs) {
           SUBST
         ]
       },
+      // `$` is EOL (grammars compile with the `m` flag). Python single-line
+      // strings cannot span lines, so recover at EOL instead of leaking.
       {
         begin: /([uU]|[rR])'/,
-        end: /'/,
+        end: /'|$/,
         relevance: 10
       },
       {
         begin: /([uU]|[rR])"/,
-        end: /"/,
+        end: /"|$/,
         relevance: 10
       },
       {
         begin: /([bB]|[bB][rR]|[rR][bB])'/,
-        end: /'/
+        end: /'|$/
       },
       {
         begin: /([bB]|[bB][rR]|[rR][bB])"/,
-        end: /"/
+        end: /"|$/
       },
       {
         begin: /([fFtT][rR]|[rR][fFtT]|[fFtT])'/,
-        end: /'/,
+        end: /'|$/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
           LITERAL_BRACKET,
@@ -247,15 +249,15 @@ export default function(hljs) {
       },
       {
         begin: /([fFtT][rR]|[rR][fFtT]|[fFtT])"/,
-        end: /"/,
+        end: /"|$/,
         contains: [
           hljs.BACKSLASH_ESCAPE,
           LITERAL_BRACKET,
           SUBST
         ]
       },
-      hljs.APOS_STRING_MODE,
-      hljs.QUOTE_STRING_MODE
+      hljs.inherit(hljs.APOS_STRING_MODE, { end: /'|$/ }),
+      hljs.inherit(hljs.QUOTE_STRING_MODE, { end: /"|$/ })
     ]
   };
 

--- a/test/markup/python/f-strings.expect.txt
+++ b/test/markup/python/f-strings.expect.txt
@@ -22,10 +22,10 @@
 <span class="hljs-keyword">or</span> <span class="hljs-string">rb&quot;https://&quot;</span>
 test()<span class="hljs-keyword">or</span><span class="hljs-string">&quot;&quot;</span>
 
-<span class="hljs-string">&quot;my ...
-... name&quot;</span>
-<span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">&quot;my ...
-... name&quot;</span>
+<span class="hljs-string">&quot;my ...</span>
+<span class="hljs-meta">... </span>name<span class="hljs-string">&quot;</span>
+<span class="hljs-meta">&gt;&gt;&gt; </span><span class="hljs-string">&quot;my ...</span>
+<span class="hljs-meta">... </span>name<span class="hljs-string">&quot;</span>
 
 <span class="hljs-built_in">print</span>(<span class="hljs-string">&quot;kkds&quot;</span>+<span class="hljs-string">&quot;kdjsa&quot;</span>)
 <span class="hljs-built_in">print</span>(<span class="hljs-string">&quot;kkds&quot;</span>+<span class="hljs-string">b&quot;kdjsa&quot;</span>)

--- a/test/markup/python/unterminated-string.expect.txt
+++ b/test/markup/python/unterminated-string.expect.txt
@@ -1,0 +1,20 @@
+<span class="hljs-comment"># 1. valid string</span>
+a = <span class="hljs-string">&#x27;abc&#x27;</span>
+<span class="hljs-built_in">print</span>(a)
+
+<span class="hljs-comment"># 2. invalid string should not paint the next line</span>
+b = <span class="hljs-string">&#x27;abc</span>
+<span class="hljs-built_in">print</span>(b)
+
+<span class="hljs-comment"># 3. prefixed variants should recover too</span>
+c = <span class="hljs-string">r&#x27;abc</span>
+<span class="hljs-built_in">print</span>(c)
+d = <span class="hljs-string">b&quot;abc</span>
+<span class="hljs-built_in">print</span>(d)
+e = <span class="hljs-string">f&#x27;abc</span>
+<span class="hljs-built_in">print</span>(e)
+
+<span class="hljs-comment"># 4. triple quotes may still span lines</span>
+f = <span class="hljs-string">&#x27;&#x27;&#x27;abc
+def&#x27;&#x27;&#x27;</span>
+<span class="hljs-built_in">print</span>(f)

--- a/test/markup/python/unterminated-string.txt
+++ b/test/markup/python/unterminated-string.txt
@@ -1,0 +1,20 @@
+# 1. valid string
+a = 'abc'
+print(a)
+
+# 2. invalid string should not paint the next line
+b = 'abc
+print(b)
+
+# 3. prefixed variants should recover too
+c = r'abc
+print(c)
+d = b"abc
+print(d)
+e = f'abc
+print(e)
+
+# 4. triple quotes may still span lines
+f = '''abc
+def'''
+print(f)


### PR DESCRIPTION
Fixes #4331

### Changes
Python single-quoted / double-quoted strings cannot span physical lines. The grammar already put `illegal: '\\n'` on `APOS_STRING_MODE`, but `highlight()` / `highlightAll()` default to `ignoreIllegals: true`, so that newline was swallowed and the next line stayed a string:

```python
b = 'abc
print(b)   # was highlighted as a string
```

End every non-triple-quoted string variant at `'|$` / `"|$` instead (`$` is EOL because grammars compile with the `m` flag). Triple-quoted strings are unchanged.

Also updates the `f-strings` markup fixture that assumed `"my ...\\n... name"` should stay one string.

### Checklist
- [x] Added markup tests
- [x] I have read and followed our [AI-assisted contributions](https://github.com/highlightjs/highlight.js/blob/main/docs/ai-contributions.md) policy (human review, no slop)

Assisted-by: Cursor Grok 4.5

Made with [Cursor](https://cursor.com)