### PR TITLE
Add Astro as supported 3rd party language

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -27,6 +27,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | ARM assembler           | armasm, arm            |         |
 | AsciiDoc                | asciidoc, adoc         |         |
 | AspectJ                 | aspectj                |         |
+| Astro                   | astro, astrojs         | [highlightjs-astro](https://github.com/chrisknepper/highlightjs-astro) |
 | AutoHotkey              | autohotkey, ahk        |         |
 | AutoIt                  | autoit                 |         |
 | AVR assembler           | avrasm                 |         |


### PR DESCRIPTION
### Changes
Adds support for Astro (aka Astro.js) components. Astro is a popular web framework. Astro components are conceptually similar to JSX and contain frontmatter, markup, inline CSS and JavaScript/TypeScript.

The package is mine and published to NPM at https://www.npmjs.com/package/highlightjs-astro-js

Repo: https://github.com/chrisknepper/highlightjs-astro

CodePen example: https://codepen.io/editor/chrisknepper/pen/01a02b88-61b4-7ee0-84f8-7587ff594385

Astro site: https://astro.build/

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)
