### PR TITLE
fix(x86asm, mipsasm, llvm) don't swallow the preceding blank line into label spans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 11.12.1
 
+Core Grammars:
+
+- fix(x86asm, mipsasm, llvm) stop label and directive matches swallowing the preceding blank line, issue #4525 [Matt Godbolt][]
+
 Documentation:
 
 - docs: switch the Sphinx docs theme from ReadTheDocs to Shibuya [Haowei Hsu][]
@@ -8,6 +12,7 @@ Documentation:
 CONTRIBUTORS
 
 [Haowei Hsu]: https://github.com/hwhsu1231
+[Matt Godbolt]: https://github.com/mattgodbolt
 
 ## Version 11.12.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 Core Grammars:
 
 - fix(x86asm, mipsasm, llvm) stop label and directive matches swallowing the preceding blank line, issue #4525 [Matt Godbolt][]
+- fix(mipsasm) stop mnemonic spans swallowing the whitespace that terminates them, issue #4525 [Matt Godbolt][]
 
 Documentation:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,5 @@
 ## Version 11.12.1
 
-Core Grammars:
-
-- fix(x86asm, mipsasm, llvm) stop label and directive matches swallowing the preceding blank line, issue #4525 [Matt Godbolt][]
-- fix(mipsasm) stop mnemonic spans swallowing the whitespace that terminates them, issue #4525 [Matt Godbolt][]
-
 Documentation:
 
 - docs: switch the Sphinx docs theme from ReadTheDocs to Shibuya [Haowei Hsu][]
@@ -13,7 +8,6 @@ Documentation:
 CONTRIBUTORS
 
 [Haowei Hsu]: https://github.com/hwhsu1231
-[Matt Godbolt]: https://github.com/mattgodbolt
 
 ## Version 11.12.0
 

--- a/src/languages/llvm.js
+++ b/src/languages/llvm.js
@@ -34,7 +34,7 @@ export default function(hljs) {
     relevance: 0
   };
   const LABEL = {
-    className: 'symbol',
+    scope: 'symbol',
     variants: [ { begin: /^[ \t]*[a-z]+:/ }, // labels
     ],
     relevance: 0

--- a/src/languages/llvm.js
+++ b/src/languages/llvm.js
@@ -35,7 +35,7 @@ export default function(hljs) {
   };
   const LABEL = {
     className: 'symbol',
-    variants: [ { begin: /^\s*[a-z]+:/ }, // labels
+    variants: [ { begin: /^[ \t]*[a-z]+:/ }, // labels
     ],
     relevance: 0
   };

--- a/src/languages/mipsasm.js
+++ b/src/languages/mipsasm.js
@@ -84,7 +84,7 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'symbol',
+        scope: 'symbol',
         variants: [
           { // GNU MIPS syntax
             begin: '^[ \\t]*[a-z_\\.\\$][a-z0-9_\\.\\$]+:' },

--- a/src/languages/mipsasm.js
+++ b/src/languages/mipsasm.js
@@ -87,9 +87,9 @@ export default function(hljs) {
         className: 'symbol',
         variants: [
           { // GNU MIPS syntax
-            begin: '^\\s*[a-z_\\.\\$][a-z0-9_\\.\\$]+:' },
+            begin: '^[ \\t]*[a-z_\\.\\$][a-z0-9_\\.\\$]+:' },
           { // numbered local labels
-            begin: '^\\s*[0-9]+:' },
+            begin: '^[ \\t]*[0-9]+:' },
           { // number local label reference (backwards, forwards)
             begin: '[0-9]+[bf]' }
         ],

--- a/src/languages/mipsasm.js
+++ b/src/languages/mipsasm.js
@@ -53,8 +53,10 @@ export default function(hljs) {
             + 'break|cache|d?eret|[de]i|ehb|mfc0|mtc0|pause|prefx?|rdhwr|'
             + 'rdpgpr|sdbbp|ssnop|synci?|syscall|teqi?|tgei?u?|tlb(p|r|w[ir])|'
             + 'tlti?u?|tnei?|wait|wrpgpr'
-        + ')',
-        end: '\\s'
+        + ')'
+        // lookahead, so the span doesn't swallow the whitespace (or newline)
+        // that terminates the mnemonic
+        + '(?=\\s|$)',
       },
       // lines ending with ; or # aren't really comments, probably auto-detect fail
       hljs.COMMENT('[;#](?!\\s*$)', '$'),

--- a/src/languages/x86asm.js
+++ b/src/languages/x86asm.js
@@ -124,9 +124,9 @@ export default function(hljs) {
         className: 'symbol',
         variants: [
           // Global label and local label
-          { begin: '^\\s*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|\\s+label)' },
+          { begin: '^[ \\t]*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|[ \\t]+label)' },
           // Macro-local label
-          { begin: '^\\s*%%[A-Za-z0-9_$#@~.?]*:' }
+          { begin: '^[ \\t]*%%[A-Za-z0-9_$#@~.?]*:' }
         ],
         relevance: 0
       },
@@ -144,7 +144,7 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^\s*\.[\w_-]+/
+        begin: /^[ \t]*\.[\w_-]+/
       }
     ]
   };

--- a/src/languages/x86asm.js
+++ b/src/languages/x86asm.js
@@ -121,7 +121,7 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'symbol',
+        scope: 'symbol',
         variants: [
           // Global label and local label
           { begin: '^[ \\t]*[A-Za-z._?][A-Za-z0-9_$#@~.?]*(:|[ \\t]+label)' },
@@ -143,7 +143,7 @@ export default function(hljs) {
         relevance: 0
       },
       {
-        className: 'meta',
+        scope: 'meta',
         begin: /^[ \t]*\.[\w_-]+/
       }
     ]

--- a/test/markup/llvm/labels-after-blank-line.expect.txt
+++ b/test/markup/llvm/labels-after-blank-line.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-symbol">entry:</span>
+  <span class="hljs-keyword">br</span> <span class="hljs-type">label</span> <span class="hljs-variable">%exit</span>
+
+<span class="hljs-symbol">exit:</span>
+  <span class="hljs-keyword">ret</span> <span class="hljs-type">void</span>

--- a/test/markup/llvm/labels-after-blank-line.txt
+++ b/test/markup/llvm/labels-after-blank-line.txt
@@ -1,0 +1,5 @@
+entry:
+  br label %exit
+
+exit:
+  ret void

--- a/test/markup/mipsasm/default.expect.txt
+++ b/test/markup/mipsasm/default.expect.txt
@@ -6,15 +6,15 @@
 <span class="hljs-comment">#   2nd parameter ($a1) n</span>
 <span class="hljs-comment"># Postconditions:</span>
 <span class="hljs-comment">#   result in ($v0) = value of A(m,n)</span>
-<span class="hljs-symbol">
-AckermannFunc:</span>
+
+<span class="hljs-symbol">AckermannFunc:</span>
             <span class="hljs-keyword">addi </span>   $<span class="hljs-built_in">sp</span>,   $<span class="hljs-built_in">sp</span>, -<span class="hljs-number">8</span>
             <span class="hljs-keyword">sw </span>     $<span class="hljs-built_in">s0</span>, <span class="hljs-number">4</span>($<span class="hljs-built_in">sp</span>)
             <span class="hljs-keyword">sw </span>     $<span class="hljs-built_in">ra</span>, <span class="hljs-number">0</span>($<span class="hljs-built_in">sp</span>)
 
             <span class="hljs-comment"># move the parameter registers to temporary  - no, only when nec.</span>
-<span class="hljs-symbol">
-LABEL_IF:</span>   <span class="hljs-keyword">bne </span>    $<span class="hljs-built_in">a0</span>, $<span class="hljs-built_in">zero</span>, LABEL_ELSE_IF
+
+<span class="hljs-symbol">LABEL_IF:</span>   <span class="hljs-keyword">bne </span>    $<span class="hljs-built_in">a0</span>, $<span class="hljs-built_in">zero</span>, LABEL_ELSE_IF
 
             <span class="hljs-keyword">addi </span>   $<span class="hljs-built_in">v0</span>, $<span class="hljs-built_in">a1</span>, <span class="hljs-number">1</span>
 

--- a/test/markup/mipsasm/default.expect.txt
+++ b/test/markup/mipsasm/default.expect.txt
@@ -8,15 +8,15 @@
 <span class="hljs-comment">#   result in ($v0) = value of A(m,n)</span>
 
 <span class="hljs-symbol">AckermannFunc:</span>
-            <span class="hljs-keyword">addi </span>   $<span class="hljs-built_in">sp</span>,   $<span class="hljs-built_in">sp</span>, -<span class="hljs-number">8</span>
-            <span class="hljs-keyword">sw </span>     $<span class="hljs-built_in">s0</span>, <span class="hljs-number">4</span>($<span class="hljs-built_in">sp</span>)
-            <span class="hljs-keyword">sw </span>     $<span class="hljs-built_in">ra</span>, <span class="hljs-number">0</span>($<span class="hljs-built_in">sp</span>)
+            <span class="hljs-keyword">addi</span>    $<span class="hljs-built_in">sp</span>,   $<span class="hljs-built_in">sp</span>, -<span class="hljs-number">8</span>
+            <span class="hljs-keyword">sw</span>      $<span class="hljs-built_in">s0</span>, <span class="hljs-number">4</span>($<span class="hljs-built_in">sp</span>)
+            <span class="hljs-keyword">sw</span>      $<span class="hljs-built_in">ra</span>, <span class="hljs-number">0</span>($<span class="hljs-built_in">sp</span>)
 
             <span class="hljs-comment"># move the parameter registers to temporary  - no, only when nec.</span>
 
-<span class="hljs-symbol">LABEL_IF:</span>   <span class="hljs-keyword">bne </span>    $<span class="hljs-built_in">a0</span>, $<span class="hljs-built_in">zero</span>, LABEL_ELSE_IF
+<span class="hljs-symbol">LABEL_IF:</span>   <span class="hljs-keyword">bne</span>     $<span class="hljs-built_in">a0</span>, $<span class="hljs-built_in">zero</span>, LABEL_ELSE_IF
 
-            <span class="hljs-keyword">addi </span>   $<span class="hljs-built_in">v0</span>, $<span class="hljs-built_in">a1</span>, <span class="hljs-number">1</span>
+            <span class="hljs-keyword">addi</span>    $<span class="hljs-built_in">v0</span>, $<span class="hljs-built_in">a1</span>, <span class="hljs-number">1</span>
 
             <span class="hljs-comment"># jump to LABEL_DONE</span>
-            <span class="hljs-keyword">j </span>LABEL_DONE
+            <span class="hljs-keyword">j</span> LABEL_DONE

--- a/test/markup/mipsasm/labels-after-blank-line.expect.txt
+++ b/test/markup/mipsasm/labels-after-blank-line.expect.txt
@@ -1,0 +1,8 @@
+<span class="hljs-symbol">main:</span>
+        li      $<span class="hljs-built_in">v0</span>, <span class="hljs-number">1</span>
+
+<span class="hljs-symbol">loop:</span>
+        <span class="hljs-keyword">addi </span>   $<span class="hljs-built_in">t0</span>, $<span class="hljs-built_in">t0</span>, <span class="hljs-number">1</span>
+
+<span class="hljs-symbol">    indented:</span>
+        <span class="hljs-keyword">jr </span>     $<span class="hljs-built_in">ra</span>

--- a/test/markup/mipsasm/labels-after-blank-line.txt
+++ b/test/markup/mipsasm/labels-after-blank-line.txt
@@ -1,0 +1,8 @@
+main:
+        li      $v0, 1
+
+loop:
+        addi    $t0, $t0, 1
+
+    indented:
+        jr      $ra

--- a/test/markup/mipsasm/mnemonic-trailing-whitespace.expect.txt
+++ b/test/markup/mipsasm/mnemonic-trailing-whitespace.expect.txt
@@ -1,8 +1,4 @@
 <span class="hljs-symbol">main:</span>
-        li      $<span class="hljs-built_in">v0</span>, <span class="hljs-number">1</span>
-
-<span class="hljs-symbol">loop:</span>
         <span class="hljs-keyword">addi</span>    $<span class="hljs-built_in">t0</span>, $<span class="hljs-built_in">t0</span>, <span class="hljs-number">1</span>
-
-<span class="hljs-symbol">    indented:</span>
+        <span class="hljs-keyword">nop</span>
         <span class="hljs-keyword">jr</span>      $<span class="hljs-built_in">ra</span>

--- a/test/markup/mipsasm/mnemonic-trailing-whitespace.txt
+++ b/test/markup/mipsasm/mnemonic-trailing-whitespace.txt
@@ -1,0 +1,4 @@
+main:
+        addi    $t0, $t0, 1
+        nop
+        jr      $ra

--- a/test/markup/x86asm/labels-after-blank-line.expect.txt
+++ b/test/markup/x86asm/labels-after-blank-line.expect.txt
@@ -1,0 +1,16 @@
+<span class="hljs-symbol">_start:</span>
+    <span class="hljs-keyword">mov</span>     <span class="hljs-built_in">eax</span>, <span class="hljs-number">1</span>
+
+<span class="hljs-symbol">.retry:</span>
+    <span class="hljs-keyword">dec</span>     <span class="hljs-built_in">eax</span>
+
+<span class="hljs-meta">    .align</span>  <span class="hljs-number">16</span>
+    <span class="hljs-keyword">ret</span>
+
+<span class="hljs-symbol">    %%local:</span>
+    <span class="hljs-keyword">nop</span>
+
+<span class="hljs-symbol">bar label</span> <span class="hljs-built_in">near</span>
+
+foo
+    label <span class="hljs-built_in">near</span>

--- a/test/markup/x86asm/labels-after-blank-line.txt
+++ b/test/markup/x86asm/labels-after-blank-line.txt
@@ -1,0 +1,16 @@
+_start:
+    mov     eax, 1
+
+.retry:
+    dec     eax
+
+    .align  16
+    ret
+
+    %%local:
+    nop
+
+bar label near
+
+foo
+    label near


### PR DESCRIPTION
Resolves #4525

Both halves of this were already fixed in `armasm` in a34abcb5 / #2410, in passing
while fixing #2408. This applies the same two fixes to the sibling grammars that
were missed.

### Labels and directives starting a line early

The label and directive rules anchor with `^\s*`. `\s` matches `\n`, so a match
starting at the beginning of a preceding blank (or whitespace-only) line runs through
the newline and into the label on the next line. JS regexes prefer the leftmost match,
so that earlier start wins and the span begins one line early:

```html
<span class="hljs-symbol">
.exit:</span>
```

Indentation in front of a label or directive is same-line by definition, so this uses
`[ \t]` instead of `\s`:

- `x86asm` — global/local labels, macro-local labels, and the `.directive` meta rule
- `mipsasm` — GNU-syntax labels and numbered local labels
- `llvm` — block labels

This is character-for-character the change made to `armasm`'s label rule in a34abcb5
("symbols should not include prior newline", "also accept tabs as white space").
`armasm` and `mipsasm` were added with the same rule in 2015; `armasm` got the fix in
2020 and the others didn't. `avrasm` never had the bug, as its label rule doesn't
allow leading whitespace at all.

The trailing `\s+label` separator in the x86asm rule had the same defect
independently (it could join a bare identifier to a `label` keyword on the *following*
line), so that becomes `[ \t]+label`. The valid single-line `foo label near` form is
unaffected, including when tab-separated.

### Mnemonic spans swallowing their terminator

`mipsasm`'s mnemonic mode used `end: '\s'`, which consumes the character that ends
the match, so a mnemonic ending a line emitted `<span class="hljs-keyword">nop\n</span>`
and one mid-line kept its trailing space. a34abcb5's first bullet ("instructions
should not include the space after") fixed this in `armasm` by replacing the `end`
with a lookahead on `begin`; this does the same.

One deliberate deviation: `(?=\s|$)` rather than `armasm`'s `(?=\s)`, so a mnemonic
at the very end of the input, with no trailing whitespace, still highlights. `armasm`
currently drops it in that case — happy to send a follow-up for that if you'd like.

### Also

A separate commit switches the touched modes from `className` to `scope`, per
`AGENTS.md`.

### Verification

The blank-line bug was baked into the existing `mipsasm/default` expectation, which
this corrects:

```diff
-<span class="hljs-symbol">
-AckermannFunc:</span>
+
+<span class="hljs-symbol">AckermannFunc:</span>
```

I diffed before/after highlighting over a corpus of asm/LLVM snippets (labels at
column 0, space- and tab-indented labels, directives, macro-local labels, NASM `label`
keyword form, mnemonics mid-line, ending a line and at EOF, CRLF input, consecutive
blank lines, whitespace-only lines, labels inside strings and comments, plus the
existing fixtures). Relevance is unchanged throughout, so auto-detection is
unaffected.

Every markup difference is whitespace moving out of a span, with one exception: a
mipsasm numbered local label preceded by a blank line (`2:`) changes from `symbol` to
`number` followed by a bare colon. That's the dead-rule issue noted below — the symbol
rule only ever won there by starting on the earlier blank line, and at a true line
start the `number` mode has always won.

With the patch reverted the new markup tests fail; with it the suite is green.

### Noted but deliberately not fixed

One more pre-existing `mipsasm` defect, left alone to keep this reviewable (described
in #4525): the numbered-local-label rule `^\s*[0-9]+:` is effectively dead, because
the `number` mode appears earlier in `contains` and wins at a true line start.

### Checklist
- [x] Added markup tests, or they don't apply here because...
- [x] I have read and followed our [AI-assisted contributions](../docs/ai-contributions.md) policy (human review, no slop)

---

<sub>Investigated, patched and drafted by Claude Code (Claude Opus 5) working with me,
and posted from my account with my permission. I have reviewed the analysis, the diff
and the test expectations and can speak to them in review.
`Assisted-by: Claude Opus 5 (high)`</sub>
