### PR TITLE
fix(python): handle nested `{}` replacement fields in f-string format specs

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -358,6 +358,7 @@ export default function(hljs) {
     ]
   };
   SUBST.contains = [
+    'self',
     STRING,
     NUMBER,
     PROMPT


### PR DESCRIPTION
## Summary

Fixes #4503 — `SUBST` (begin: `{`, end: `}`) did not contain itself, so a nested replacement field inside an f-string format spec (e.g. `f"{x:{w}}"`) closed the `subst` region at the inner `}`. The outer `}` was then emitted as plain string text, leaving the `subst` span brace-unbalanced.

## Changes

### `src/languages/python.js`
- Added `'self'` to `SUBST.contains` so that `SUBST` can contain nested replacement fields

## Why `'self'`

In highlight.js, `'self'` in a mode's `contains` array refers to the mode itself. This is the standard way to allow a mode to contain instances of itself, which is exactly what we need for nested `{}` replacement fields in Python f-strings.

## Test plan

```python
f"{x:{w}}"          # nested field in format spec
f"{value:{width}.{prec}f}"  # multiple nested fields
```

Before this fix:
- `f"{x:{w}}"` → `subst` span is `{x:{w}` (unmatched `{`)
- After: the whole `{x:{w}}` is a single balanced `subst`
