### PR TITLE
fix(php-template): a quote in a // or # line comment no longer swallows the rest of the document

### DIFF
--- a/src/languages/php-template.js
+++ b/src/languages/php-template.js
@@ -26,6 +26,22 @@ export default function(hljs) {
             end: '\\*/',
             skip: true
           },
+          // A quote inside a `//` or `#` line comment must not be treated as
+          // the start of a string, or it swallows everything up to the next
+          // matching quote in the document (see #4152). A line comment ends
+          // at the first newline, or right before `?>` so that construct can
+          // still close the block. `#[` starts a PHP 8 attribute, not a
+          // comment, so it's excluded here.
+          {
+            begin: /\/\//,
+            end: /\n|(?=\?>)/,
+            skip: true
+          },
+          {
+            begin: /#(?!\[)/,
+            end: /\n|(?=\?>)/,
+            skip: true
+          },
           {
             begin: 'b"',
             end: '"',

--- a/test/markup/php-template/line-comment-apostrophe.expect.txt
+++ b/test/markup/php-template/line-comment-apostrophe.expect.txt
@@ -1,0 +1,6 @@
+<span class="language-php"><span class="hljs-meta">&lt;?php</span>
+<span class="hljs-comment">// This won&#x27;t be highlighted unless there is another</span>
+<span class="hljs-comment">// single apostrophe later.</span>
+<span class="hljs-meta">?&gt;</span></span><span class="language-xml">
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>Some HTML </span><span class="language-php"><span class="hljs-meta">&lt;?=</span> <span class="hljs-string">&#x27;\code&#x27;</span> <span class="hljs-meta">?&gt;</span></span><span class="language-xml"><span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+</span>

--- a/test/markup/php-template/line-comment-apostrophe.txt
+++ b/test/markup/php-template/line-comment-apostrophe.txt
@@ -1,0 +1,5 @@
+<?php
+// This won't be highlighted unless there is another
+// single apostrophe later.
+?>
+<p>Some HTML <?= '\code' ?></p>


### PR DESCRIPTION
Resolves #4152

### Changes

php-template scans PHP-tag content for skip-regions (block comments, strings) so a `?>` inside them doesn't end the block early. It had no notion of `//` or `#` line comments, so a quote inside one (e.g. the apostrophe in "won't") was matched as the start of a skipped string instead, which then consumed everything up to the next real quote in the document — breaking all highlighting in between, exactly as described in the issue.

Adds two line-comment skip patterns that end at the first newline, or right before `?>` so a same-line closing tag (`<?php // note ?>`) still closes the block. `#[` starts a PHP 8 attribute, not a comment, so it's excluded via a negative lookahead.

Three previous PRs attempted this (#4374, #4411, #4495); I read all three. #4374 removed `skip: true` from the string modes, which the maintainer correctly rejected since it breaks the intended sub-processing of skipped chunks. #4495 had a similar diagnosis and fix to this one but was closed for policy reasons (claimed end-to-end by AI) rather than a technical objection, so I independently re-derived and verified the fix rather than reusing it.

### Testing

Added `test/markup/php-template/line-comment-apostrophe.txt` (+ `.expect.txt`) reproducing the issue's exact repro. Confirmed it fails against the unpatched grammar (whole document falls back to unhighlighted XML) and passes with the fix. Also manually verified edge cases: same-line `// `/`# ` comment before `?>`, and `#[Attribute]` PHP 8 syntax is untouched. Full suite: `npm run build_and_test` — 1651 passing. Lint: `npx eslint --no-eslintrc -c .eslintrc.lang.js src/languages/php-template.js` — clean.

### Checklist
- [x] Added markup tests
- [x] I have read and followed our [AI-assisted contributions](docs/ai-contributions.md) policy (human review, no slop) — Claude Sonnet 5 assisted with root-cause analysis and implementation; I reviewed and understand the change. Disclosed per policy as `Assisted-by: Claude Sonnet 5 (medium)` in the commit trailer.