### PR TITLE
fix(ini) don't highlight the trailing digit of a dotted bare value as a number, issue #4038

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Core Grammars:
 - enh(go) recognize binary integer literals [spokodev][]
 - enh(groovy) support underscores in numeric literals [greymoth][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
+- fix(ini) do not highlight the trailing digit of a dotted bare value (e.g. the `2` in `TLSv1.2`) as a number, issue #4038 [youdie006][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
 - enh(kotlin) add `ktm` and `ktx` aliases [DarkMatter-999][]
@@ -148,6 +149,7 @@ CONTRIBUTORS
 [allejo]: https://github.com/allejo
 [KJyang-0114]: https://github.com/KJyang-0114
 [webdiscus]: https://github.com/webdiscus
+[youdie006]: https://github.com/youdie006
 
 
 ## Version 11.11.2

--- a/src/languages/ini.js
+++ b/src/languages/ini.js
@@ -13,7 +13,9 @@ export default function(hljs) {
     relevance: 0,
     variants: [
       { begin: /([+-]+)?[\d]+_[\d_]+/ },
-      { begin: hljs.NUMBER_RE }
+      // A word or `.` before the number means it is part of a larger bare
+      // value (e.g. the `2` in `TLSv1.2`), not a real number. See issue #4038.
+      { begin: regex.concat(/(?<![\w.])/, hljs.NUMBER_RE) }
     ]
   };
   const COMMENTS = hljs.COMMENT();

--- a/test/markup/ini/types.expect.txt
+++ b/test/markup/ini/types.expect.txt
@@ -18,3 +18,4 @@ lines&#x27;&#x27;&#x27;</span>
 <span class="hljs-attr">dotted.key</span> = <span class="hljs-number">1</span>
 <span class="hljs-attr">array</span> = [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]
 <span class="hljs-attr">inline</span> = {name = <span class="hljs-string">&quot;foo&quot;</span>, id = <span class="hljs-number">123</span>}
+<span class="hljs-attr">unquoted</span> = TLSv1.2

--- a/test/markup/ini/types.txt
+++ b/test/markup/ini/types.txt
@@ -18,3 +18,4 @@ b = no
 dotted.key = 1
 array = [1, 2, 3]
 inline = {name = "foo", id = 123}
+unquoted = TLSv1.2


### PR DESCRIPTION
Fixes #4038.

## Problem

In the `ini`/TOML grammar, an unquoted bare value with an embedded period such as `TLSv1.2` is mis-highlighted: the trailing `2` is wrapped in an `hljs-number` span while the rest of the token stays plain.

As @joshgoebel diagnosed in the issue (2026-08-09), this is not "unquoted strings are broken" but a false-positive number matching inside a bare token. `NUMBER_RE` is `\b\d+(\.\d+)?`, and in `TLSv1.2` there is a word boundary between `.` and `2`, so the lone `2` is tagged as a number. The suggested fix was a targeted negative lookbehind/lookahead around the number token, plus a markup fixture for the TLS-style case.

## Fix

In `src/languages/ini.js`, the shared `NUMBERS` mode's `NUMBER_RE` variant now carries a negative lookbehind so a number cannot begin immediately after a word character or a dot:

```js
{ begin: regex.concat(/(?<![\w.])/, hljs.NUMBER_RE) }
```

This is the smallest change that fixes `TLSv1.2` while leaving real TOML numbers untouched. Lookbehind is already used in shipped grammars (haskell, r, gcode, scala), so it is safe for supported runtimes.

Highlighting *all* unquoted values as strings (Prism-style) is intentionally out of scope, as noted in the issue -- that's a separate product choice for TOML/INI.

## Tests

Added a markup fixture line `unquoted = TLSv1.2` to `test/markup/ini/types.txt` and the matching expected HTML (an `attr` span for `unquoted`, no number span around `2`) to `test/markup/ini/types.expect.txt`.

Red/green (`node:22`, `npm run build && npm run test-markup`):

- Before the fix the new fixture fails -- output is `... = TLSv1.<span class="hljs-number">2</span>`.
- After the fix it passes (589 markup tests green); full `npm test` is 1631 passing, 0 failing. Existing numbers (`1_234`, `1.23`, `7e+12`, `2e3`, `-1.234e-12`, arrays `[1, 2, 3]`) still tokenize as numbers.

---

AI-assisted: this change was drafted with an AI coding assistant; I reviewed it and ran the build + full test suite locally before opening this PR.

Assisted-by: Claude Opus 4.8 (high)