### PR TITLE
fix(css, less, scss, stylus) keep escaped characters in selector names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 11.12.1
 
+Core Grammars:
+
+- fix(css, less, scss, stylus) keep escaped characters inside class and id names, issue #3965 [Maxim Gagiev][]
+
 Documentation:
 
 - docs: switch the Sphinx docs theme from ReadTheDocs to Shibuya [Haowei Hsu][]
@@ -8,6 +12,7 @@ Documentation:
 CONTRIBUTORS
 
 [Haowei Hsu]: https://github.com/hwhsu1231
+[Maxim Gagiev]: https://github.com/maximilliangrand
 
 ## Version 11.12.0
 

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -14,7 +14,7 @@ export default function(hljs) {
   const VENDOR_PREFIX = { begin: /-(webkit|moz|ms|o)-(?=[a-z])/ };
   const AT_MODIFIERS = "and or not only";
   const AT_PROPERTY_RE = /@-?\w[\w]*(-\w+)*/; // @-webkit-keyframes
-  const IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
+  const IDENT_RE = css.SELECTOR_IDENT_RE('[a-zA-Z-]', '[a-zA-Z0-9_-]');
   const STRINGS = [
     hljs.APOS_STRING_MODE,
     hljs.QUOTE_STRING_MODE
@@ -37,7 +37,7 @@ export default function(hljs) {
       modes.CSS_NUMBER_MODE,
       {
         className: 'selector-id',
-        begin: /#[A-Za-z0-9_-]+/,
+        begin: '#' + css.SELECTOR_IDENT_RE('[A-Za-z0-9_-]', '[A-Za-z0-9_-]'),
         relevance: 0
       },
       {

--- a/src/languages/less.js
+++ b/src/languages/less.js
@@ -16,6 +16,9 @@ export default function(hljs) {
   const AT_MODIFIERS = "and or not only";
   const IDENT_RE = '[\\w-]+'; // yes, Less identifiers may begin with a digit
   const INTERP_IDENT_RE = '(' + IDENT_RE + '|@\\{' + IDENT_RE + '\\})';
+  // as INTERP_IDENT_RE, but class and id names may also carry CSS escapes
+  const INTERP_SELECTOR_RE = '(' + css.SELECTOR_IDENT_RE('[\\w-]', '[\\w-]')
+    + '|@\\{' + IDENT_RE + '\\})';
 
   /* Generic Modes */
 
@@ -185,8 +188,8 @@ export default function(hljs) {
       },
       modes.CSS_NUMBER_MODE,
       IDENT_MODE('selector-tag', INTERP_IDENT_RE, 0),
-      IDENT_MODE('selector-id', '#' + INTERP_IDENT_RE),
-      IDENT_MODE('selector-class', '\\.' + INTERP_IDENT_RE, 0),
+      IDENT_MODE('selector-id', '#' + INTERP_SELECTOR_RE),
+      IDENT_MODE('selector-class', '\\.' + INTERP_SELECTOR_RE, 0),
       IDENT_MODE('selector-tag', '&', 0),
       modes.ATTRIBUTE_SELECTOR_MODE,
       {

--- a/src/languages/lib/css-shared.js
+++ b/src/languages/lib/css-shared.js
@@ -1,3 +1,32 @@
+/**
+ * A CSS escape sequence: a backslash followed either by up to six hex digits
+ * (with an optional single trailing space) or by any one character that is not
+ * a hex digit. Newlines cannot be escaped.
+ *
+ * The hex branches are kept disjoint so the sequence cannot be split more than
+ * one way, which would let the surrounding quantifier backtrack exponentially.
+ * A run of six digits is only taken when a seventh follows, since a hex escape
+ * stops after six; every shorter run has to reach a non-hex character.
+ *
+ * https://www.w3.org/TR/css-syntax-3/#escaping
+ */
+export const ESCAPE_RE = '\\\\(?:'
+  + '[\\da-fA-F]{6}(?=[\\da-fA-F])'
+  + '|[\\da-fA-F]{1,6}(?![\\da-fA-F]) ?'
+  + '|[^\\da-fA-F\\r\\n]'
+  + ')';
+
+/**
+ * Builds a selector name pattern that also accepts CSS escape sequences, so
+ * that names such as `.dark\\:hover\\:bg-sky-500` are matched in one piece
+ * instead of breaking apart at the backslash.
+ *
+ * @param {string} first character class the name may begin with
+ * @param {string} rest character class the remaining characters may use
+ */
+export const SELECTOR_IDENT_RE = (first, rest) =>
+  '(?:' + first + '|' + ESCAPE_RE + ')(?:' + rest + '|' + ESCAPE_RE + ')*';
+
 export const MODES = (hljs) => {
   return {
     IMPORTANT: {

--- a/src/languages/scss.js
+++ b/src/languages/scss.js
@@ -35,12 +35,12 @@ export default function(hljs) {
       modes.CSS_NUMBER_MODE,
       {
         className: 'selector-id',
-        begin: '#[A-Za-z0-9_-]+',
+        begin: '#' + css.SELECTOR_IDENT_RE('[A-Za-z0-9_-]', '[A-Za-z0-9_-]'),
         relevance: 0
       },
       {
         className: 'selector-class',
-        begin: '\\.[A-Za-z0-9_-]+',
+        begin: '\\.' + css.SELECTOR_IDENT_RE('[A-Za-z0-9_-]', '[A-Za-z0-9_-]'),
         relevance: 0
       },
       modes.ATTRIBUTE_SELECTOR_MODE,

--- a/src/languages/stylus.js
+++ b/src/languages/stylus.js
@@ -73,13 +73,13 @@ export default function(hljs) {
 
       // class tag
       {
-        begin: '\\.[a-zA-Z][a-zA-Z0-9_-]*' + LOOKAHEAD_TAG_END,
+        begin: '\\.' + css.SELECTOR_IDENT_RE('[a-zA-Z]', '[a-zA-Z0-9_-]') + LOOKAHEAD_TAG_END,
         className: 'selector-class'
       },
 
       // id tag
       {
-        begin: '#[a-zA-Z][a-zA-Z0-9_-]*' + LOOKAHEAD_TAG_END,
+        begin: '#' + css.SELECTOR_IDENT_RE('[a-zA-Z]', '[a-zA-Z0-9_-]') + LOOKAHEAD_TAG_END,
         className: 'selector-id'
       },
 

--- a/test/markup/css/css_consistency.expect.txt
+++ b/test/markup/css/css_consistency.expect.txt
@@ -76,3 +76,9 @@
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }
+
+<span class="hljs-comment">/* escaped special characters are part of the class or id name */</span>
+<span class="hljs-selector-class">.dark\:hover\:bg-sky-500</span><span class="hljs-selector-pseudo">:hover</span> {}
+<span class="hljs-selector-class">.w-1\/2</span> {}
+<span class="hljs-selector-class">.foo\3A bar</span> {}
+<span class="hljs-selector-id">#main\@md</span> {}

--- a/test/markup/css/css_consistency.txt
+++ b/test/markup/css/css_consistency.txt
@@ -76,3 +76,9 @@ main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }
+
+/* escaped special characters are part of the class or id name */
+.dark\:hover\:bg-sky-500:hover {}
+.w-1\/2 {}
+.foo\3A bar {}
+#main\@md {}

--- a/test/markup/less/css_consistency.expect.txt
+++ b/test/markup/less/css_consistency.expect.txt
@@ -75,3 +75,9 @@
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }
+
+<span class="hljs-comment">/* escaped special characters are part of the class or id name */</span>
+<span class="hljs-selector-class">.dark\:hover\:bg-sky-500</span><span class="hljs-selector-pseudo">:hover</span> {}
+<span class="hljs-selector-class">.w-1\/2</span> {}
+<span class="hljs-selector-class">.foo\3A bar</span> {}
+<span class="hljs-selector-id">#main\@md</span> {}

--- a/test/markup/less/css_consistency.txt
+++ b/test/markup/less/css_consistency.txt
@@ -75,3 +75,9 @@ main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }
+
+/* escaped special characters are part of the class or id name */
+.dark\:hover\:bg-sky-500:hover {}
+.w-1\/2 {}
+.foo\3A bar {}
+#main\@md {}

--- a/test/markup/scss/css_consistency.expect.txt
+++ b/test/markup/scss/css_consistency.expect.txt
@@ -75,3 +75,9 @@
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }
+
+<span class="hljs-comment">/* escaped special characters are part of the class or id name */</span>
+<span class="hljs-selector-class">.dark\:hover\:bg-sky-500</span><span class="hljs-selector-pseudo">:hover</span> {}
+<span class="hljs-selector-class">.w-1\/2</span> {}
+<span class="hljs-selector-class">.foo\3A bar</span> {}
+<span class="hljs-selector-id">#main\@md</span> {}

--- a/test/markup/scss/css_consistency.txt
+++ b/test/markup/scss/css_consistency.txt
@@ -75,3 +75,9 @@ main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }
+
+/* escaped special characters are part of the class or id name */
+.dark\:hover\:bg-sky-500:hover {}
+.w-1\/2 {}
+.foo\3A bar {}
+#main\@md {}

--- a/test/markup/stylus/css_consistency.expect.txt
+++ b/test/markup/stylus/css_consistency.expect.txt
@@ -75,3 +75,9 @@
   <span class="hljs-comment">/* normal comment */</span>
   <span class="hljs-attribute">width</span>: <span class="hljs-comment">/* inline comment */</span> <span class="hljs-number">50px</span>;
 }
+
+<span class="hljs-comment">/* escaped special characters are part of the class or id name */</span>
+<span class="hljs-selector-class">.dark\:hover\:bg-sky-500</span><span class="hljs-selector-pseudo">:hover</span> {}
+<span class="hljs-selector-class">.w-1\/2</span> {}
+<span class="hljs-selector-class">.foo\3A bar</span> {}
+<span class="hljs-selector-id">#main\@md</span> {}

--- a/test/markup/stylus/css_consistency.txt
+++ b/test/markup/stylus/css_consistency.txt
@@ -75,3 +75,9 @@ main {
   /* normal comment */
   width: /* inline comment */ 50px;
 }
+
+/* escaped special characters are part of the class or id name */
+.dark\:hover\:bg-sky-500:hover {}
+.w-1\/2 {}
+.foo\3A bar {}
+#main\@md {}


### PR DESCRIPTION
Fixes #3965.

## The bug

Class and id names may contain CSS escape sequences, which Tailwind emits for its variant separators. The selector patterns stopped at the backslash, so the name was cut short and the remainder rescanned:

```css
.dark\:hover\:bg-sky-500:hover {}
```

On 11.12.0 that scopes `.dark` as the class, then the escaped `\:hover` as a pseudo class and `500` as a number. All four css-like grammars are affected.

## Root cause

Each grammar spelled its own class and id pattern from a plain character class with no notion of escapes:

- `src/languages/css.js:17` (IDENT_RE, used by selector-class) and `:40`
- `src/languages/scss.js:38` and `:43`
- `src/languages/less.js:188` and `:189`, via `INTERP_IDENT_RE`
- `src/languages/stylus.js:76` and `:82`

## The fix

Adds `ESCAPE_RE` and `SELECTOR_IDENT_RE` to `src/languages/lib/css-shared.js` and uses them for the class and id patterns in all four grammars, following your note on the issue about pushing a shared name pattern down into `css-shared.js`. Each grammar keeps its own leading-character rules, so the change is additive.

The hex branches of the escape are kept disjoint: a six digit run is only taken when a seventh follows, and every shorter run has to reach a non-hex character. Without that, `\0` plus `0` and `\00` are both valid splits of the same text and `test/regex` fails with exponential backtracking on `"\00".repeat(n)`.

## Tests

Four escape cases added to `test/markup/css/css_consistency.txt` and mirrored into less, scss and stylus with `tools/css`, so the shared fixture is what proves the four grammars now agree.

With the source change reverted those four `css_consistency` tests fail (598 passing, 4 failing); with it applied the markup suite is 602 passing and the full suite 1649 passing, 3 pending, matching main.

Assisted-by: Claude Opus 4.8 (high)
