### PR TITLE
fix(ruby): don't treat :: scope resolution as symbols after single-letter constants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,14 @@ Documentation:
 - docs: switch the Sphinx docs theme from ReadTheDocs to Shibuya [Haowei Hsu][]
 - docs: revamp the docs landing page using sphinx-design [Haowei Hsu][]
 
+Core Grammars:
+
+- fix(ruby) don't treat `::` scope resolution as symbols after single-letter constants, issue #4516 [Xi-7yao][]
+
 CONTRIBUTORS
 
 [Haowei Hsu]: https://github.com/hwhsu1231
+[Xi-7yao]: https://github.com/Xi-7yao
 
 ## Version 11.12.0
 

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -360,12 +360,12 @@ export default function(hljs) {
     },
     {
       className: 'symbol',
-      begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:',
+      begin: hljs.UNDERSCORE_IDENT_RE + '(!|\\?)?:(?!:)',
       relevance: 0
     },
     {
       className: 'symbol',
-      begin: ':(?!\\s)',
+      begin: '(?<!:):(?!\\s)',
       contains: [
         STRING,
         { begin: RUBY_METHOD_RE }

--- a/test/markup/ruby/symbols.expect.txt
+++ b/test/markup/ruby/symbols.expect.txt
@@ -10,3 +10,7 @@ obj.send(<span class="hljs-symbol">:to_s</span>)
 ::<span class="hljs-title class_">TopLevel</span>.new
 A::a
 A::B::c
+
+<span class="hljs-comment"># left side of :: may be a variable, not just a CamelCase constant (#4518 regression check)</span>
+an_alias = A
+an_alias::a_method(<span class="hljs-symbol">sym:</span> <span class="hljs-number">5</span>)

--- a/test/markup/ruby/symbols.expect.txt
+++ b/test/markup/ruby/symbols.expect.txt
@@ -8,3 +8,5 @@ obj.send(<span class="hljs-symbol">:to_s</span>)
 <span class="hljs-title class_">ClassName</span>::method
 <span class="hljs-title class_">Math</span>::<span class="hljs-variable constant_">PI</span>
 ::<span class="hljs-title class_">TopLevel</span>.new
+A::a
+A::B::c

--- a/test/markup/ruby/symbols.txt
+++ b/test/markup/ruby/symbols.txt
@@ -8,3 +8,5 @@ Foo::Bar::baz(1)
 ClassName::method
 Math::PI
 ::TopLevel.new
+A::a
+A::B::c

--- a/test/markup/ruby/symbols.txt
+++ b/test/markup/ruby/symbols.txt
@@ -10,3 +10,7 @@ Math::PI
 ::TopLevel.new
 A::a
 A::B::c
+
+# left side of :: may be a variable, not just a CamelCase constant (#4518 regression check)
+an_alias = A
+an_alias::a_method(sym: 5)


### PR DESCRIPTION
Fixes #4516

## Problem
`A::a` (calling a method on a single-letter constant) was highlighted as two symbols: `A:` and `:a`. Single-letter constants are not matched by the CamelCase class rule, so the trailing-colon symbol rule (`IDENT:`) consumed the first colon and the leading-colon symbol rule (`:`) then matched the second one, splitting the scope-resolution operator across two symbol matches.

## Fix
- Trailing-colon symbol rule: added a negative lookahead `(?!:)` so `IDENT:` is not matched when followed by another colon.
- Leading-colon symbol rule: added a negative lookbehind `(?<!:)` so a `:` preceded by `:` is never treated as a symbol.

The existing `::` swallow rule still handles CamelCase constants (`Foo::Bar`, `ClassName::method`); these guards close the gap for non-CamelCase (e.g. single-letter) constants.

## Test
- Added `A::a` and `A::B::c` to `test/markup/ruby/symbols.txt` (+ matching `symbols.expect.txt`).
- `npm test`: 1650 passing, 0 failing (incl. all ruby markup fixtures).
- `npm run build`: ok.
