### PR TITLE
fix(typescript): do not treat <string[]> assertions as HTML tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ Core Grammars:
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
+- fix(typescript) do not treat type assertions like `<string[]>` as HTML tags, issue #4301 [Arron Zou][]
 - enh(kotlin) add `ktm` and `ktx` aliases [DarkMatter-999][]
 - fix(leaf) fix bug in Leaf keyword highlighting [Francesco Paolo Severino][]
 - fix(lisp) preserve highlighting after quoted multiplication expressions [arturict][]
@@ -148,6 +149,7 @@ CONTRIBUTORS
 [allejo]: https://github.com/allejo
 [KJyang-0114]: https://github.com/KJyang-0114
 [webdiscus]: https://github.com/webdiscus
+[Arron Zou]: https://github.com/arronKler
 
 
 ## Version 11.11.2

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -47,7 +47,10 @@ export default function(hljs) {
         nextChar === "<" ||
         // the , gives away that this is not HTML
         // `<T, A extends keyof T, V>`
-        nextChar === ","
+        nextChar === "," ||
+        // the [ gives away that this is a type assertion, not HTML
+        // `<string[]>`
+        nextChar === "["
         ) {
         response.ignoreMatch();
         return;

--- a/test/markup/typescript/type-assertion-array.expect.txt
+++ b/test/markup/typescript/type-assertion-array.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-keyword">const</span> myVar = &lt;<span class="hljs-built_in">string</span>[]&gt;<span class="hljs-variable language_">this</span>.<span class="hljs-property">service</span>.<span class="hljs-title function_">invoke</span>();
+<span class="hljs-keyword">const</span> nums = &lt;<span class="hljs-built_in">number</span>[]&gt;<span class="hljs-title function_">getValues</span>();
+<span class="hljs-keyword">const</span> items = &lt;<span class="hljs-title class_">Item</span>[]&gt;list;
+<span class="hljs-keyword">const</span> nested = &lt;<span class="hljs-built_in">string</span>[][]&gt;matrix;

--- a/test/markup/typescript/type-assertion-array.txt
+++ b/test/markup/typescript/type-assertion-array.txt
@@ -1,0 +1,4 @@
+const myVar = <string[]>this.service.invoke();
+const nums = <number[]>getValues();
+const items = <Item[]>list;
+const nested = <string[][]>matrix;


### PR DESCRIPTION
`<string[]>` (and other angle-bracket array type assertions) were treated as JSX/XML tags, so highlighting stopped at the `[]`. `[` cannot follow an HTML tag name, so `isTrulyOpeningTag` now ignores that case the same way it already ignores nested generics (`<`) and type parameters (`,`).

Fixes #4301

### Changes
- Ignore `<Type[]>` in the shared JS/TS JSX tag check
- Add a TypeScript markup fixture for the reported case

### Checklist
- [x] Added markup tests
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
