### PR TITLE
fix(java): tokenize method invocations and parameter types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@ Core Grammars:
 - enh(groovy) support underscores in numeric literals [greymoth][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
+- fix(java) tokenize method invocations and parameter types, issue #4229 [Arron Zou][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
 - enh(kotlin) add `ktm` and `ktx` aliases [DarkMatter-999][]
 - fix(leaf) fix bug in Leaf keyword highlighting [Francesco Paolo Severino][]
@@ -120,6 +121,7 @@ CONTRIBUTORS
 [Hirse]: https://github.com/Hirse
 [greymoth]: https://github.com/mahirhir
 [Hannes Wallnoefer]: https://github.com/hns
+[Arron Zou]: https://github.com/arronKler
 [Dsaquel]: https://github.com/Dsaquel
 [DarkMatter-999]: https://github.com/DarkMatter-999
 [Francesco Paolo Severino]: https://github.com/fpseverino

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -137,13 +137,42 @@ export default function(hljs) {
       }
     ]
   };
+  // Simple `Type name` / `Type[] name` parameters. Avoids generic type
+  // arguments so `super`/`extends` bounds stay keyword-highlighted.
+  const PARAM_DECLARATION = {
+    match: [
+      regex.concat(
+        /\b/,
+        /(?!(?:super|extends|implements|final|new|return|throw|else|yield|assert|case)\b)/,
+        JAVA_IDENT_RE
+      ),
+      ARRAY_BRACKETS_OPTIONAL_RE,
+      /\s+/,
+      JAVA_IDENT_RE
+    ],
+    scope: {
+      1: "type",
+      4: "variable"
+    }
+  };
+  const FUNCTION_INVOKE = {
+    match: regex.concat(
+      /\b/,
+      /(?!(?:if|for|while|switch|catch|synchronized|try|when|this|super)\b)/,
+      JAVA_IDENT_RE,
+      regex.lookahead(/\s*\(/)
+    ),
+    scope: "title.function.invoke"
+  };
   const PARAMS = {
-    className: 'params',
+    scope: 'params',
     begin: /\(/,
     end: /\)/,
     keywords: KEYWORDS,
-    relevance: 0,
-    contains: [ hljs.C_BLOCK_COMMENT_MODE ],
+    contains: [
+      hljs.C_BLOCK_COMMENT_MODE,
+      PARAM_DECLARATION
+    ],
     endsParent: true
   };
 
@@ -254,13 +283,13 @@ export default function(hljs) {
         keywords: KEYWORDS,
         contains: [
           {
-            className: 'params',
+            scope: 'params',
             begin: /\(/,
             end: /\)/,
             keywords: KEYWORDS,
-            relevance: 0,
             contains: [
               ANNOTATION,
+              PARAM_DECLARATION,
               hljs.APOS_STRING_MODE,
               hljs.QUOTE_STRING_MODE,
               NUMBER,
@@ -271,6 +300,7 @@ export default function(hljs) {
           hljs.C_BLOCK_COMMENT_MODE
         ]
       },
+      FUNCTION_INVOKE,
       NUMBER,
       ANNOTATION
     ]

--- a/test/api/highlight.js
+++ b/test/api/highlight.js
@@ -37,9 +37,9 @@ describe('.highlight()', () => {
     result.value.should.equal(
       '<span class="hljs-keyword">public</span> ' +
       '<span class="hljs-type">void</span> <span class="hljs-title function_">moveTo</span>' +
-      '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
-      '<span class="hljs-type">int</span> y, ' +
-      '<span class="hljs-type">int</span> z)</span>;'
+      '<span class="hljs-params">(<span class="hljs-type">int</span> <span class="hljs-variable">x</span>, ' +
+      '<span class="hljs-type">int</span> <span class="hljs-variable">y</span>, ' +
+      '<span class="hljs-type">int</span> <span class="hljs-variable">z</span>)</span>;'
     );
   });
   it('should works without continuation', () => {
@@ -49,9 +49,9 @@ describe('.highlight()', () => {
     result.value.should.equal(
       '<span class="hljs-keyword">public</span> ' +
       '<span class="hljs-type">void</span> <span class="hljs-title function_">moveTo</span>' +
-      '<span class="hljs-params">(<span class="hljs-type">int</span> x, ' +
-      '<span class="hljs-type">int</span> y, ' +
-      '<span class="hljs-type">int</span> z)</span>;'
+      '<span class="hljs-params">(<span class="hljs-type">int</span> <span class="hljs-variable">x</span>, ' +
+      '<span class="hljs-type">int</span> <span class="hljs-variable">y</span>, ' +
+      '<span class="hljs-type">int</span> <span class="hljs-variable">z</span>)</span>;'
     );
   });
 });

--- a/test/markup/java/annotations.expect.txt
+++ b/test/markup/java/annotations.expect.txt
@@ -8,5 +8,5 @@
 }
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Example</span> {
-  <span class="hljs-type">void</span> <span class="hljs-title function_">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> bar)</span> { }
+  <span class="hljs-type">void</span> <span class="hljs-title function_">foo</span><span class="hljs-params">(<span class="hljs-meta">@SuppressWarnings(&quot;unused&quot;)</span> <span class="hljs-type">int</span> <span class="hljs-variable">bar</span>)</span> { }
 }

--- a/test/markup/java/fibonacci.expect.txt
+++ b/test/markup/java/fibonacci.expect.txt
@@ -1,0 +1,14 @@
+<span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title class_">Fibonacci</span> {
+  <span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> <span class="hljs-type">void</span> <span class="hljs-title function_">fibonacci</span><span class="hljs-params">(<span class="hljs-type">int</span> <span class="hljs-variable">n</span>)</span> {
+    <span class="hljs-type">int</span> <span class="hljs-variable">a</span> <span class="hljs-operator">=</span> <span class="hljs-number">0</span>, b = <span class="hljs-number">1</span>;
+    <span class="hljs-keyword">for</span> (<span class="hljs-type">int</span> <span class="hljs-variable">i</span> <span class="hljs-operator">=</span> <span class="hljs-number">0</span>; i &lt; n; i++) {
+      System.out.<span class="hljs-title function_ invoke__">print</span>(a + <span class="hljs-string">&quot; &quot;</span>);
+      <span class="hljs-type">int</span> <span class="hljs-variable">sum</span> <span class="hljs-operator">=</span> a + b;
+      a = b;
+      b = sum;
+    }
+  }
+  <span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> <span class="hljs-type">void</span> <span class="hljs-title function_">main</span><span class="hljs-params">(<span class="hljs-type">String</span>[] <span class="hljs-variable">args</span>)</span> {
+    <span class="hljs-title function_ invoke__">fibonacci</span>(<span class="hljs-number">10</span>); <span class="hljs-comment">// Prints first 10 numbers</span>
+  }
+}

--- a/test/markup/java/fibonacci.txt
+++ b/test/markup/java/fibonacci.txt
@@ -1,0 +1,14 @@
+public class Fibonacci {
+  public static void fibonacci(int n) {
+    int a = 0, b = 1;
+    for (int i = 0; i < n; i++) {
+      System.out.print(a + " ");
+      int sum = a + b;
+      a = b;
+      b = sum;
+    }
+  }
+  public static void main(String[] args) {
+    fibonacci(10); // Prints first 10 numbers
+  }
+}

--- a/test/markup/java/functions.expect.txt
+++ b/test/markup/java/functions.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;A,B,C&gt; <span class="hljs-type">Tuple</span>&lt;A,B,C&gt; <span class="hljs-title function_">fun</span><span class="hljs-params">(Future&lt;Tuple&lt;A,B,C&gt;&gt; future)</span> <span class="hljs-keyword">throws</span> Exceptions {
 }
 
-<span class="hljs-keyword">static</span> <span class="hljs-type">Optional</span>&lt;List&lt;Token&gt;&gt; <span class="hljs-title function_">parseAll</span><span class="hljs-params">(String s)</span> {
+<span class="hljs-keyword">static</span> <span class="hljs-type">Optional</span>&lt;List&lt;Token&gt;&gt; <span class="hljs-title function_">parseAll</span><span class="hljs-params">(<span class="hljs-type">String</span> <span class="hljs-variable">s</span>)</span> {
 }

--- a/test/markup/java/generics.expect.txt
+++ b/test/markup/java/generics.expect.txt
@@ -4,11 +4,11 @@
 <span class="hljs-type">List</span>&lt;String[]&gt; <span class="hljs-variable">arrayStrings</span> <span class="hljs-operator">=</span> <span class="hljs-keyword">new</span> <span class="hljs-title class_">ArrayList</span>&lt;&gt;();
 <span class="hljs-type">Generic</span>&lt;Object, ?, String&gt; <span class="hljs-variable">g</span> <span class="hljs-operator">=</span> <span class="hljs-literal">null</span>;
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">static</span> &lt;T, R&gt; <span class="hljs-type">Generic</span>&lt;T, ?, R&gt; <span class="hljs-title function_">map</span><span class="hljs-params">(Function&lt;? <span class="hljs-built_in">super</span> T, ? extends R&gt; mapper)</span>;
-<span class="hljs-type">Map</span>&lt;? extends Key, List&lt;? <span class="hljs-built_in">super</span> Value&gt;&gt; <span class="hljs-variable">map</span> <span class="hljs-operator">=</span> getMap();
-<span class="hljs-type">Map</span>&lt;? extends Key[], List&lt;? <span class="hljs-built_in">super</span> Value[]&gt;&gt; <span class="hljs-variable">arrayMap</span> <span class="hljs-operator">=</span> getMap();
+<span class="hljs-type">Map</span>&lt;? extends Key, List&lt;? <span class="hljs-built_in">super</span> Value&gt;&gt; <span class="hljs-variable">map</span> <span class="hljs-operator">=</span> <span class="hljs-title function_ invoke__">getMap</span>();
+<span class="hljs-type">Map</span>&lt;? extends Key[], List&lt;? <span class="hljs-built_in">super</span> Value[]&gt;&gt; <span class="hljs-variable">arrayMap</span> <span class="hljs-operator">=</span> <span class="hljs-title function_ invoke__">getMap</span>();
 <span class="hljs-keyword">static</span> <span class="hljs-type">Set</span> &lt; Integer &gt; <span class="hljs-title function_">getInts</span><span class="hljs-params">()</span> { ... }
 
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Map</span>&lt;K, V&gt; {
-  <span class="hljs-type">void</span> <span class="hljs-title function_">put</span><span class="hljs-params">(K key, V value)</span>;
-  <span class="hljs-type">V</span> <span class="hljs-title function_">get</span><span class="hljs-params">(K key)</span>;
+  <span class="hljs-type">void</span> <span class="hljs-title function_">put</span><span class="hljs-params">(<span class="hljs-type">K</span> <span class="hljs-variable">key</span>, <span class="hljs-type">V</span> <span class="hljs-variable">value</span>)</span>;
+  <span class="hljs-type">V</span> <span class="hljs-title function_">get</span><span class="hljs-params">(<span class="hljs-type">K</span> <span class="hljs-variable">key</span>)</span>;
 }

--- a/test/markup/java/numbers.expect.txt
+++ b/test/markup/java/numbers.expect.txt
@@ -82,11 +82,11 @@
 
 
 <span class="hljs-comment">// expressions containing numeric literals</span>
-fn(<span class="hljs-number">.5</span>);
-fn(<span class="hljs-number">5.</span>);
+<span class="hljs-title function_ invoke__">fn</span>(<span class="hljs-number">.5</span>);
+<span class="hljs-title function_ invoke__">fn</span>(<span class="hljs-number">5.</span>);
 
 <span class="hljs-comment">// expressions not containing numeric literals</span>
-fn(x0.d);
+<span class="hljs-title function_ invoke__">fn</span>(x0.d);
 
 <span class="hljs-comment">// invalid pseudo-numeric literals</span>
 <span class="hljs-type">int</span>[] <span class="hljs-variable">badNonDecimalIntegers</span> <span class="hljs-operator">=</span>      { 08,  0_8,  019,     0x0g,      0B02, };

--- a/test/markup/java/titles.expect.txt
+++ b/test/markup/java/titles.expect.txt
@@ -1,10 +1,10 @@
 <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title class_">Greet</span> {
-    <span class="hljs-keyword">public</span> <span class="hljs-type">Either</span>&lt;Integer, String&gt; <span class="hljs-title function_">f</span><span class="hljs-params">(<span class="hljs-type">int</span> val)</span> {
+    <span class="hljs-keyword">public</span> <span class="hljs-type">Either</span>&lt;Integer, String&gt; <span class="hljs-title function_">f</span><span class="hljs-params">(<span class="hljs-type">int</span> <span class="hljs-variable">val</span>)</span> {
         <span class="hljs-keyword">new</span> <span class="hljs-title class_">Type</span>();
         <span class="hljs-keyword">if</span> (val) {
-            <span class="hljs-keyword">return</span> getType();
+            <span class="hljs-keyword">return</span> <span class="hljs-title function_ invoke__">getType</span>();
         } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (!val) {
-            <span class="hljs-keyword">throw</span> getError();
+            <span class="hljs-keyword">throw</span> <span class="hljs-title function_ invoke__">getError</span>();
         }
     }
 }

--- a/test/parser/resume-scan.js
+++ b/test/parser/resume-scan.js
@@ -8,7 +8,7 @@ describe("bugs", function() {
     it("should continue to highlight later matches", () => {
       const result = hljs.highlight('ImmutablePair.of(Stuff.class, "bar")', {language: 'java'});
       result.value.should.equal(
-        'ImmutablePair.of(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>)'
+        'ImmutablePair.<span class="hljs-title function_ invoke__">of</span>(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>)'
       );
     });
     // previously the match rule was resumed but it would scan ahead too far and ignore
@@ -18,7 +18,7 @@ describe("bugs", function() {
     it("BUT should not skip ahead too far", () => {
       const result = hljs.highlight('ImmutablePair.of(Stuff.class, "bar");\n23', {language: 'java'});
       result.value.should.equal(
-        'ImmutablePair.of(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>);\n' +
+        'ImmutablePair.<span class="hljs-title function_ invoke__">of</span>(Stuff.class, <span class="hljs-string">&quot;bar&quot;</span>);\n' +
         '<span class="hljs-number">23</span>'
       );
     });


### PR DESCRIPTION
Fixes #4229

### Changes

Java highlighted keywords, declarations, strings, and numbers, but left ordinary call sites and many parameter types as plain text. The Fibonacci sample from the issue is a typical case: `System.out.print(...)`, `fibonacci(10)`, and `main(String[] args)` were not marked up.

- Match identifier + `(` as `title.function.invoke`, excluding statement keywords (`if`, `for`, `while`, `switch`, `catch`, `synchronized`, `try`, `when`) plus `this`/`super`.
- Match simple `Type name` / `Type[] name` inside parameter lists so `String[] args` and `int n` are scoped. Generic arguments are left alone so `? super T` / `? extends R` keep their existing highlighting.
- Add a markup fixture from the issue sample.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
