### PR TITLE
(docs) Add Kusto Query Language (KQL) to supported languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -131,6 +131,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Julia                   | julia, jl               |         |
 | Julia REPL              | julia-repl             |         |
 | Kotlin                  | kotlin, kt, kts, ktm, ktx |         |
+| Kusto Query Language    | kql, kusto             | [hljs-kql](https://github.com/ivanduplenskikh/hljs-kql) |
 | L4                      | l4, legal              | [highlightjs-l4](https://github.com/legalese/highlightjs-l4)
 | Lang                    |                        | [highlightjs-lang](https://github.com/highlightjs/highlightjs-lang)
 | Lasso                   | lasso, ls, lassoscript |         |

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -131,7 +131,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | Julia                   | julia, jl               |         |
 | Julia REPL              | julia-repl             |         |
 | Kotlin                  | kotlin, kt, kts, ktm, ktx |         |
-| Kusto Query Language    | kql, kusto             | [hljs-kql](https://github.com/ivanduplenskikh/hljs-kql) |
+| Kusto Query Language    | kql, kusto             | [highlightjs-kql](https://github.com/ivanduplenskikh/highlightjs-kql) |
 | L4                      | l4, legal              | [highlightjs-l4](https://github.com/legalese/highlightjs-l4)
 | Lang                    |                        | [highlightjs-lang](https://github.com/highlightjs/highlightjs-lang)
 | Lasso                   | lasso, ls, lassoscript |         |


### PR DESCRIPTION
Adding Kusto Query Language to supported languages

### Changes
Adds Kusto Query Language to SUPPORTED_LANGUAGES.md, including the **kql** and **kusto** aliases and a link to the third-party grammar package: https://github.com/ivanduplenskikh/hljs-kql

### Checklist
- [x] Added markup tests, or they don't apply here because - this is a documentation-only catalog change.
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
