### PR TITLE
(docs) add Typst to SUPPORTED_LANGUAGES

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -282,6 +282,7 @@ The table below shows the full list of languages (and corresponding classes/alia
 | TTCN-3                  | ttcn, ttcnpp, ttcn3    | [highlightjs-ttcn3](https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3) |
 | Twig                    | twig, craftcms         |         |
 | TypeScript              | typescript, ts, tsx, mts, cts |         |
+| Typst                   | typst                  | [highlightjs-typst](https://github.com/fabeat/highlight-typst) |
 | Unicorn Rails log       | unicorn-rails-log      | [highlightjs-unicorn-rails-log](https://github.com/sweetppro/highlightjs-unicorn-rails-log) |
 | Unison                  | unison, u              | [highlightjs-unison](https://github.com/highlightjs/highlightjs-unison) |
 | Vala                    | vala                   |         |


### PR DESCRIPTION
Third-party grammar published as `highlightjs-typst` on npm (v0.1.0).
Repository: https://github.com/fabeat/highlight-typst

Three top-level modes — markup, code (triggered by a leading `#`),
math (`$…$`) — with keyword / literal / built-in lists sourced from
the official Typst reference.

Follows the [3RD_PARTY_QUICK_START](https://github.com/highlightjs/highlight.js/blob/main/extra/3RD_PARTY_QUICK_START.md)
flow: grammar lives in its own repo, listed here for discoverability.

- npm: https://www.npmjs.com/package/highlightjs-typst
- CI: 14 markup golden tests across markup / code / math paths, plus
  bundle-load smoke tests for ESM / CJS / IIFE / wrapper
- Build: rollup, no native deps
- License: MIT