### PR TITLE
(docs) add Verse to SUPPORTED_LANGUAGES

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -290,6 +290,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | VBScript                | vbscript, vbs          |         |
 | VBScript in HTML        | vbscript-html          |         |
 | Verilog                 | verilog, v, sv, svh    |         |
+| Verse                   | verse                  | [highlightjs-verse](https://github.com/simnJS/highlightjs-verse) |
 | Veryl                   | veryl                  | [highlightjs-veryl](https://github.com/veryl-lang/veryl/tree/master/support/highlightjs) |
 | VHDL                    | vhdl                   |         |
 | Vim Script              | vim                    |         |


### PR DESCRIPTION
### Changes

Adds one row to `SUPPORTED_LANGUAGES.md` for **Verse**, pointing at a
third-party grammar:

| Language | Aliases | Package |
| :-- | :-- | :-- |
| Verse | `verse` | [highlightjs-verse](https://github.com/simnJS/highlightjs-verse) |

#### About the language

[Verse](https://dev.epicgames.com/documentation/en-us/uefn/verse-language-reference)
is Epic Games' multi-paradigm programming language. It is the scripting language
of Unreal Editor for Fortnite (UEFN) and Fortnite Creative, and Epic has
announced it as the programming language of Unreal Engine 6.

Verse is already an officially supported language in **GitHub Linguist**, added
in [github-linguist/linguist#7440](https://github.com/github-linguist/linguist/pull/7440)
(merged 10 Aug 2026), which registered the `.verse` extension and the
`source.verse` scope. The TextMate grammar backing that is
[`simnJS/verse-grammar`](https://github.com/simnJS/verse-grammar), which I also
maintain, so it is in production use for syntax detection and highlighting on
GitHub today. That is a Linguist outcome only — it implies nothing about this
highlight.js grammar, which is new and unaffiliated.

#### About the grammar

[`highlightjs-verse`](https://github.com/simnJS/highlightjs-verse) is a **native
highlight.js implementation**, written against the highlight.js grammar model.
It is not a mechanical conversion of the TextMate grammar — the syntax knowledge
was carried over and re-expressed as highlight.js modes.

- Built from [`highlightjs-grammar-template`](https://github.com/highlightjs/highlightjs-grammar-template);
  ESM / CJS / browser bundles in `dist/`, MIT licensed.
- Covers nested `<# … #>` block comments, string interpolation and escapes,
  character and code-point literals, `class`/`struct`/`interface`/`enum`/`module`
  definitions, failable calls, access and effect specifiers (`<public>`,
  `<computes>`, `<decides>`, `<suspends>`, …), `@editable`-style attributes,
  `/Verse.org/…` module paths, `var`/`set` mutability, and concurrency
  (`sync`/`race`/`rush`/`branch`/`spawn`).
- **Tests:** 27 passing — snapshot markup tests over 14 fixtures, plus a
  detection suite. Two detection fixtures are the real-world MIT-licensed
  samples Linguist uses for Verse (attributed in-repo); the rest is
  representative UEFN device code.
- **Auto-detection was tuned deliberately.** Verse shares a large keyword
  surface with Ruby and Pascal, so common keywords are weighted `|0` and
  relevance comes from Verse-only constructs. Specifiers are matched from a
  known list rather than a generic `<word>` rule, so C++/TypeScript generics
  like `vector<int>` are not claimed. The suite asserts Verse does **not** win
  auto-detection on Bash, C++, Delphi, Go, PowerShell, Python, Ruby or
  TypeScript sources.
- CI runs the suites and fails if the committed `dist/` drifts from `src/`.

I intend to keep maintaining it as Verse evolves, and I'm happy to adjust the
entry's wording or answer anything about the grammar.

### Checklist
- [x] Added markup tests, or they don't apply here because... this is a
  docs-only change; the markup tests live in the grammar repo
  ([`test/markup/verse`](https://github.com/simnJS/highlightjs-verse/tree/main/test/markup/verse)).
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)


`Assisted-by: Claude Opus 5 (high)`
