### PR TITLE
fix(php-template): a quote in a line comment should not break highlighting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ New Grammars:
 
 Core Grammars:
 
+- fix(php-template) do not let a quote in a line comment or an escaped quote in a string swallow the rest of the template, issue #4152 [arronKler][]
 - fix(c) only match real `atomic_*` type names, not C11 atomic functions, issue #3837 [Mark Xian][]
 - fix(c, cpp) bound the run of type tokens in front of a function name (ReDoS), issue #4362 [Jayesh Bhade][]
 - fix(c, cpp) scope angle-bracket header string to `#include`, issue #3505 [Pablo][]
@@ -89,6 +90,7 @@ Build / Tooling:
 
 CONTRIBUTORS
 
+[arronKler]: https://github.com/arronKler
 [spokodev]: https://github.com/spokodev
 [gg582]: https://github.com/gg582
 [Dhruv Maniya]: https://github.com/iamdhrv

--- a/src/languages/php-template.js
+++ b/src/languages/php-template.js
@@ -26,6 +26,19 @@ export default function(hljs) {
             end: '\\*/',
             skip: true
           },
+          // Quotes in // or # comments must not start a skip-string.
+          // Stop before ?> so `// note ?>` still closes the PHP block.
+          // `#(?!\[)` leaves PHP 8 attributes (`#[...]`) to the PHP grammar.
+          {
+            begin: /\/\//,
+            end: /$|(?=\?>)/,
+            skip: true
+          },
+          {
+            begin: /#(?!\[)/,
+            end: /$|(?=\?>)/,
+            skip: true
+          },
           {
             begin: 'b"',
             end: '"',
@@ -39,13 +52,13 @@ export default function(hljs) {
           hljs.inherit(hljs.APOS_STRING_MODE, {
             illegal: null,
             className: null,
-            contains: null,
+            contains: [ { begin: /\\./, skip: true } ],
             skip: true
           }),
           hljs.inherit(hljs.QUOTE_STRING_MODE, {
             illegal: null,
             className: null,
-            contains: null,
+            contains: [ { begin: /\\./, skip: true } ],
             skip: true
           })
         ]

--- a/test/markup/php-template/apostrophe.expect.txt
+++ b/test/markup/php-template/apostrophe.expect.txt
@@ -1,0 +1,12 @@
+<span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">html</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">body</span>&gt;</span>
+</span><span class="language-php"><span class="hljs-meta">&lt;?php</span>
+<span class="hljs-comment">// This won&#x27;t be highlighted unless there is another</span>
+<span class="hljs-comment">// single apostrophe later.</span>
+<span class="hljs-keyword">echo</span> <span class="hljs-string">&#x27;it\&#x27;s fine&#x27;</span>;
+<span class="hljs-meta">?&gt;</span></span><span class="language-xml">
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>Some HTML </span><span class="language-php"><span class="hljs-meta">&lt;?=</span> <span class="hljs-string">&#x27;\code&#x27;</span> <span class="hljs-meta">?&gt;</span></span><span class="language-xml"><span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">span</span>&gt;</span></span><span class="language-php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-variable">$name</span>; <span class="hljs-comment">// don&#x27;t ?&gt;</span></span><span class="language-xml"><span class="hljs-tag">&lt;/<span class="hljs-name">span</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">body</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">html</span>&gt;</span>
+</span>

--- a/test/markup/php-template/apostrophe.txt
+++ b/test/markup/php-template/apostrophe.txt
@@ -1,0 +1,11 @@
+<html>
+<body>
+<?php
+// This won't be highlighted unless there is another
+// single apostrophe later.
+echo 'it\'s fine';
+?>
+<p>Some HTML <?= '\code' ?></p>
+<span><?php echo $name; // don't ?></span>
+</body>
+</html>


### PR DESCRIPTION
### Changes
php-template finds `?>` by skipping strings and block comments. A `'` inside `//` or `#` started a skip-string and swallowed the closer, so later HTML/PHP was not highlighted.

This keeps `skip` on strings (so `?>` inside a string stays in PHP). It also skips `//` and `#` line comments, stopping before `?>` so `// note ?>` still closes the block, and it does not treat `#[` as a hash comment. Escaped quotes use a skipped `\.` so `\'` does not end the skipped string.

Fixes #4152

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
