### PR TITLE
fix(haml) recognize implicit div tag lines starting with .class or #id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@ Core Grammars:
 - enh(gherkin) docstrings can use backticks [Hirse][]
 - enh(go) recognize binary integer literals [spokodev][]
 - enh(groovy) support underscores in numeric literals [greymoth][]
+- fix(haml) recognize implicit `div` tag lines starting with `.class` or `#id`, issue #3783 [pikammmmm][]
 - fix(haskell) highlight `where` in GADT and closed type-family declarations, issue #3753 [Konstantin Baltsat][]
 - enh(java) improve detection of types, including generic and array types [Hannes Wallnoefer][]
 - enh(javascript) add `self` to built-in variables [Dsaquel][]
@@ -132,6 +133,7 @@ CONTRIBUTORS
 [Hashim Khan]: https://github.com/Hashim1999164
 [Hirse]: https://github.com/Hirse
 [greymoth]: https://github.com/mahirhir
+[pikammmmm]: https://github.com/pikammmmm
 [Hannes Wallnoefer]: https://github.com/hns
 [Dsaquel]: https://github.com/Dsaquel
 [DarkMatter-999]: https://github.com/DarkMatter-999

--- a/src/languages/haml.js
+++ b/src/languages/haml.js
@@ -8,6 +8,65 @@ Category: template
 
 // TODO support filter tags like :javascript, support inline HTML
 export default function(hljs) {
+  const SELECTOR_ID = {
+    className: 'selector-id',
+    begin: '#[\\w-]+'
+  };
+  const SELECTOR_CLASS = {
+    className: 'selector-class',
+    begin: '\\.[\\w-]+'
+  };
+  const RUBY_HASH_ATTRS = {
+    begin: /\{\s*/,
+    end: /\s*\}/,
+    contains: [
+      {
+        begin: ':\\w+\\s*=>',
+        end: ',\\s+',
+        returnBegin: true,
+        endsWithParent: true,
+        contains: [
+          {
+            className: 'attr',
+            begin: ':\\w+'
+          },
+          hljs.APOS_STRING_MODE,
+          hljs.QUOTE_STRING_MODE,
+          {
+            begin: '\\w+',
+            relevance: 0
+          }
+        ]
+      }
+    ]
+  };
+  const HTML_ATTRS = {
+    begin: '\\(\\s*',
+    end: '\\s*\\)',
+    excludeEnd: true,
+    contains: [
+      {
+        begin: '\\w+\\s*=',
+        end: '\\s+',
+        returnBegin: true,
+        endsWithParent: true,
+        contains: [
+          {
+            className: 'attr',
+            begin: '\\w+',
+            relevance: 0
+          },
+          hljs.APOS_STRING_MODE,
+          hljs.QUOTE_STRING_MODE,
+          {
+            begin: '\\w+',
+            relevance: 0
+          }
+        ]
+      }
+    ]
+  };
+
   return {
     name: 'HAML',
     case_insensitive: true,
@@ -38,64 +97,26 @@ export default function(hljs) {
             className: 'selector-tag',
             begin: '\\w+'
           },
-          {
-            className: 'selector-id',
-            begin: '#[\\w-]+'
-          },
-          {
-            className: 'selector-class',
-            begin: '\\.[\\w-]+'
-          },
-          {
-            begin: /\{\s*/,
-            end: /\s*\}/,
-            contains: [
-              {
-                begin: ':\\w+\\s*=>',
-                end: ',\\s+',
-                returnBegin: true,
-                endsWithParent: true,
-                contains: [
-                  {
-                    className: 'attr',
-                    begin: ':\\w+'
-                  },
-                  hljs.APOS_STRING_MODE,
-                  hljs.QUOTE_STRING_MODE,
-                  {
-                    begin: '\\w+',
-                    relevance: 0
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            begin: '\\(\\s*',
-            end: '\\s*\\)',
-            excludeEnd: true,
-            contains: [
-              {
-                begin: '\\w+\\s*=',
-                end: '\\s+',
-                returnBegin: true,
-                endsWithParent: true,
-                contains: [
-                  {
-                    className: 'attr',
-                    begin: '\\w+',
-                    relevance: 0
-                  },
-                  hljs.APOS_STRING_MODE,
-                  hljs.QUOTE_STRING_MODE,
-                  {
-                    begin: '\\w+',
-                    relevance: 0
-                  }
-                ]
-              }
-            ]
-          }
+          SELECTOR_ID,
+          SELECTOR_CLASS,
+          RUBY_HASH_ATTRS,
+          HTML_ATTRS
+        ]
+      },
+      {
+        className: 'tag',
+        // implicit div: the line starts directly with `.class` or `#id`;
+        // `[\w-]` keeps `#{interpolation}` out of this case
+        begin: '^\\s*(?=[.#][\\w-])',
+        // relevance 0 everywhere: lines starting with `.foo` / `#foo` are
+        // common in other languages (CSS selectors, C preprocessor,
+        // assembler directives), so they must not count towards HAML
+        relevance: 0,
+        contains: [
+          hljs.inherit(SELECTOR_ID, { relevance: 0 }),
+          hljs.inherit(SELECTOR_CLASS, { relevance: 0 }),
+          hljs.inherit(RUBY_HASH_ATTRS, { relevance: 0 }),
+          hljs.inherit(HTML_ATTRS, { relevance: 0 })
         ]
       },
       { begin: '^\\s*[=~]\\s*' },

--- a/src/languages/haml.js
+++ b/src/languages/haml.js
@@ -8,59 +8,56 @@ Category: template
 
 // TODO support filter tags like :javascript, support inline HTML
 export default function(hljs) {
+  const regex = hljs.regex;
   const SELECTOR_ID = {
-    className: 'selector-id',
-    begin: '#[\\w-]+'
+    scope: 'selector-id',
+    match: /#[\w-]+/
   };
   const SELECTOR_CLASS = {
-    className: 'selector-class',
-    begin: '\\.[\\w-]+'
+    scope: 'selector-class',
+    match: /\.[\w-]+/
   };
   const RUBY_HASH_ATTRS = {
     begin: /\{\s*/,
     end: /\s*\}/,
     contains: [
       {
-        begin: ':\\w+\\s*=>',
-        end: ',\\s+',
+        begin: /:\w+\s*=>/,
+        end: /,\s+/,
         returnBegin: true,
         endsWithParent: true,
         contains: [
           {
-            className: 'attr',
-            begin: ':\\w+'
+            scope: 'attr',
+            match: /:\w+/
           },
           hljs.APOS_STRING_MODE,
           hljs.QUOTE_STRING_MODE,
           {
-            begin: '\\w+',
-            relevance: 0
+            match: /\w+/
           }
         ]
       }
     ]
   };
   const HTML_ATTRS = {
-    begin: '\\(\\s*',
-    end: '\\s*\\)',
-    excludeEnd: true,
+    begin: /\(\s*/,
+    end: regex.lookahead(/\s*\)/),
     contains: [
       {
-        begin: '\\w+\\s*=',
-        end: '\\s+',
+        begin: /\w+\s*=/,
+        end: /\s+/,
         returnBegin: true,
         endsWithParent: true,
         contains: [
           {
-            className: 'attr',
-            begin: '\\w+',
-            relevance: 0
+            scope: 'attr',
+            match: /\w+/
           },
           hljs.APOS_STRING_MODE,
           hljs.QUOTE_STRING_MODE,
           {
-            begin: '\\w+',
-            relevance: 0
+            match: /\w+/
           }
         ]
       }
@@ -104,19 +101,15 @@ export default function(hljs) {
         ]
       },
       {
-        className: 'tag',
+        scope: 'tag',
         // implicit div: the line starts directly with `.class` or `#id`;
         // `[\w-]` keeps `#{interpolation}` out of this case
-        begin: '^\\s*(?=[.#][\\w-])',
-        // relevance 0 everywhere: lines starting with `.foo` / `#foo` are
-        // common in other languages (CSS selectors, C preprocessor,
-        // assembler directives), so they must not count towards HAML
-        relevance: 0,
+        begin: /^\s*(?=[.#][\w-])/,
         contains: [
-          hljs.inherit(SELECTOR_ID, { relevance: 0 }),
-          hljs.inherit(SELECTOR_CLASS, { relevance: 0 }),
-          hljs.inherit(RUBY_HASH_ATTRS, { relevance: 0 }),
-          hljs.inherit(HTML_ATTRS, { relevance: 0 })
+          SELECTOR_ID,
+          SELECTOR_CLASS,
+          RUBY_HASH_ATTRS,
+          HTML_ATTRS
         ]
       },
       { begin: '^\\s*[=~]\\s*' },

--- a/src/languages/haml.js
+++ b/src/languages/haml.js
@@ -8,7 +8,6 @@ Category: template
 
 // TODO support filter tags like :javascript, support inline HTML
 export default function(hljs) {
-  const regex = hljs.regex;
   const SELECTOR_ID = {
     scope: 'selector-id',
     match: /#[\w-]+/
@@ -18,8 +17,8 @@ export default function(hljs) {
     match: /\.[\w-]+/
   };
   const RUBY_HASH_ATTRS = {
-    begin: /\{\s*/,
-    end: /\s*\}/,
+    begin: /\{/,
+    end: /\}/,
     contains: [
       {
         begin: /:\w+\s*=>/,
@@ -41,8 +40,8 @@ export default function(hljs) {
     ]
   };
   const HTML_ATTRS = {
-    begin: /\(\s*/,
-    end: regex.lookahead(/\s*\)/),
+    begin: /\(/,
+    end: /\)/,
     contains: [
       {
         begin: /\w+\s*=/,

--- a/test/markup/haml/default.expect.txt
+++ b/test/markup/haml/default.expect.txt
@@ -4,7 +4,7 @@
 <span class="hljs-tag">    %<span class="hljs-selector-tag">h1</span><span class="hljs-selector-class">.jumbo</span>{<span class="hljs-attr">:id</span>=&gt;<span class="hljs-string">&quot;a&quot;</span>, <span class="hljs-attr">:style</span>=&gt;<span class="hljs-string">&#x27;font-weight: normal&#x27;</span>, <span class="hljs-attr">:title</span>=&gt;title}</span> highlight.js
 <span class="hljs-comment">    /html comment</span>
 <span class="hljs-comment">    -# ignore this line</span>
-<span class="hljs-tag">    %<span class="hljs-selector-tag">ul</span>(<span class="hljs-attr">style</span>=<span class="hljs-string">&#x27;margin: 0&#x27;</span>)</span>
+<span class="hljs-tag">    %<span class="hljs-selector-tag">ul</span>(<span class="hljs-attr">style</span>=<span class="hljs-string">&#x27;margin: 0&#x27;</span></span>)
     -<span class="language-ruby">items.each <span class="hljs-keyword">do</span> |<span class="hljs-params">i</span>|</span>
 <span class="hljs-tag">      %<span class="hljs-selector-tag">i</span></span>= i
     =<span class="language-ruby"> variable</span>

--- a/test/markup/haml/default.expect.txt
+++ b/test/markup/haml/default.expect.txt
@@ -4,7 +4,7 @@
 <span class="hljs-tag">    %<span class="hljs-selector-tag">h1</span><span class="hljs-selector-class">.jumbo</span>{<span class="hljs-attr">:id</span>=&gt;<span class="hljs-string">&quot;a&quot;</span>, <span class="hljs-attr">:style</span>=&gt;<span class="hljs-string">&#x27;font-weight: normal&#x27;</span>, <span class="hljs-attr">:title</span>=&gt;title}</span> highlight.js
 <span class="hljs-comment">    /html comment</span>
 <span class="hljs-comment">    -# ignore this line</span>
-<span class="hljs-tag">    %<span class="hljs-selector-tag">ul</span>(<span class="hljs-attr">style</span>=<span class="hljs-string">&#x27;margin: 0&#x27;</span></span>)
+<span class="hljs-tag">    %<span class="hljs-selector-tag">ul</span>(<span class="hljs-attr">style</span>=<span class="hljs-string">&#x27;margin: 0&#x27;</span>)</span>
     -<span class="language-ruby">items.each <span class="hljs-keyword">do</span> |<span class="hljs-params">i</span>|</span>
 <span class="hljs-tag">      %<span class="hljs-selector-tag">i</span></span>= i
     =<span class="language-ruby"> variable</span>

--- a/test/markup/haml/implicit_div.expect.txt
+++ b/test/markup/haml/implicit_div.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-tag">%<span class="hljs-selector-tag">ul</span><span class="hljs-selector-class">.list</span></span>
+<span class="hljs-tag">  <span class="hljs-selector-class">.item</span></span> plain class
+<span class="hljs-tag">  <span class="hljs-selector-class">.item</span><span class="hljs-selector-class">.selected</span>{<span class="hljs-attr">:title</span>=&gt;<span class="hljs-string">&#x27;yes&#x27;</span>}</span> class with attrs
+<span class="hljs-tag">  <span class="hljs-selector-id">#main</span></span> an id
+<span class="hljs-tag">  <span class="hljs-selector-id">#footer</span><span class="hljs-selector-class">.dark</span>{<span class="hljs-attr">:id</span>=&gt;<span class="hljs-string">&quot;f&quot;</span>}</span> id, class and attrs
+<span class="hljs-tag">    <span class="hljs-selector-class">.nested</span></span>
+<span class="hljs-tag">      %<span class="hljs-selector-tag">h1</span><span class="hljs-selector-class">.good</span></span> explicit tags still work
+  #{<span class="language-ruby">interpolation</span>} is not a div

--- a/test/markup/haml/implicit_div.txt
+++ b/test/markup/haml/implicit_div.txt
@@ -1,0 +1,8 @@
+%ul.list
+  .item plain class
+  .item.selected{:title=>'yes'} class with attrs
+  #main an id
+  #footer.dark{:id=>"f"} id, class and attrs
+    .nested
+      %h1.good explicit tags still work
+  #{interpolation} is not a div


### PR DESCRIPTION
Resolves #3783.

### Changes

HAML's implicit-div syntax gets no highlighting at all. Lines like

```haml
.broken{ broken: 'yes' }
#main content
```

emit zero spans, while the equivalent `%div.broken{ broken: 'yes' }` highlights fine (sample and screenshots in the issue).

The cause: the tag mode only opens on `^\s*%`, and the `selector-class` / `selector-id` rules that would handle `.class` and `#id` are nested inside it, so a line without a leading `%` never reaches them.

The fix adds a second variant of the tag mode that begins, zero-width, on a line starting with `.class` or `#id`:

```js
begin: '^\\s*(?=[.#][\\w-])',
```

and reuses the same nested rules — they're extracted into shared constants, which is most of the diff's line count. The `%` mode itself is unchanged, and I diffed the rendered output of the existing haml fixtures before and after: byte-identical.

A few deliberate choices:

- The implicit-div variant carries `relevance: 0` throughout. Lines starting with `.foo` / `#foo` are everywhere in other languages (CSS selectors, C preprocessor, assembler directives); without this, a three-rule CSS snippet ties HAML with CSS in `highlightAuto` (6 vs 6). With it, such snippets contribute 0 to HAML, while real HAML detection is unchanged (the detect sample still scores 36).
- The lookahead requires `[\w-]` after the `.`/`#`, so `#{ruby}` interpolation at the start of a line still renders as Ruby, not as a div.
- The dot/hash stays part of the `selector-class` / `selector-id` span — the Rouge-style option @j-erasmus suggested in the thread, and what the nested rules already do for `%tag.class` today. If you'd rather have them as punctuation (the other option raised there), that's an easy switch.

Out of scope: new-style hash attributes (`{ broken: 'yes' }`) get no highlighting inside the braces — but that's equally true for `%tag{ ... }` today, so it's a pre-existing, separate enhancement rather than part of this bug.

### Checklist
- [ ] Added markup tests (`test/markup/haml/implicit_div.txt`)
- [ ] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
