### PR TITLE
test(css-like): cover function highlighting consistency

### DIFF
--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -73,6 +73,11 @@
 }
 
 <span class="hljs-selector-tag">main</span> {
+  <span class="hljs-attribute">filter</span>: <span class="hljs-built_in">grayscale</span>(<span class="hljs-number">0.5</span>) <span class="hljs-built_in">blur</span>(<span class="hljs-number">10px</span>);
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>(to right, <span class="hljs-built_in">rgb</span>(<span class="hljs-number">0</span> <span class="hljs-number">0</span> <span class="hljs-number">0</span> / <span class="hljs-number">50%</span>), <span class="hljs-built_in">var</span>(--color));
+}
+
+<span class="hljs-selector-tag">main</span> {
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }

--- a/test/markup/css/css_consistency.txt
+++ b/test/markup/css/css_consistency.txt
@@ -73,6 +73,11 @@ main {
 }
 
 main {
+  filter: grayscale(0.5) blur(10px);
+  background: linear-gradient(to right, rgb(0 0 0 / 50%), var(--color));
+}
+
+main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }

--- a/test/markup/less/css_consistency.expect.txt
+++ b/test/markup/less/css_consistency.expect.txt
@@ -72,6 +72,11 @@
 }
 
 <span class="hljs-selector-tag">main</span> {
+  <span class="hljs-attribute">filter</span>: <span class="hljs-built_in">grayscale</span>(<span class="hljs-number">0.5</span>) <span class="hljs-built_in">blur</span>(<span class="hljs-number">10px</span>);
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>(to right, <span class="hljs-built_in">rgb</span>(<span class="hljs-number">0</span> <span class="hljs-number">0</span> <span class="hljs-number">0</span> / <span class="hljs-number">50%</span>), <span class="hljs-built_in">var</span>(--color));
+}
+
+<span class="hljs-selector-tag">main</span> {
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }

--- a/test/markup/less/css_consistency.txt
+++ b/test/markup/less/css_consistency.txt
@@ -72,6 +72,11 @@ main {
 }
 
 main {
+  filter: grayscale(0.5) blur(10px);
+  background: linear-gradient(to right, rgb(0 0 0 / 50%), var(--color));
+}
+
+main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }

--- a/test/markup/scss/css_consistency.expect.txt
+++ b/test/markup/scss/css_consistency.expect.txt
@@ -72,6 +72,11 @@
 }
 
 <span class="hljs-selector-tag">main</span> {
+  <span class="hljs-attribute">filter</span>: <span class="hljs-built_in">grayscale</span>(<span class="hljs-number">0.5</span>) <span class="hljs-built_in">blur</span>(<span class="hljs-number">10px</span>);
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>(to right, <span class="hljs-built_in">rgb</span>(<span class="hljs-number">0</span> <span class="hljs-number">0</span> <span class="hljs-number">0</span> / <span class="hljs-number">50%</span>), <span class="hljs-built_in">var</span>(--color));
+}
+
+<span class="hljs-selector-tag">main</span> {
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }

--- a/test/markup/scss/css_consistency.txt
+++ b/test/markup/scss/css_consistency.txt
@@ -72,6 +72,11 @@ main {
 }
 
 main {
+  filter: grayscale(0.5) blur(10px);
+  background: linear-gradient(to right, rgb(0 0 0 / 50%), var(--color));
+}
+
+main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }

--- a/test/markup/stylus/css_consistency.expect.txt
+++ b/test/markup/stylus/css_consistency.expect.txt
@@ -72,6 +72,11 @@
 }
 
 <span class="hljs-selector-tag">main</span> {
+  <span class="hljs-attribute">filter</span>: <span class="hljs-built_in">grayscale</span>(<span class="hljs-number">0.5</span>) <span class="hljs-built_in">blur</span>(<span class="hljs-number">10px</span>);
+  <span class="hljs-attribute">background</span>: <span class="hljs-built_in">linear-gradient</span>(to right, <span class="hljs-built_in">rgb</span>(<span class="hljs-number">0</span> <span class="hljs-number">0</span> <span class="hljs-number">0</span> / <span class="hljs-number">50%</span>), <span class="hljs-built_in">var</span>(--color));
+}
+
+<span class="hljs-selector-tag">main</span> {
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }

--- a/test/markup/stylus/css_consistency.txt
+++ b/test/markup/stylus/css_consistency.txt
@@ -72,6 +72,11 @@ main {
 }
 
 main {
+  filter: grayscale(0.5) blur(10px);
+  background: linear-gradient(to right, rgb(0 0 0 / 50%), var(--color));
+}
+
+main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }


### PR DESCRIPTION
### Changes

Adds synchronized markup coverage for function highlighting across CSS, SCSS, Less, and Stylus.

The fixtures cover ordinary, adjacent, and nested calls using `grayscale`, `blur`, `linear-gradient`, `rgb`, and `var`. The existing shared matcher already produces consistent output, so no runtime grammar changes are needed.

Addresses the function-highlighting checklist item in #4489.

### Testing

- `npm run build`
- `npm run test` — 1635 passing, 3 pending

### Checklist

- [x] Added markup tests, or they don't apply here because...
- [x] I have read and followed our [AI-assisted contributions](https://github.com/highlightjs/highlight.js/blob/main/docs/ai-contributions.md) policy (human review, no slop)

Assisted-by: OpenAI Codex
